### PR TITLE
fix(style): added full width on mobile viewport for affected cards

### DIFF
--- a/.changeset/silent-singers-cross.md
+++ b/.changeset/silent-singers-cross.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+added full width on mobile viewport for affected cards

--- a/packages/styles/scss/components/_datacard.scss
+++ b/packages/styles/scss/components/_datacard.scss
@@ -91,6 +91,10 @@
           --max-width: #{px-to-rem(301px)};
           @include cornercut(72px, 40px);
           padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(53px);
+
+          @include breakpoint("medium", true) {
+            --max-width: 100%;
+          }
         }
 
         &__wide {

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -18,6 +18,10 @@
         padding: px-to-rem(32px) 0;
       }
 
+      @include breakpoint("medium", true) {
+        --max-width: 100%;
+      }
+
       &:hover,
       &:focus,
       &:focus-within {
@@ -75,6 +79,10 @@
 
         &__narrow {
           --max-width: #{px-to-rem(343px)};
+
+          @include breakpoint("medium", true) {
+            --max-width: 100%;
+          }
         }
       }
 

--- a/packages/styles/scss/components/_promocard.scss
+++ b/packages/styles/scss/components/_promocard.scss
@@ -12,6 +12,10 @@
     &__size {
       &__narrow {
         --max-width: #{px-to-rem(343px)};
+
+        @include breakpoint("medium", true) {
+          --max-width: 100%;
+        }
       }
 
       &__standard {

--- a/packages/styles/scss/components/_statcard.scss
+++ b/packages/styles/scss/components/_statcard.scss
@@ -10,6 +10,10 @@
     &__stat {
       --max-width: #{px-to-rem(343px)};
 
+      @include breakpoint("medium", true) {
+        --max-width: 100%;
+      }
+
       border-bottom: px-to-rem(3px) solid $brand-ilo-purple;
       padding: px-to-rem(24px) px-to-rem(40px) px-to-rem(22px);
       position: relative;

--- a/packages/styles/scss/components/_textcard.scss
+++ b/packages/styles/scss/components/_textcard.scss
@@ -33,7 +33,8 @@
         }
       }
 
-      @include breakpoint("medium") {
+      @include breakpoint("medium", true) {
+        --max-width: 100%;
         padding: px-to-rem(32px) px-to-rem(40px);
       }
 
@@ -54,7 +55,8 @@
 
           padding: px-to-rem(24px) px-to-rem(40px);
 
-          @include breakpoint("medium") {
+          @include breakpoint("medium", true) {
+            --max-width: 100%;
             padding: px-to-rem(24px) px-to-rem(40px);
           }
 


### PR DESCRIPTION
## Responsive cards

Current `PR` is primarily focused on `twig` part, `react` components are styled differently and have no breakpoint width issue, but since `scss` is shared I included `react` in the changeset too.

### Affected Components
This table displays which cards had the problem with which sizes

| Card Type      | Component name   | Size                   | Width Problem |
| -------------- | ---------------- | ---------------------- | ------------- |
| Default        | `card`           | *                      | ❌            |
| Text Card      | `card_text`      | standard, narrow       | ✅            |
| Details Card   | `card_detail`    | standard, narrow       | ✅            |
| Promo Card     | `card_promo`     | narrow                 | ✅            |
| Multilink Card | `card_multilink` | *                      | ❌            |
| Data Card      | `card_data`      | narrow                 | ✅            |
| Stat Card      | `card_stat`      | Standard, narrow, wide | ✅            |
| Fact List Card | `card_factlist`  | *                      | ❌            |
| Feature Card   | `card_feature`  | *                      | ❌            |

### Breakpoints
Implementation follows the repo's breakpoint standard and affects screen sizes with `@breakpont("medium", true)`

Fixes #518 

