### PR TITLE
Fix(Style): ol showing as ul

### DIFF
--- a/.changeset/shiny-glasses-admire.md
+++ b/.changeset/shiny-glasses-admire.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix ol showing icon instead of numbers

--- a/packages/styles/scss/_reset.scss
+++ b/packages/styles/scss/_reset.scss
@@ -117,7 +117,6 @@ body {
   line-height: 1;
 }
 
-ol,
 ul {
   list-style: none;
 }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -157,6 +157,18 @@
   ul,
   ol {
     li {
+      margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
+      margin-left: px-to-rem(20px);
+      padding-left: px-to-rem(12px);
+      position: relative;
+    }
+    margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
+  }
+
+  ul {
+    li {
+      margin-left: px-to-rem(12px);
+
       &::before {
         content: "";
         display: inline-block;
@@ -167,12 +179,7 @@
         width: px-to-rem(12px);
         @include dataurlicon("listarrow", $color-base-neutrals-light);
       }
-      margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
-      margin-left: px-to-rem(12px);
-      padding-left: px-to-rem(12px);
-      position: relative;
     }
-    margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
   }
 
   blockquote {
@@ -402,15 +409,21 @@
     ul,
     ol {
       li {
+        margin-left: 0;
+        margin-right: px-to-rem(20px);
+        padding-left: 0;
+        padding-right: px-to-rem(12px);
+      }
+    }
+
+    ul {
+      li {
+        margin-right: px-to-rem(12px);
         &::before {
           left: auto;
           right: px-to-rem(-12px);
           @include dataurlicon("listarrowreverse");
         }
-        margin-left: 0;
-        margin-right: px-to-rem(12px);
-        padding-left: 0;
-        padding-right: px-to-rem(12px);
       }
     }
 


### PR DESCRIPTION
Issue :- https://github.com/international-labour-organization/designsystem/issues/336

Problem

 **Based on the investigation there are two issues why this is happening.**
* Currently both ul and ol have their list marker removed.
* Both the ul and ol have a common style set to overide the marker.

Solution

* Remove the list marker for ol as numbers need to be displayed. 
* Seperate out the marker styles for the ul and ol as they are different. 

Development

* Modified css by separting out the ul and ol styles applied for the marker 
* Added seperate padding for ul and ol as it differs based on the marker. 
* Styles needed to be modified for the rtl section as well

Screenshot :- 
<img width="822" alt="Screenshot 2023-11-12 at 19 27 27" src="https://github.com/international-labour-organization/designsystem/assets/32934169/2dba8ec7-b82f-4bfc-94c1-452a6684fb4e">




