### PR TITLE
Fix/Twig: cardgroup add theme and type settings

### DIFF
--- a/.changeset/gold-pumas-refuse.md
+++ b/.changeset/gold-pumas-refuse.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+- In Card Group, set `theme` and `type` properties for Cards on Card Group, not on invididual cards
+- Use `cardcount` to determine how many cards should be in a row and how wide they should be.

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -4,11 +4,10 @@
 
 .ilo--cardgroup {
   $c: &;
-  $card: ".ilo--card";
 
   &__collapsed {
     #{$c}--inner {
-      gap: 0;
+      gap: 0 !important;
     }
   }
 
@@ -32,12 +31,55 @@
     }
   }
 
+  &__count {
+    @include breakpoint("large") {
+      &__one {
+        #{$c}--inner {
+          gap: 0;
+        }
+
+        #{$c}--card {
+          flex: 1 1 100%;
+        }
+      }
+
+      &__two {
+        #{$c}--inner {
+          gap: 16px;
+        }
+
+        #{$c}--card {
+          flex: 0 1 calc(50% - 16px);
+        }
+      }
+
+      &__three {
+        #{$c}--inner {
+          gap: 21px;
+        }
+
+        #{$c}--card {
+          flex: 0 1 calc(33.3333% - 21px);
+        }
+      }
+
+      &__four {
+        #{$c}--inner {
+          gap: 24px;
+        }
+
+        #{$c}--card {
+          flex: 0 1 calc(25% - 24px);
+        }
+      }
+    }
+  }
+
   &--inner {
     display: flex;
     flex-flow: row wrap;
     justify-content: center;
     margin: auto;
-    gap: px-to-rem(32px);
     width: 100%;
 
     .right-to-left & {

--- a/packages/twig/src/patterns/components/cardgroup/cardgroup.twig
+++ b/packages/twig/src/patterns/components/cardgroup/cardgroup.twig
@@ -6,6 +6,8 @@
     {% for card in group %}
       {% include "@components/card/card.twig" with {
         size: size,
+        theme: theme,
+        type: type,
         cta: card.cta,
         dataset: card.dataset,
         date: card.date,
@@ -21,8 +23,6 @@
         color: card.color,
         cornercut: card.cornercut,
         source: card.source,
-        theme: card.theme,
-        type: card.type,
         prefix: prefix
       } only %}
     {% endfor %}

--- a/packages/twig/src/patterns/components/cardgroup/cardgroup.twig
+++ b/packages/twig/src/patterns/components/cardgroup/cardgroup.twig
@@ -1,31 +1,33 @@
 {#
   CARDGROUP COMPONENT
 #}
-<div class="{{prefix}}--cardgroup {% if collapsed %} {{prefix}}--cardgroup__collapsed {% endif %} {% if justify %} {{prefix}}--cardgroup__justify__{{justify}} {% endif %}">
+<div class="{{prefix}}--cardgroup {{prefix}}--cardgroup__count__{{cardcount}} {% if collapsed %} {{prefix}}--cardgroup__collapsed {% endif %} {% if justify %} {{prefix}}--cardgroup__justify__{{justify}} {% endif %}">
   <div class="{{prefix}}--cardgroup--inner">
     {% for card in group %}
-      {% include "@components/card/card.twig" with {
-        size: size,
-        theme: theme,
-        type: type,
-        cta: card.cta,
-        dataset: card.dataset,
-        date: card.date,
-        dateExtra: card.dateExtra,
-        eyebrow: card.eyebrow,
-        image: card.image,
-        intro: card.intro,
-        link: card.link,
-        linklist: card.linklist,
-        list: card.list,
-        title: card.title,
-        alignment: card.alignment,
-        color: card.color,
-        cornercut: card.cornercut,
-        source: card.source,
-        prefix: prefix
-      } only %}
-    {% endfor %}
+      <div class="{{prefix}}--cardgroup--card">
+        {% include "@components/card/card.twig" with {
+          size: "fluid",
+          theme: theme,
+          type: type,
+          cta: card.cta,
+          dataset: card.dataset,
+          date: card.date,
+          dateExtra: card.dateExtra,
+          eyebrow: card.eyebrow,
+          image: card.image,
+          intro: card.intro,
+          link: card.link,
+          linklist: card.linklist,
+          list: card.list,
+          title: card.title,
+          alignment: card.alignment,
+          color: card.color,
+          cornercut: card.cornercut,
+          source: card.source,
+          prefix: prefix
+        } only %}
+      </div>
+      {% endfor %}
     {% if cta %}
     <div class="{{prefix}}--cardgroup--button-wrap">
       <a

--- a/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
+++ b/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
@@ -33,6 +33,29 @@ cardgroup:
         narrow: narrow
         wide: wide
         fluid: fluid
+    theme:
+      type: select
+      label: Theme
+      description: Sets all of the cards to appear as either light or dark. Used by all card groups except for `Multilink Card`, `Data Card` and `Stat Card`.
+      required: false
+      preview: "dark"
+      options:
+        dark: Dark
+        light: Light
+    type:
+      type: select
+      label: Type
+      description: Sets the type of cards to render in the Card Group
+      preview: "feature"
+      options:
+        feature: Feature
+        text: Text
+        detail: Detail
+        promo: Promo
+        multilink: Multilink
+        data: Data
+        stat: Stat
+        factlist: Factlist
   fields:
     group:
       type: object

--- a/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
+++ b/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
@@ -13,6 +13,17 @@ cardgroup:
       options:
         true: True
         false: False
+    cardcount:
+      type: select
+      label: collapsed
+      description: Number of cards to show in a row, also determines the width of the cards as a function of how many there need to be. As a result, passing `size` to the individual cards has no effect since the card group manages the size of the cards.
+      required: false
+      preview: "three"
+      options:
+        one: one
+        two: two
+        three: three
+        four: four
     justify:
       type: select
       label: collapsed
@@ -23,16 +34,6 @@ cardgroup:
         start: start
         center: center
         between: between
-    size:
-      type: select
-      label: Size
-      description: Sets the size of all of the cards. See the `Card` component for more details on the different sizes.
-      required: false
-      options:
-        standard: standard
-        narrow: narrow
-        wide: wide
-        fluid: fluid
     theme:
       type: select
       label: Theme


### PR DESCRIPTION
- In Card Group, set `theme` and `type` properties for Cards on Card Group, not on invididual cards
- Use `cardcount` to determine how many cards should be in a row and how wide they should be.