### PR TITLE
ci(npm): fix changeset versions not updating lock files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
-name: Build, test and release
+name: Release
 
 on:
   push:
     branches:
       - main
+
+env:
+  CI: true
+  PNPM_CACHE_FOLDER: .pnpm-store
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -12,8 +16,21 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+
+      - name: Checkout code repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 16.14.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.3
 
       - name: Add auth token to .npmrc
         run: |
@@ -23,34 +40,29 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 6.32.3
-
-      - name: Setup Node.js 16.14.0
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.14.0
-          cache: "pnpm"
+      - name: Setup pnpm config
+        run: pnpm config set store-dir $PNPM_CACHE_FOLDER
 
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build
-        run: pnpm build:all
-
       - name: Check types
         run: pnpm check:types
+
+      - name: Build
+        run: pnpm build:all
 
       - name: Test
         run: pnpm test:all
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create and publish versions
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          version: pnpm ci:version
+          commit: "chore: update versions"
+          title: "chore: update versions"
+          publish: pnpm ci:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:react": "pnpm run test --filter=@ilo-org/react",
     "test:react-update": "pnpm run test:update --filter=@ilo-org/react",
     "test:utils": "pnpm run test --filter=@ilo-org/utils",
-    "release": "pnpm changeset version && pnpm changeset publish"
+    "ci:version": "pnpm changeset version && pnpm install --lockfile-only",
+    "ci:publish": "pnpm changeset publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changeset github action failed to deploy because version updates weren't updating the lock file. This runs pnpm install command after version script to make sure the package lock file gets updated also.