### PR TITLE
fix(style): video timecode hover

### DIFF
--- a/.changeset/metal-peas-exercise.md
+++ b/.changeset/metal-peas-exercise.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": minor
+"@ilo-org/twig": minor
+"@ilo-org/styles": patch
+---
+
+Added chained hover effect for video play button

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -1,4 +1,11 @@
-import { FC, createRef, useState } from "react";
+import {
+  FC,
+  FocusEvent,
+  MouseEvent,
+  createRef,
+  useCallback,
+  useState,
+} from "react";
 /* temporary way of importing ReactPlayer due to a known issue with ReactPlayer.
  * Revert to standard method of importing once RP's dev has fixed.
  */
@@ -166,6 +173,27 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
     setSeeking(false);
   };
 
+  const handlePlayHover = useCallback(
+    (
+      event: MouseEvent<HTMLButtonElement> | FocusEvent<HTMLButtonElement>,
+      state: boolean
+    ) => {
+      const element = event.currentTarget;
+      if (!element.classList.contains(`${controlsClasses}--play`)) {
+        return;
+      }
+
+      const duration = element.previousSibling;
+      if (duration instanceof HTMLLabelElement) {
+        duration.classList.toggle(
+          `${controlsClasses}--duration--hovered`,
+          state
+        );
+      }
+    },
+    [controlsClasses]
+  );
+
   return (
     <div
       className={`${baseClass}--container`}
@@ -214,6 +242,10 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
         <button
           className={`${controlsClasses}--${!playing ? "play" : "pause"}`}
           onClick={togglePlay}
+          onMouseOver={(e) => handlePlayHover(e, true)}
+          onFocus={(e) => handlePlayHover(e, true)}
+          onMouseOut={(e) => handlePlayHover(e, false)}
+          onBlur={(e) => handlePlayHover(e, false)}
         >
           <span>
             {!playing ? controls && controls.play : controls && controls.pause}

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -244,10 +244,22 @@
       text-align: center;
       width: px-to-rem(80px);
 
+      &.ilo--video--controls--duration--hovered,
       &:hover,
       &:focus {
         background-color: $color-ux-video-controls-hover-background;
         color: $color-ux-video-controls-hover-icon;
+
+        // react-player play button,  https://github.com/international-labour-organization/designsystem/issues/521
+        & ~ .ilo--video--controls--play {
+          background-color: $color-ux-video-controls-hover-background;
+          @include iconbutton(
+            "play",
+            $spacing-ux-video-bigplaybutton-height,
+            $spacing-ux-video-bigplaybutton-width,
+            $color-ux-video-controls-hover-icon
+          );
+        }
       }
 
       @include font-styles("label-small");

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -165,6 +165,7 @@
         $color-ux-video-controls-default-icon
       );
 
