### PR TITLE
fix(twig): implemented tab strategy for external links

### DIFF
--- a/.changeset/mighty-ducks-return.md
+++ b/.changeset/mighty-ducks-return.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": minor
+---
+
+Implemented functionality for external links to open in new browser tab

--- a/packages/twig/src/patterns/components/linklist/index.js
+++ b/packages/twig/src/patterns/components/linklist/index.js
@@ -4,3 +4,4 @@
 // Module template
 import "./linklist.twig";
 import "./linklist.wingsuit.yml";
+import "./linklist.behavior";

--- a/packages/twig/src/patterns/components/linklist/linklist.behavior.js
+++ b/packages/twig/src/patterns/components/linklist/linklist.behavior.js
@@ -1,0 +1,15 @@
+import LinkList from "./linklist";
+
+Drupal.behaviors.link = {
+  attach() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll(`[data-loadcomponent="LinkList"]`),
+      (element) => {
+        if (!element.dataset.jsProcessed) {
+          new LinkList(element);
+          element.dataset.jsProcessed = true;
+        }
+      }
+    );
+  },
+};

--- a/packages/twig/src/patterns/components/linklist/linklist.js
+++ b/packages/twig/src/patterns/components/linklist/linklist.js
@@ -1,0 +1,55 @@
+export default class LinkList {
+  /**
+   * LinkList constructor which assigns the element passed into the constructor
+   * to the `this.element` property for later reference
+   *
+   * @param {HTMLElement} element - REQUIRED - the module's container
+   */
+
+  constructor(element) {
+    /**
+     * Reference to the DOM element that is the root of the component
+     * @property {Object}
+     */
+    this.element = element;
+
+    /** element prefix */
+    this.prefix = `${this.element.dataset.prefix}--link-list`;
+
+    this.init();
+  }
+
+  /**
+   * Initializes the view by calling the functions to
+   * create DOM references, setup event handlers and
+   * then create the event listeners
+   *
+   * @return {Object} LinkList A reference to the instance of the class
+   * @chainable
+   */
+  init() {
+    this.append();
+
+    return this;
+  }
+
+  /**
+   * Appends target="_blank" to all external links in the list
+   *
+   * @return {Object} LinkList A reference to the current instance of the class
+   * @chainable
+   */
+  append() {
+    const selector = `a:not([target=_blank]).${this.prefix}--link`;
+    const links = this.element.querySelectorAll(selector);
+    const origin = window.location.origin;
+
+    for (const link of links) {
+      if (new URL(link.href).origin !== origin) {
+        link.setAttribute("target", "_blank");
+      }
+    }
+
+    return this;
+  }
+}

--- a/packages/twig/src/patterns/components/linklist/linklist.twig
+++ b/packages/twig/src/patterns/components/linklist/linklist.twig
@@ -1,7 +1,7 @@
 {#
   LINK LIST COMPONENT
 #}
-<div class="{{prefix}}--link-list {{prefix}}--link-list--{{theme}}">
+<div class="{{prefix}}--link-list {{prefix}}--link-list--{{theme}}" data-loadcomponent="LinkList" data-prefix="{{prefix}}">
   {% if headline %}
     <h3 class="{{prefix}}--link-list--headline">{{headline}}</h3>
   {% endif %}


### PR DESCRIPTION
## LinkList external links

I added a twig implementation for external links inside `linklist` component to open in a new browser tab. Implementation attaches `target=_blank" based on **origin** comparison using [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).

### Demo
https://github.com/international-labour-organization/designsystem/assets/36326203/80e17054-d909-4384-aee4-2ca80441e157



Fixes #547 