### PR TITLE
fix(styles): added hover effect for anchor item

### DIFF
--- a/.changeset/curvy-olives-obey.md
+++ b/.changeset/curvy-olives-obey.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+added hover effect for anchor item inside indented linked list

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -57,6 +57,8 @@
         }
       }
 
+      & .ilo--link-list--link:hover,
+      & .ilo--link-list--link:focus,
       &:hover,
       &:focus {
         .ilo--link-list--label:before {


### PR DESCRIPTION
## LinkList padding issue 

### Investigation
At first glance current implementation hovers the indicator(arrow) for the indented list item `(Asset 1)`, but if we force the `:hover` state for the actual anchor tag arrow has no effect `(Asset 2)`. This might be a big issue during keyboard navigation `(Asset 3`)`

> Asset 1

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/62efbcf5-af5d-433d-b91f-befd973e1291)

> Asset 2

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/3739e675-a41c-4469-a3a9-757a9aab8fbd)

> Asset 3

https://github.com/international-labour-organization/designsystem/assets/36326203/7539e81b-8107-499b-ba61-aab342368c36

### Solution
Current implementation fixes the issue by adding hover directly to anchor(`<a>`) item inside indented `LinkList`

https://github.com/international-labour-organization/designsystem/assets/36326203/66829c8d-f37a-4361-ab3a-305d8cc2dc27



Closing #444