+      &.ilo--video--controls--play--hovered,
       &:hover,
       &:focus {
         background-color: $color-ux-video-controls-hover-background;

--- a/packages/twig/src/patterns/components/video/video.js
+++ b/packages/twig/src/patterns/components/video/video.js
@@ -1,3 +1,4 @@
+import { EVENTS } from "@ilo-org/utils";
 import videojs from "video.js";
 
 /**
@@ -36,7 +37,11 @@ export default class Video {
    * @chainable
    */
   init() {
-    this.cacheDomReferences().start().setupHandlers().enable();
+    this.cacheDomReferences()
+      .start()
+      .cacheVideoReferences()
+      .setupHandlers()
+      .enable();
 
     return this;
   }
@@ -60,25 +65,57 @@ export default class Video {
   }
 
   /**
+   * Find all necessary DOM elements inside videojs
+   *
+   * @return {Object} Video A reference to the instance of the class
+   * @chainable
+   */
+  cacheVideoReferences() {
+    /**
+     * The button for video play control
+     * @type {?Element}
+     */
+    this.PlayButton = this.element.querySelector(".vjs-play-control");
+
+    /**
+     * The duration display
+     * @type {?Element}
+     */
+    this.Duration = this.element.querySelector(".vjs-duration");
+
+    return this;
+  }
+
+  /**
    * Bind event handlers with the proper context of `this`.
    *
    * @return {Object} Video A reference to the current instance of the class
    * @chainable
    */
   setupHandlers() {
+    this.onDurationHover = this.onDurationHover.bind(this);
+
     return this;
   }
 
   /**
-   * Creates event listeners to enable interaction with view
+   * Creates event listeners to fix duration hover
+   * https://github.com/international-labour-organization/designsystem/issues/521
    *
-   * @return {Object} ReadMore A reference to the instance of the class
+   * @return {Object} Video A reference to the instance of the class
    * @chainable
    */
   enable() {
+    if (!this.Duration) return this;
+    this.Duration.addEventListener(EVENTS.MOUSEOVER, () =>
+      this.onDurationHover(true)
+    );
+    this.Duration.addEventListener(EVENTS.MOUSEOUT, () => {
+      this.onDurationHover(false);
+    });
+
     return this;
   }
-
   /**
    * Starts up videojs
    *
@@ -110,6 +147,23 @@ export default class Video {
         { type: this.element.dataset.vjsType, src: this.element.dataset.src },
       ],
     });
+
+    return this;
+  }
+
+  /**
+   * Controls duration hover
+   *
+   * @param {boolean} state - whether or not the duration is hovered
+   * @return {Object} Video A reference to the instance of the class
+   * @chainable
+   */
+  onDurationHover(state) {
+    if (!this.PlayButton) return this;
+    const className = `${this.controlsprefix}--play--hovered`;
+
+    if (this.PlayButton.classList.contains("vjs-playing")) return this;
+    this.PlayButton.classList.toggle(className, state);
 
     return this;
   }


### PR DESCRIPTION
## Breakdown 
Let's break down this PR into 2 pieces, for `react` and `twig`. This separation is necessary because video components have drastically different implementations.

## Twig 
Twig component uses `video.js` for display, which has its own makeup for controls.
![image](https://github.com/international-labour-organization/designsystem/assets/36326203/468be043-dbbd-4844-a8c2-dfaa8181b091)
When we hover the button, duration is also styled because we are using the `sibling`(`~`) selector 
```scss
&:hover,
&:focus {
  background-color: $color-ux-video-controls-hover-background;
  @include iconbutton(
    "play",
    $spacing-ux-video-bigplaybutton-height,
    $spacing-ux-video-bigplaybutton-width,
    $color-ux-video-controls-hover-icon
  );

  & ~ .vjs-duration,
  & ~ .ilo--video--controls--duration {
    background-color: $color-ux-video-controls-hover-background;
    color: $color-ux-video-controls-hover-icon;
  }
```
but when we want to invert the behavior we can't use the `sibling` selector because the button is on top of `duration`  and sibling selectors can't select items above it
> The subsequent-sibling combinator (~) separates two selectors and matches all instances of the second element that follow the first element (not necessarily immediately) and share the same parent element.

Because of that we have Javascript implementation that listens to [mouseover](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseover_event) and [mouseout](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseout_event) on duration element and attaches `hovered` class to the button.

### Demo
https://github.com/international-labour-organization/designsystem/assets/36326203/48eb65b1-f4dd-470a-a3c4-13b1e06421f0

For implementation details, the `Video` class has the function `cacheDomReferences` but the current implementation is using `cacheVideoReferences` because of this chain 
```js
init() {
  this.cacheDomReferences()
    .start()
    .cacheVideoReferences()
    .setupHandlers()
    .enable();

  return this;
}
```
We can't find dom references for `video.js` until it's instantiated.

### a11y 
Since button element is first and it's tab indexed there is no problem for `keyboard` a11y

https://github.com/international-labour-organization/designsystem/assets/36326203/80f05f67-d728-4afd-905c-c7a7740874a2

----
## React
The current react implementation has no implementation for this feature at all, so I included that one too. 

### Current
https://github.com/international-labour-organization/designsystem/assets/36326203/1ed2dd8f-1319-4f7e-a87c-0addc5625b87

### Fixed
https://github.com/international-labour-organization/designsystem/assets/36326203/60fa0434-78f0-43f4-9ff6-94fa42a93a5f


but on the react side everything is upside down compared to Twig, I mean that controls are reversed 
```jsx
<>
  <label
    className={`${controlsClasses}--duration ${showposter ? "show" : ""}`}
  >
    {duration}
  </label>
  <button
    className={`${controlsClasses}--${!playing ? "play" : "pause"}`}
    onClick={togglePlay}
  >
    <span>
      {!playing ? controls && controls.play : controls && controls.pause}
    </span>
  </button>
</>
```
so without breaking an old implementation, the initial flow was done by a sibling selector but reversed, and the problematic part was done with the same behavior as the Twig one. 

For implementation details, I'm handling `mouseover` and `mouseout` directly on the button without controlling the hover effect with `state`, because there is no need to bring extra rerenders for the `hover` effect, since the application logic does not need it

### a11y
Since the button element is the second one we also handling `onFocus` and `onBlur` for keyboard navigation 

https://github.com/international-labour-organization/designsystem/assets/36326203/18f4885d-bf54-4e6c-b2d8-2fbed58f8758



Closing #521



