### PR TITLE
Fix(Style): Refactor RTL to use dir in credit

### DIFF
--- a/.changeset/proud-lies-jump.md
+++ b/.changeset/proud-lies-jump.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix(Style): Refactor RTL to use dir in caption

--- a/packages/styles/scss/components/_credit.scss
+++ b/packages/styles/scss/components/_credit.scss
@@ -80,7 +80,7 @@
     }
   }
 
-  .right-to-left & {
+  [dir="rtl"] & {
     &:after {
       background-position: top left;
       left: auto;


### PR DESCRIPTION
Issue :- https://github.com/orgs/international-labour-organization/projects/2/views/2?pane=issue&itemId=44244511

Development

* Modified css to use dir attribute selector instead of right-to-left class