### PR TITLE
fix(styles): Added background color to the content tabs

### DIFF
--- a/.changeset/ten-jobs-chew.md
+++ b/.changeset/ten-jobs-chew.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+added background color white to the content tabs

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -134,6 +134,7 @@
     }
 
     .ilo--tabs--content {
+      background-color: $color-base-neutrals-white;
       padding: px-to-rem($spacing-padding-5) px-to-rem($spacing-padding-3)
         px-to-rem($spacing-padding-7) px-to-rem($spacing-padding-3);
 


### PR DESCRIPTION
Added background color white to the content tabs, to make sure it will be white when used different background colors on the component.
Before:
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/5a4db2dc-18f5-45d2-a0a1-885d2e026648)


After:
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/0dbe84de-565b-44b4-912a-3aa46d4619db)
