### PR TITLE
feat(twig): Add a block to wrap the modal content

### DIFF
--- a/.changeset/strong-zoos-tap.md
+++ b/.changeset/strong-zoos-tap.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add a block wrap the modal content so it can be overriden.

--- a/packages/twig/src/patterns/components/modal/modal.twig
+++ b/packages/twig/src/patterns/components/modal/modal.twig
@@ -10,7 +10,9 @@
     <div class="{{prefix}}--modal--wrapper" aria-modal="true" role="alertdialog">
       <div class="{{prefix}}--modal--background" role="presentation"></div>
       <div class="{{prefix}}--modal--contents">
-        {% include '@components/' ~ component ~ '/' ~ component ~ '.twig' with modaldata %}
+        {% block modal_content %}
+          {% include '@components/' ~ component ~ '/' ~ component ~ '.twig' with modaldata %}
+        {% endblock %}
         {% include '@components/button/button.twig' with closebutton %}
       </div>
     </div>


### PR DESCRIPTION
Add a block wrap the modal content so it can be overriden.