### PR TITLE
Fix(Style): Truncate long text in tags

### DIFF
--- a/.changeset/blue-lizards-pay.md
+++ b/.changeset/blue-lizards-pay.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/themes": minor
+"@ilo-org/styles": patch
+---
+
+Truncate long text in tags

--- a/packages/styles/scss/components/_tag.scss
+++ b/packages/styles/scss/components/_tag.scss
@@ -30,6 +30,10 @@
   text-decoration: none;
   $self: &;
   @include globaltransition("color, background-color, border-color");
+  max-width: $widths-tags-max-width;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &--active {
     background: map-get($color, "tag", "background", "active");

--- a/packages/themes/tokens/widths/tags.json
+++ b/packages/themes/tokens/widths/tags.json
@@ -1,0 +1,7 @@
+{
+  "widths": {
+    "tags": {
+      "max-width": { "value": "190px" }
+    }
+  }
+}


### PR DESCRIPTION
Issue :- https://github.com/international-labour-organization/designsystem/issues/400

Problem

* Currently long texts in tags take up a lot of space.

Solution

* Text should truncate by showing an ellipsis so that it does not exceed 190px as per the design.

Development

* Modified css by adding a max-width of 190px and a text-overflow style.
* Added variable $widths-tags-max-width

Screenshot 

<img width="710" alt="Screenshot 2023-11-10 at 00 03 07" src="https://github.com/international-labour-organization/designsystem/assets/32934169/2f6c7d1a-ba35-4208-b645-2f5efc1412b2">

