### PR TITLE
fix(ci/cd): publish icon-build-helpers

### DIFF
--- a/packages/icon-build-helpers/package.json
+++ b/packages/icon-build-helpers/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@ilo-org/icon-build-helpers",
-  "private": true,
   "description": "Build helpers for ILO's Design System icon library",
   "version": "0.0.1",
-  "author": "@justintemps",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
Make `icon-build-helpers` public so that it's accessible to other packages when consumed.