### PR TITLE
fix(styles): Removed max width of the cards

### DIFF
--- a/.changeset/mean-cats-dance.md
+++ b/.changeset/mean-cats-dance.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+removed max width of the cards

--- a/packages/styles/scss/components/_card.scss
+++ b/packages/styles/scss/components/_card.scss
@@ -7,7 +7,6 @@
   $self: &;
   $transition-timing: 150ms;
   margin: 0;
-  max-width: px-to-rem(920px);
 
   .right-to-left & {
     text-align: right;


### PR DESCRIPTION
Removed the max-width of the cards, so when we have only one card on the row, it can have the page container width.
Before: 
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/ca29ae38-fc01-422f-892d-0b66e7c8e4e2)


After:
![image](https://github.com/international-labour-organization/designsystem/assets/40777732/2d124bb7-daf9-4d7c-852a-03dc340c12df)
