### PR TITLE
Hotfix(styles/themes): set all opacity values with decimals

### DIFF
--- a/.changeset/blue-knives-fix.md
+++ b/.changeset/blue-knives-fix.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/themes": patch
+---
+
+Set opacity with decimals instead of percents to prevent cssnano from clamping values at 1%.

--- a/packages/styles/scss/components/_checkbox.scss
+++ b/packages/styles/scss/components/_checkbox.scss
@@ -70,7 +70,7 @@
   }
 
   &:disabled {
-    opacity: 45%;
+    opacity: 0.45;
     pointer-events: none;
   }
 

--- a/packages/styles/scss/components/_dropdown.scss
+++ b/packages/styles/scss/components/_dropdown.scss
@@ -34,7 +34,7 @@
   background-position: calc(100% - 14px) center, 100% center;
   background-repeat: no-repeat;
   background-size: 24px 24px, 102px 100%;
-  background-image: url("#{colortodataurlicon("arrow", $color-ux-labels-actionable)}"),
+  background-image: url("#{colortodataurlicon('arrow', $color-ux-labels-actionable)}"),
     linear-gradient(
       to right,
       transparent 0%,
@@ -61,7 +61,7 @@
     );
     @include bordervalues("input", "formelements", "hover");
     border-left-width: 2px;
-    background-image: url("#{colortodataurlicon("arrow", $color-ux-labels-hover)}"),
+    background-image: url("#{colortodataurlicon('arrow', $color-ux-labels-hover)}"),
       linear-gradient(
         to right,
         transparent 0%,
@@ -84,7 +84,7 @@
     );
     @include bordervalues("input", "formelements", "focus");
     border-left-width: 2px;
-    background-image: url("#{colortodataurlicon("arrow", $color-ux-labels-hover)}"),
+    background-image: url("#{colortodataurlicon('arrow', $color-ux-labels-hover)}"),
       linear-gradient(
         to right,
         transparent 0%,
@@ -100,7 +100,7 @@
     background-position: calc(100% - 14px) center, 100% center;
     background-repeat: no-repeat;
     background-size: 24px 24px, 102px 100%;
-    background-image: url("#{colortodataurlicon("arrow", $color-ux-labels-actionable)}"),
+    background-image: url("#{colortodataurlicon('arrow', $color-ux-labels-actionable)}"),
       linear-gradient(
         to right,
         transparent 0%,
@@ -114,7 +114,7 @@
   }
 
   &:disabled {
-    opacity: 45%;
+    opacity: 0.45;
     pointer-events: none;
   }
 

--- a/packages/styles/scss/components/_fieldset.scss
+++ b/packages/styles/scss/components/_fieldset.scss
@@ -97,7 +97,7 @@
   }
 
   &__disabled {
-    opacity: 50%;
+    opacity: 0.5;
     pointer-events: none;
   }
 

--- a/packages/styles/scss/components/_file-upload.scss
+++ b/packages/styles/scss/components/_file-upload.scss
@@ -58,7 +58,7 @@
     }
 
     &:disabled {
-      opacity: 45%;
+      opacity: 0.45;
       pointer-events: none;
     }
 

--- a/packages/styles/scss/components/_form.scss
+++ b/packages/styles/scss/components/_form.scss
@@ -39,7 +39,7 @@
   }
 
   &__disabled {
-    opacity: 50%;
+    opacity: 0.5;
     pointer-events: none;
   }
 }

--- a/packages/styles/scss/components/_input.scss
+++ b/packages/styles/scss/components/_input.scss
@@ -40,7 +40,7 @@
   }
 
   &:disabled {
-    opacity: 45%;
+    opacity: 0.45;
     pointer-events: none;
   }
 

--- a/packages/styles/scss/components/_radio.scss
+++ b/packages/styles/scss/components/_radio.scss
@@ -62,7 +62,7 @@
 
   input:disabled + &--control:after,
   input:disabled + &--control:before {
-    opacity: 45%;
+    opacity: 0.45;
   }
 
   input:invalid + &--control:after,

--- a/packages/styles/scss/components/_searchfield.scss
+++ b/packages/styles/scss/components/_searchfield.scss
@@ -63,7 +63,7 @@
     }
 
     &:disabled {
-      opacity: 45%;
+      opacity: 0.45;
       pointer-events: none;
     }
   }

--- a/packages/styles/scss/components/_textarea.scss
+++ b/packages/styles/scss/components/_textarea.scss
@@ -43,7 +43,7 @@
   }
 
   &:disabled {
-    opacity: 45%;
+    opacity: 0.45;
     pointer-events: none;
   }
 

--- a/packages/styles/scss/components/_textinput.scss
+++ b/packages/styles/scss/components/_textinput.scss
@@ -40,7 +40,7 @@
   }
 
   &:disabled {
-    opacity: 45%;
+    opacity: 0.45;
     pointer-events: none;
   }
 

--- a/packages/themes/tokens/opacity/base.json
+++ b/packages/themes/tokens/opacity/base.json
@@ -1,6 +1,6 @@
 {
   "opacity": {
-    "disabled": { "value": "45%" },
-    "semi-transparent": { "value": "60%" }
+    "disabled": { "value": "0.45" },
+    "semi-transparent": { "value": "0.6" }
   }
 }


### PR DESCRIPTION
Fixes incorrect opacity values in production where cssnano was clamping percentages to 1%.