### PR TITLE
Fix: Netlify support for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A design system for the International Labour Organization",
   "license": "Apache-2.0",
   "main": "index.js",
+  "packageManager": "pnpm@6.32.3",
   "engines": {
     "pnpm": "6.32.3"
   },


### PR DESCRIPTION
Should fix builds broken by the fact that Netlify now provides native support for pnpm. 

Note that this also requires changing the buildscript in Netlify to (for example)

```
pnpm build:react
```

and setting `NETLIFY_USE_PNPM=true`

Reference:
- [New for Netlify Build: Out of the box support for pnpm](https://www.netlify.com/blog/how-to-use-pnpm-with-netlify-build/)
- [Twitter convo with Lukas Holzer/@luka5c0m](https://twitter.com/luka5c0m/status/1583117359988236288)



