### PR TITLE
Fix/Twig: Allow button in Callout to act as a link

### DIFF
--- a/.changeset/popular-peas-reply.md
+++ b/.changeset/popular-peas-reply.md
@@ -1,5 +1,5 @@
 ---
-"@ilo-org/twig": patch
+"@ilo-org/twig": minor
 ---
 
 In the Callout component, use the Button component so it can take a url and act as a link

--- a/.changeset/popular-peas-reply.md
+++ b/.changeset/popular-peas-reply.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+In the Callout component, use the Button component so it can take a url and act as a link

--- a/packages/twig/src/patterns/components/callout/callout.twig
+++ b/packages/twig/src/patterns/components/callout/callout.twig
@@ -16,14 +16,19 @@
       {% endif %}
     </div>
     {{ content }}
-    {% if buttonLabel %}
+    {% if button %}
       <div class="{{prefix}}--callout--footer">
-        <button
-          class="{{prefix}}--button {{prefix}}--button--small {{prefix}}--button--secondary"
-          type="button"
-        >
-          <span class="button__label">{{ buttonLabel }}</span>
-        </button>
+        {% include '@components/button/button.twig' with {
+          label: button.label,
+          url: button.url,
+          target: button.target,
+          icon: button.icon,
+          className: button.className,
+          icon: button.icon,
+          iconPosition: button.iconPosition,
+          size: "small",
+          type: "secondary",
+        } %}
       </div>
     {% endif %}
   </div>

--- a/packages/twig/src/patterns/components/callout/callout.wingsuit.yml
+++ b/packages/twig/src/patterns/components/callout/callout.wingsuit.yml
@@ -3,12 +3,17 @@ callout:
   label: Callout
   description: A callout alert section with a few different types
   fields:
-    buttonLabel:
-      type: string
+    button:
+      type: object
       label: Button Label
-      description: The label for the optional button
-      preview: "Optional Button Label"
+      description: Fields to pass to the button if there is one
       required: false
+      preview:
+        label: "Button"
+        url: "https://www.ilo.org"
+        target: "_blank"
+        icon: false
+        className: "optionalclass"
     content:
       type: text
       label: Content


### PR DESCRIPTION
## Overview

This replaces the <button> html element in the Callout component with the Button Twig component, allowing it to act as either a button or a link.

## ⚠️ Minor release with a breaking change

This PR will trigger a minor release that however includes a breaking change. This is a violation of semver which is tolerated while the package is still in >v1.0.0. Future changes of this sort should not be allowed once the library has reached v1.0.0.

## Description of changes

The `buttonLabel` field in the `Callout` component is replaced with a `button` field that takes a subject of the fields passed to the underlying Button. The `buttonLabel` field is no long used.

The Button in the Callout applies the styles of a `small` and `secondary` Button, which can't be overridden.

The available fields that can be set through the `button` property are:

```json
{
  "label": "The button's label", 
  "url": "Where the button should point to. Turns it into a link",
  "target": "If there is a url, the _target attribute for the link",
  "icon": "Optional icon",
  "className": "Optional classname",
  "iconPosition": "Position for optional icon"
}
```

Fixes #407.