### PR TITLE
fix(styles): reduced padding for accordion inner panel

### DIFF
--- a/.changeset/red-ghosts-smile.md
+++ b/.changeset/red-ghosts-smile.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+"@ilo-org/react": patch
+---
+
+reduced padding for accordion inner panel

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -86,7 +86,7 @@
     overflow: hidden;
 
     .ilo--accordion--innerpanel {
-      padding-bottom: px-to-rem($spacing-ui-padding-xxl);
+      padding-bottom: px-to-rem($spacing-ui-padding-sm);
       padding-top: px-to-rem(8px);
     }
 


### PR DESCRIPTION
## Accordion padding

Reduced accordion inner panel bottom padding.


## Demo
### TWIG

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/1761758c-2a83-4c70-8c8c-054c80136f3d)
![image](https://github.com/international-labour-organization/designsystem/assets/36326203/38893a1f-7e94-4a55-829b-6f5f9654d76c)
---
### React

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/f26b202c-3352-4af7-b87c-6d91785965c4)


The accordion component inside Figma has no open-state example 

Fixes #572 
