### PR TITLE
Add block wrapping the hero image

### DIFF
--- a/.changeset/brown-houses-trade.md
+++ b/.changeset/brown-houses-trade.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Added a block to wrap the image on the Hero component. That allows Drupal to include responsive images.

--- a/packages/twig/src/patterns/components/hero/hero.twig
+++ b/packages/twig/src/patterns/components/hero/hero.twig
@@ -9,15 +9,17 @@
       prefix: prefix,
     } only %}
   {% endif %}
-  {% if not image %}
-  {% else %}
-    {% include "@components/image/image.twig" with {
-      alt: image.alt,
-      prefix: prefix,
-      url: image.url,
-      ishero: "true"
-    } only %}
-  {% endif %}
+  {% block hero_image %}
+    {% if not image %}
+    {% else %}
+      {% include "@components/image/image.twig" with {
+        alt: image.alt,
+        prefix: prefix,
+        url: image.url,
+        ishero: "true"
+      } only %}
+    {% endif %}
+  {% endblock %}
   {% include "@components/herocard/herocard.twig" with {
     alignment: herocard.alignment,
     eyebrow: herocard.eyebrow,


### PR DESCRIPTION
Added a block to wrap the image on the Hero component. 
That allows Drupal to include responsive images.