### PR TITLE
Styles: card layout fixes

### DIFF
--- a/.changeset/neat-hotels-try.md
+++ b/.changeset/neat-hotels-try.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Avoid card wrappers getting stretched beyond the width of the actual component

--- a/.changeset/rare-apples-add.md
+++ b/.changeset/rare-apples-add.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Cards should have white background by default

--- a/.changeset/shiny-chicken-call.md
+++ b/.changeset/shiny-chicken-call.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+All cards in card group should be the same height.

--- a/.changeset/strong-bananas-jam.md
+++ b/.changeset/strong-bananas-jam.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+In Feature Card, push dates and ctas to the bottom of the card

--- a/packages/styles/scss/components/_card.scss
+++ b/packages/styles/scss/components/_card.scss
@@ -86,6 +86,8 @@
   }
 
   &--wrapper {
+    max-width: var(--max-width);
+
     &:hover,
     &:focus,
     &:focus-within {

--- a/packages/styles/scss/components/_card.scss
+++ b/packages/styles/scss/components/_card.scss
@@ -9,6 +9,7 @@
 
   box-sizing: border-box;
   position: relative;
+  background-color: map-get($color, "base", "neutrals", "white");
 
   // Max width is set in the invididual card types unless fluid
   max-width: var(--max-width);

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -87,6 +87,11 @@
     }
   }
 
+  .ilo--card,
+  .ilo--card--wrapper {
+    height: 100%;
+  }
+
   &--button-wrap {
     display: flex;
     justify-content: center;

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -199,6 +199,7 @@
         );
         font-family: $fonts-display;
         font-weight: 700;
+        flex: 1;
       }
 
       #{$self}--eyebrow {

--- a/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
+++ b/packages/twig/src/patterns/components/cardgroup/cardgroup.wingsuit.yml
@@ -74,8 +74,27 @@ cardgroup:
       label: Group of cards
       description: "The group of cards. Each card can be one of the following types: multilink, feature, detail, graphicpromo, stat, graphic, factlist, data."
       preview:
-        - eyebrow: "Podcast"
-          title: "Can digital technology be an equality machine?"
+        - eyebrow: "Press release"
+          title: "ILO welcomes first global agreement on working conditions and rights of professional football players"
+          link: "https://www.ilo.org/"
+          cta:
+            label: "Read the press release"
+            url: "https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_846303/lang--en/index.htm"
+          theme: dark
+          image:
+            alt: "Image alt text"
+            loading: "lazy"
+            url:
+              - breakpoint: "(min-width: 0px)"
+                src: "/images/small.jpg"
+              - breakpoint: "(min-width: 800px)"
+                src: "/images/medium.jpg"
+              - breakpoint: "(min-width: 1200px)"
+                src: "/images/large.jpg"
+              - breakpoint: "(min-width: 1440px)"
+                src: "/images/large.jpg"
+        - eyebrow: "Report"
+          title: "Renewable energy jobs hit 12.7 million globally"
           link: "https://www.ilo.org/"
           cta:
             label: "Read the press release"
@@ -94,26 +113,7 @@ cardgroup:
               - breakpoint: "(min-width: 1440px)"
                 src: "/images/large.jpg"
         - eyebrow: "Podcast"
-          title: "Can digital technology be an equality machine?"
-          link: "https://www.ilo.org/"
-          cta:
-            label: "Read the press release"
-            url: "https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_846303/lang--en/index.htm"
-          theme: dark
-          image:
-            alt: "Image alt text"
-            loading: "lazy"
-            url:
-              - breakpoint: "(min-width: 0px)"
-                src: "/images/small.jpg"
-              - breakpoint: "(min-width: 800px)"
-                src: "/images/medium.jpg"
-              - breakpoint: "(min-width: 1200px)"
-                src: "/images/large.jpg"
-              - breakpoint: "(min-width: 1440px)"
-                src: "/images/large.jpg"
-        - eyebrow: "Podcast"
-          title: "Can digital technology be an equality machine?"
+          title: "Telangana and Andhra Pradesh launch pre-departure handbook for Indians going to the European Union"
           link: "https://www.ilo.org/"
           cta:
             label: "Read the press release"


### PR DESCRIPTION
- Avoid card wrappers getting stretched beyond the width of the actual component
- Cards should have white background by default
- All cards in card group should be the same height.
- In Feature Card, push dates and ctas to the bottom of the card