### PR TITLE
feat(twig): formControlClass variable set with default value

### DIFF
--- a/.changeset/afraid-pants-wink.md
+++ b/.changeset/afraid-pants-wink.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Setting formControlClass as a variable with the default value at the begining of the template.

--- a/packages/twig/src/patterns/components/form/formcontrol.twig
+++ b/packages/twig/src/patterns/components/form/formcontrol.twig
@@ -5,6 +5,9 @@
 {# Initialize ariaDescribedBy #}
 {% set ariaDescribedBy  = [] %}
 
+{# Initialize formControlClass #}
+{% set formControlClass = formControlClass|default([]) %}
+
 {# if not defined id will be set to the value of name or to a random number #}
 {% if not id %}
 	{% if name  %}
@@ -38,7 +41,7 @@
 {% set errorClass = baseClass ~ "__error" %}
 {% set disabledClass = baseClass ~ "__disabled" %}
 {% set labelPlacementClass = baseClass ~ "__label-placement__" ~ labelPlacement|default("start") %}
-{% set formControlClass = [baseClass, class, labelPlacementClass] %}
+{% set formControlClass = formControlClass|merge([baseClass, class, labelPlacementClass]) %}
 
 {% if error %}
 	{% set formControlClass = formControlClass|merge([errorClass]) %}


### PR DESCRIPTION
With this change it will be possible to merge default classes from Drupal if they are needed for the functionality of the forms.