### PR TITLE
fix(styles): fixed input border radius on iOS Safari

### DIFF
--- a/.changeset/witty-trees-greet.md
+++ b/.changeset/witty-trees-greet.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+"@ilo-org/react": patch
+---
+
+fixed input border-radius on iOS Safari

--- a/packages/styles/scss/_reset.scss
+++ b/packages/styles/scss/_reset.scss
@@ -151,6 +151,12 @@ select {
   -moz-appearance: none;
 }
 
+// Reset border-radius on iOS Safari
+input,
+textarea {
+  border-radius: 0;
+}
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
Fixes #546 

Upon investigation, the issue affected more than just the search field outlined in the issue and also affected all inputs and text areas. As such, this fix addresses all of it.

It is highly suspect that the CSS reset being used in this project does not already cover this. It seems like it is out of date. @justintemps  perhaps we should consider moving to a more maintained css reset.