### PR TITLE
Twig/Styles: Align Hero Content to main content area

### DIFF
--- a/.changeset/many-pots-begin.md
+++ b/.changeset/many-pots-begin.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Hero Card and Breadcrumbs get their padding-inline-start value from a CSS variable calculated in the Hero

--- a/.changeset/neat-hotels-prove.md
+++ b/.changeset/neat-hotels-prove.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Prevent artifact from appearing between the Hero Card and the card offset space in Chrome

--- a/.changeset/silent-countries-yell.md
+++ b/.changeset/silent-countries-yell.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Align Hero Card content with main body content when `justify` is set to `start` or `offset`

--- a/.changeset/tender-carpets-tie.md
+++ b/.changeset/tender-carpets-tie.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix alignment of Hero Card content in RTL layouts

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -12,7 +12,7 @@
     background-color: $color-base-neutrals-white;
     display: inline-flex;
     justify-content: flex-start;
-    padding: px-to-rem(16px) 0 px-to-rem(16px) px-to-rem($spacing-padding-1-5);
+    padding: px-to-rem(16px) 0 px-to-rem(16px) var(--card-padding-start);
     position: relative;
 
     &.context--menu {

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -12,7 +12,9 @@
     background-color: $color-base-neutrals-white;
     display: inline-flex;
     justify-content: flex-start;
-    padding: px-to-rem(16px) 0 px-to-rem(16px) var(--card-padding-start);
+    padding-block: px-to-rem(16px);
+    padding-inline-end: 0;
+    padding-inline-start: var(--card-padding-start);
     position: relative;
 
     &.context--menu {
@@ -66,7 +68,7 @@
       align-items: center;
       display: flex;
       position: relative;
-      width: px-to-rem($spacing-padding-4);
+      width: 17px;
 
       .ilo--breadcrumb--link {
         padding-left: 0;

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -411,13 +411,23 @@
 
       &--card-offset {
         grid-area: 3 / 4 / 6 / 5;
+
+        &:after {
+          right: initial;
+          left: -1px;
+        }
       }
 
       &--card {
         grid-area: 3 / 3 / 6 / 4;
       }
 
+      &--breadcrumbs-offset {
+        grid-area: 1 / 4 / 2 / 5;
+      }
+
       &--breadcrumbs {
+        grid-area: 1 / 4 / 2 / 1;
         flex-direction: row-reverse;
       }
 

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -5,14 +5,19 @@
 .hero {
   $c: &;
 
-  // Offset from the edge of the window to keep content in the main content area
+  // Total offset from the edge of the window
   $base-offset: calc((100vw - #{$layout-max-width}) / 2);
+
+  // The card padding from the edge of the window This is a CSS variable
+  // so it can be used by the card and breadcrumb to calculate their own
+  // padding from the edge of the window
+  --card-padding-start: max(
+    16px,
+    min(#{$base-offset}, #{$spacing-hero-card-padding-x-lg})
+  );
 
   // Card offset from the edge of the window minus the card's padding
   $card-offset: calc(#{$base-offset} - #{$spacing-hero-card-padding-x-lg});
-
-  // Added offset for justified offset
-  $card-offset-justified: minmax(108px, #{$card-offset});
 
   // The height of the corner cut
   --corner-cut-height: #{$spacing-hero-card-corner-cut-height-sm};
@@ -82,8 +87,7 @@
       var(--row-1-lg)
       var(--row-2-lg)
       var(--row-3-lg)
-      var(--row-4-lg)
-      var(--row-5-lg);
+      var(--row-4-lg);
 
     grid-template-columns:
       var(--col-1-lg)
@@ -132,12 +136,9 @@
     }
 
     &__card-justify {
-      &__start {
-        --col-1-lg: #{$card-offset};
-      }
-
+      &__start,
       &__offset {
-        --col-1-lg: #{$card-offset-justified};
+        --col-1-lg: #{$card-offset};
       }
 
       &__center {
@@ -201,22 +202,29 @@
       }
     }
 
+    &--breadcrumbs-offset {
+      grid-area: 1 / 1 / 2 / 2;
+      background-color: $color-base-neutrals-white;
+      z-index: 1;
+    }
+
     &--breadcrumbs {
-      grid-area: 1 / 1 / 2 / 5;
+      grid-area: 1 / 2 / 2 / 5;
       z-index: 1;
       display: flex;
       flex-flow: row nowrap;
 
+      // &:before {
+      //   content: "";
+      //   position: relative;
+      //   display: inline-block;
+      //   height: 100%;
+      //   width: var(--card-padding-start);
+      //   background-color: $color-base-neutrals-white;
+      // }
+
       &--wrapper {
         width: 100%;
-      }
-
-      &:before {
-        content: "";
-        background-color: $color-base-neutrals-white;
-        position: relative;
-        height: 100%;
-        width: max($spacing-hero-card-padding-x-lg, $base-offset);
       }
     }
 
@@ -235,7 +243,6 @@
     &--card-offset {
       grid-area: 3 / 1 / 6 / 2;
       z-index: 0;
-      background-color: transparent;
 
       #{$c}__card-justify__offset &,
       #{$c}__card-justify__center & {
@@ -334,7 +341,7 @@
           --col-1-lg: 1fr;
           --col-2-lg: #{$spacing-hero-tooltip-width};
           --col-3-lg: var(--card-width);
-          --col-4-lg: #{$card-offset-justified};
+          --col-4-lg: #{$card-offset};
         }
 
         &__center {

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -8,15 +8,20 @@
   // Total offset from the edge of the window
   $base-offset: calc((100vw - #{$layout-max-width}) / 2);
 
-  // The card padding from the edge of the window This is a CSS variable
-  // so it can be used by the card and breadcrumb to calculate their own
-  // padding from the edge of the window
-  --card-padding-start: max(
+  // Card padding defaults to a fixed value. But it's a CSS variable
+  // so that we can make it squeezy when the card is justified `start`
+  // or `offset`
+  --card-padding-start: #{$spacing-hero-card-padding-x-lg};
+
+  // Squishy padding makes it so we can have a flexible padding value
+  // that will be somewhere between 16px and the card's fixed padding
+  // depending on how far the card is from the edge of the screen
+  $squeezy-padding-start: max(
     16px,
     min(#{$base-offset}, #{$spacing-hero-card-padding-x-lg})
   );
 
-  // Card offset from the edge of the window minus the card's padding
+  // Card offset from the edge of the window minus the card's fixed padding
   $card-offset: calc(#{$base-offset} - #{$spacing-hero-card-padding-x-lg});
 
   // The height of the corner cut
@@ -139,6 +144,7 @@
     &__card-justify {
       &__start,
       &__offset {
+        --card-padding-start: #{$squeezy-padding-start};
         --col-1-lg: #{$card-offset};
       }
 

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -31,6 +31,7 @@
     $spacing-hero-card-corner-cut-height-sm
     auto;
   grid-template-columns: 1fr;
+  overflow: hidden;
 
   &--breadcrumbs {
     display: none;
@@ -174,6 +175,7 @@
       &__dark {
         #{$c}--card-offset {
           background-color: map-get($color, "base", "blue", "dark");
+          position: relative;
         }
 
         &[class*="semi-transparent"] {
@@ -214,15 +216,6 @@
       display: flex;
       flex-flow: row nowrap;
 
-      // &:before {
-      //   content: "";
-      //   position: relative;
-      //   display: inline-block;
-      //   height: 100%;
-      //   width: var(--card-padding-start);
-      //   background-color: $color-base-neutrals-white;
-      // }
-
       &--wrapper {
         width: 100%;
       }
@@ -243,6 +236,19 @@
     &--card-offset {
       grid-area: 3 / 1 / 6 / 2;
       z-index: 0;
+      position: relative;
+
+      // A band-aid that prevents artifacts from appearing
+      // between the card and the card offset in Chrome
+      &::after {
+        content: "";
+        position: absolute;
+        height: 100%;
+        width: 3px;
+        right: -1px;
+        background-color: inherit;
+        z-index: 1;
+      }
 
       #{$c}__card-justify__offset &,
       #{$c}__card-justify__center & {

--- a/packages/styles/scss/components/_herocard.scss
+++ b/packages/styles/scss/components/_herocard.scss
@@ -10,7 +10,9 @@
   padding: $spacing-hero-card-padding-y-sm $spacing-hero-card-padding-x-sm;
 
   @include breakpoint("large") {
-    padding: $spacing-hero-card-padding-y-lg $spacing-hero-card-padding-x-lg;
+    padding-block: $spacing-hero-card-padding-y-lg;
+    padding-inline-end: $spacing-hero-card-padding-x-lg;
+    padding-inline-start: var(--card-padding-start);
   }
 
   .right-to-left & {

--- a/packages/twig/src/patterns/components/hero/hero.twig
+++ b/packages/twig/src/patterns/components/hero/hero.twig
@@ -19,6 +19,7 @@
 		{% endblock %}
 	</figure>
 	{% if breadcrumb %}
+		<div class="hero--breadcrumbs-offset"></div>
 		<div class="hero--breadcrumbs">
 			<div class="hero--breadcrumbs--wrapper">
 				{% include "@components/breadcrumb/breadcrumb.twig" with {


### PR DESCRIPTION
Align Hero Card content with main body content when `justify` is set to `start` or `offset`. 

Fixes #580 