### PR TITLE
fix(styles): Changed space between cards

### DIFF
--- a/.changeset/green-jokes-allow.md
+++ b/.changeset/green-jokes-allow.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+changed spaces between cards

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -24,7 +24,7 @@
   &--two {
     @include breakpoint("large") {
       #{$card} {
-        width: calc(50% - 24px);
+        width: calc(50% - 16px);
       }
     }
   }
@@ -32,7 +32,7 @@
   &--three {
     @include breakpoint("large") {
       #{$card} {
-        width: calc(33.333% - 24px);
+        width: calc(33.333% - 21px);
       }
     }
   }


### PR DESCRIPTION
Added the same space between the cards, 32px.
Before:
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/7e1688c7-d71a-4496-8b69-8ab5754433f9)

After:
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/2fbe8b86-f325-49fa-8f24-f5d9e340aaba)
