### PR TITLE
fix(styles/themes): fixed text input invalid state

### DIFF
--- a/.changeset/spicy-ads-roll.md
+++ b/.changeset/spicy-ads-roll.md
@@ -1,0 +1,8 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/themes": patch
+"@ilo-org/twig": patch
+---
+
+fixed text input invalid state

--- a/packages/styles/scss/components/_textinput.scss
+++ b/packages/styles/scss/components/_textinput.scss
@@ -53,13 +53,6 @@
       "error",
       "background"
     );
-  }
-
-  &:invalid {
-    @include bordervalues("input", "formelements", "invalid");
-  }
-
-  &__error {
     @include bordervalues("input", "formelements", "error");
   }
 }

--- a/packages/themes/tokens/color/formelements.json
+++ b/packages/themes/tokens/color/formelements.json
@@ -42,16 +42,6 @@
           },
           "color": { "value": "{color.base.neutrals.medium}" }
         },
-        "invalid": {
-          "background": { "value": "{color.base.neutrals.white}" },
-          "border": {
-            "bottom": { "value": "{color.base.neutrals.light}" },
-            "left": { "value": "{color.base.yellow}" },
-            "right": { "value": "{color.base.neutrals.light}" },
-            "top": { "value": "{color.base.neutrals.light}" }
-          },
-          "color": { "value": "{color.base.neutrals.medium}" }
-        },
         "disabled": {
           "background": { "value": "{color.base.neutrals.white}" },
           "border": {

--- a/packages/twig/src/patterns/components/textinput/textinput.wingsuit.yml
+++ b/packages/twig/src/patterns/components/textinput/textinput.wingsuit.yml
@@ -43,7 +43,6 @@ textinput:
       type: text
       label: Pattern
       description: The pattern of the text input.
-      preview: textinput``
       default: ""
   settings:
     labelPlacement:


### PR DESCRIPTION
Fixes #591 

The Text area already has the desired behaviour (red on error / required, blue when not and in focus). Changed the Text input to have the same behaviour, removed the tokens for the unused invalid state and removed the default pattern in wingsuit so that the Text input behaves as expected when opened by default in storybook.