### PR TITLE
Feat/Twig: Support responsive images in cards

### DIFF
--- a/.changeset/big-eyes-join.md
+++ b/.changeset/big-eyes-join.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add support for reponsive images in the Card component. The `image` field can take either a string (for a non-responsive image) or an array of objects with an `src` and `breakpoint` property. The `image` field of the card now works the same way as the `url` field of the Image component. This also adds an `imageAlt` field that applies a describe alt tag to the image.

--- a/packages/twig/src/patterns/components/card/card.twig
+++ b/packages/twig/src/patterns/components/card/card.twig
@@ -10,18 +10,24 @@
   {% endif %}
   <div class="{{prefix}}--card--wrap">
     {% if image %}
-      <div class="{{prefix}}--card--image--wrapper">
-        {% block card_image %}
-          <picture>
-            {% for img in url|reverse %}
-              {% if loop.last == false  %}
-                <source srcset="{{img.src}}" media="(min-width: {{img.breakpoint}}px)">
-              {% endif %}
-            {% endfor %}
-            <img class="{{prefix}}--card--image" src="{{url|reverse|last.src}}" alt="{{alt}}" {% if loading %}loading="{{ loading }}"{% endif %}>
-          </picture>
-        {% endblock %}
-      </div>
+      {% block card_image %}
+        <div class="{{prefix}}--card--image--wrapper">
+          {% if image is iterable %}
+            <picture>
+              {% for img in image|reverse %}
+                {% if loop.last == false  %}
+                  <source srcset="{{img.src}}" media="(min-width: {{img.breakpoint}}px)">
+                {% endif %}
+              {% endfor %}
+              <img class="{{prefix}}--card--image" src="{{image|reverse|last.src}}" alt="{{imageAlt}}" {% if loading %} loading="{{ loading }}"{% endif %}>
+            </picture>
+            {% else %}
+            <picture>
+              <img class="{{prefix}}--card--image" src="{{image}}" alt="{{imageAlt}}">
+            </picture>
+          {% endif %}
+        </div>
+      {% endblock %}
     {% endif %}
     <div class="{{prefix}}--card--content">
       {% if eyebrow %}
@@ -31,18 +37,7 @@
         <h5 class="{{prefix}}--card--title">{{title}}</h5>
       {% endif %}
       {% if type == "multilink" or type == "data" and image %}
-        <div class="{{prefix}}--card--image--wrapper">
-          {% block card_image_multilink_or_data %}
-            <picture>
-              {% for img in url|reverse %}
-                {% if loop.last == false  %}
-                  <source srcset="{{img.src}}" media="(min-width: {{img.breakpoint}}px)">
-                {% endif %}
-              {% endfor %}
-              <img class="{{prefix}}--card--image" src="{{url|reverse|last.src}}" alt="{{alt}}" {% if loading %}loading="{{ loading }}"{% endif %}>
-            </picture>
-          {% endblock %}
-        </div>
+        {{ block("card_image") }}
       {% endif %}
       {% if intro %}
         <p class="{{prefix}}--card--intro">{{intro}}</p>

--- a/packages/twig/src/patterns/components/card/card.wingsuit.yml
+++ b/packages/twig/src/patterns/components/card/card.wingsuit.yml
@@ -30,6 +30,16 @@ card:
       label: Eyebrow
       description: Event details for `Detail` card
       preview: ""
+    image:
+      type: object
+      label: Image
+      description: Image settings for the card. Only applies to `Graphic Promo` and `Graphic Text` cards. Image can be a string consisting of an image src or an array of objects with `src` and `breakpoint` properties for responsive images.
+      preview: ""
+    imageAlt:
+      type: string
+      label: Image Alt
+      description: Alt text for the image
+      preview: "This is the alt text for the image"
     profile:
       type: object
       label: Profile
@@ -49,22 +59,14 @@ card:
       type: object
       label: CTA
       description: Items for clickable CTA button. Button used for `Graphic Promo` card.
-      preview:
-    image:
-      type: string
-      label: Image
-      description: The image for the card. Images should be avoided on `Graphic Promo`, `Graphic Text`, `Factlist`, and `Stat` card.
-      preview: ""
     source:
       type: object
       label: Source
       description: Source link for `Stat` cards
-      preview:
     linklist:
       type: object
       label: Link List
       description: Implementation of the LinkList component. Appears at the bottom of `Multilink` or `Feature` card.
-      preview:
     dataset:
       type: object
       label: Dataset object
@@ -164,7 +166,15 @@ card:
       fields:
         eyebrow: High-level meeting
         title: "ILO welcomes G7 call to make a just transition to a green economy happen"
-        image: "/images/hero.jpg"
+        image:
+          - breakpoint: 0
+            src: "/images/small.jpg"
+          - breakpoint: 800
+            src: "/images/medium.jpg"
+          - breakpoint: 1200
+            src: "/images/large.jpg"
+          - breakpoint: 1440
+            src: "/images/large.jpg"
         intro: "At the end of their meeting the G7 Labour Ministers highlighted the urgent need to greater focus on rights and occupational safety and health."
         linklist:
           linkgroup:


### PR DESCRIPTION
Add support for reponsive images in the Card component. The `image` field can take either a string (for a non-responsive image) or an array of objects with an `src` and `breakpoint` property. The `image` field of the card now works the same way as the `url` field of the Image component. This also adds an `imageAlt` field that applies a describe alt tag to the image.

