### PR TITLE
React: LocalNav can have subbrand

### DIFF
--- a/.changeset/wild-eels-brake.md
+++ b/.changeset/wild-eels-brake.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": minor
+---
+
+LocalNav uses Logo component so that it can have sub-brands

--- a/packages/react/src/components/LocalNav/LocalNav.args.ts
+++ b/packages/react/src/components/LocalNav/LocalNav.args.ts
@@ -3,8 +3,12 @@ import ilo_logo_white from "@ilo-org/brand-assets/logo_en_horizontal_white.svg";
 
 const basic: LocalNavProps = {
   background: "#960A55",
-  logo: ilo_logo_white,
-  siteurl: "https://www.ilo.org/",
+  logo: {
+    src: ilo_logo_white,
+    alt: "ILO Voices Logo",
+    subbrand: "Voices",
+    theme: "dark",
+  },
   primarynav: {
     navlabel: "Primary Nav Menu",
     mobilecloselabel: "Close",
@@ -23,10 +27,6 @@ const basic: LocalNavProps = {
       },
       {
         label: "Menu Item 4",
-        url: "https://www.ilo.org",
-      },
-      {
-        label: "Menu Item 5",
         url: "https://www.ilo.org",
       },
     ],

--- a/packages/react/src/components/LocalNav/LocalNav.props.ts
+++ b/packages/react/src/components/LocalNav/LocalNav.props.ts
@@ -1,4 +1,5 @@
 import { LinkProps, ContextMenuProps } from "../ContextMenu/ContextMenu.props";
+import { LogoProps } from "../Logo/Logo.props";
 
 export interface LocalNavProps {
   /**
@@ -7,19 +8,14 @@ export interface LocalNavProps {
   background?: string;
 
   /**
-   * Props for the logo of the LocalNav
+   * Props for the Logo component of the LocalNav
    */
-  logo?: Required<string>;
-
-  /**
-   * Props for the home url of the LocalNav
-   */
-  siteurl?: Required<string>;
+  logo: LogoProps;
 
   /**
    * Specify the primary items for the LocalNav
    */
-  primarynav?: Required<PrimaryNavProps>;
+  primarynav?: PrimaryNavProps;
 
   /**
    * Specify the main link for the LocalNav

--- a/packages/react/src/components/LocalNav/LocalNav.tsx
+++ b/packages/react/src/components/LocalNav/LocalNav.tsx
@@ -4,11 +4,13 @@ import { ContextMenu } from "../ContextMenu";
 import { LocalNavProps } from "./LocalNav.props";
 import { brand } from "@ilo-org/themes/tokens/brand/base.json";
 import classnames from "classnames";
+import { Logo } from "../Logo";
+
+const DEFAULT_LOGO_SIZE = 280;
 
 const LocalNav: FC<LocalNavProps> = ({
   background,
   logo,
-  siteurl,
   primarynav,
   mainlink,
   menucloselabel,
@@ -43,13 +45,15 @@ const LocalNav: FC<LocalNavProps> = ({
       >
         <nav className={`${prefix}--nav--local`}>
           <div className={`${prefix}--nav--local--logo-wrapper`}>
-            <a href={siteurl} className={`${prefix}--nav--local--logo-link`}>
-              <img
-                src={logo}
-                alt="ILO Logo"
-                className={`${prefix}--nav--local--logo`}
-              />
-            </a>
+            <Logo
+              url={logo.url}
+              src={logo.src}
+              alt={logo.alt}
+              className={`${prefix}--nav--local--logo`}
+              subbrand={logo.subbrand}
+              theme={logo.theme}
+              size={logo.size || DEFAULT_LOGO_SIZE}
+            />
           </div>
           <ul className={`${prefix}--nav--local--set`}>
             {primarynav?.items &&
@@ -90,13 +94,15 @@ const LocalNav: FC<LocalNavProps> = ({
           <div className={`${baseClass}--inner`}>
             <div className={`${prefix}--mobile--nav`}>
               <div className={`${prefix}--mobile--nav--logo`}>
-                <a href={siteurl} className={`${baseClass}--logo-link`}>
-                  <img
-                    className={`${baseClass}--logo`}
-                    src={logo}
-                    alt="ILO Logo"
-                  />
-                </a>
+                <Logo
+                  url={logo.url}
+                  src={logo.src}
+                  alt={logo.alt}
+                  className={`${prefix}--nav--local--logo`}
+                  subbrand={logo.subbrand}
+                  theme={logo.theme}
+                  size={logo.size || DEFAULT_LOGO_SIZE}
+                />
                 <button
                   className={`${baseClass}--menu--close`}
                   onClick={handleMenuToggle}


### PR DESCRIPTION
This uses the Logo component in the LocalNav so that it can support a sub-brand.

@inesdgomes to review this PR, navigate to the LocalNav component and see the logo with the sub-brand.

Fixes #319 