### PR TITLE
Fix(Style): Truncate breadcrumb for long text

### DIFF
--- a/.changeset/beige-bugs-buy.md
+++ b/.changeset/beige-bugs-buy.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Truncate text of breadcrumbs when it exceeds 40 chars

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -16,7 +16,6 @@
     padding-inline-end: 0;
     padding-inline-start: var(--card-padding-start);
     position: relative;
-
     &.context--menu {
       padding: 0;
     }
@@ -41,6 +40,10 @@
     }
 
     &--label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 40ch;
       font-family: $fonts-copy;
       font-weight: 400;
       @include font-styles("body-xxs");


### PR DESCRIPTION
**Change :-** 

* Truncate text of breadcrumbs when it exceeds 40 chars

<img width="750" alt="Screenshot 2023-11-09 at 02 19 13" src="https://github.com/international-labour-organization/designsystem/assets/32934169/a0bd1994-1db6-40c0-b750-d63ecde4f33d">


Fixes: https://github.com/international-labour-organization/designsystem/issues/564

