### PR TITLE
fix(Build): Fix issue where newer versions of Typescript don’t play nice with older versions of React

### DIFF
--- a/config/typescript-config/tsconfig.json
+++ b/config/typescript-config/tsconfig.json
@@ -5,7 +5,7 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["dom", "dom.iterable", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
An issue arose where where Typescriot threw an error both when React was imported and when it was not. The fix is to update the Typescript config - see link below:

https://github.com/microsoft/TypeScript/issues/41882#issuecomment-940734525