### PR TITLE
feat(twig): Add if statement to call accordion function only once

### DIFF
--- a/.changeset/weak-candles-laugh.md
+++ b/.changeset/weak-candles-laugh.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add a check to only run the accordion function once in Drupal.

--- a/packages/twig/src/patterns/components/accordion/accordion.behavior.js
+++ b/packages/twig/src/patterns/components/accordion/accordion.behavior.js
@@ -5,9 +5,12 @@ Drupal.behaviors.accordion = {
     Array.prototype.forEach.call(
       document.querySelectorAll(`[data-loadcomponent="Accordion"]`),
       (element) => {
-        // eslint-disable-next-line no-console
-        console.log("loading Accordion component....");
-        new Accordion(element);
+          if(!element.dataset.jsProcessed) {
+            // eslint-disable-next-line no-console
+            console.log("loading Accordion component....");
+            new Accordion(element);
+            element.dataset.jsProcessed = true;
+          }
       }
     );
   },


### PR DESCRIPTION
`Drupal.behaviors` does not only fire on page load, it fires on ajax calls or whenever new elements are inserted into the DOM. This adds an if statement checking if the js is proccessed to avoid calling the accordion function more than once, using `data` attributes.