### PR TITLE
Fix(Style): Refactor RTL to use dir in herocard

### DIFF
--- a/.changeset/tricky-jokes-vanish.md
+++ b/.changeset/tricky-jokes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in herocard

--- a/packages/styles/scss/components/_herocard.scss
+++ b/packages/styles/scss/components/_herocard.scss
@@ -15,10 +15,6 @@
     padding-inline-start: var(--card-padding-start);
   }
 
-  .right-to-left & {
-    direction: rtl;
-  }
-
   &--title-link {
     color: inherit;
     text-decoration: none;
@@ -78,7 +74,7 @@
       $spacing-hero-card-corner-cut-height-sm
     );
 
-    .right-to-left & {
+    [dir="rtl"] & {
       @include cornercut(
         $spacing-hero-card-corner-cut-width-sm,
         $spacing-hero-card-corner-cut-height-sm,
@@ -92,7 +88,7 @@
         $spacing-hero-card-corner-cut-height-lg
       );
 
-      .right-to-left & {
+      [dir="rtl"] & {
         @include cornercut(
           $spacing-hero-card-corner-cut-width-lg,
           $spacing-hero-card-corner-cut-height-lg,


### PR DESCRIPTION
Issue :- https://github.com/orgs/international-labour-organization/projects/2/views/2?pane=issue&itemId=44244511

Development

* Modified css to use dir attribute selector instead of right-to-left class