### PR TITLE
Fix(Style): Refactor and fix RTL style in linklist

### DIFF
--- a/.changeset/dull-boxes-collect.md
+++ b/.changeset/dull-boxes-collect.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in linklist and fix style bug

--- a/packages/styles/scss/components/_footer.scss
+++ b/packages/styles/scss/components/_footer.scss
@@ -371,34 +371,9 @@
   }
 
   /* RTL Styles */
-  .right-to-left & {
-    * {
-      text-align: right;
-    }
-
+  &[dir="rtl"] & {
     &--main {
       @include footer-triangle(bottom-left);
-    }
-
-    .subscribe a {
-      align-self: flex-end;
-    }
-
-    &--secondary {
-      [class*="container"] {
-        flex-direction: row-reverse;
-      }
-
-      &--details {
-        display: flex;
-        flex-flow: row-reverse wrap;
-      }
-    }
-
-    .secondarylinks {
-      &--list {
-        flex-direction: row-reverse;
-      }
     }
 
     .secondarylinks--list--item {

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -55,6 +55,15 @@
             $color-base-neutrals-light
           );
         }
+
+        [dir="rtl"] & {
+          padding-right: px-to-rem($spacing-padding-3);
+          &:before {
+            transform: translateY(-50%) rotate(90deg);
+            left: unset;
+            right: 0;
+          }
+        }
       }
 
       & .ilo--link-list--link:hover,
@@ -107,7 +116,7 @@
       @include globaltransition("color, background-color, border-color");
     }
 
-    .right-to-left & {
+    [dir="rtl"] & {
       background-position: $spacing-padding-0-5 center;
       @include dataurlicon("arrowleft", $color-link-text-default);
 
@@ -165,7 +174,7 @@
         }
       }
 
-      .right-to-left & {
+      [dir="rtl"] & {
         background-position: $spacing-padding-0-5 center;
         @include dataurlicon("arrowleft", $color-base-neutrals-white);
 
@@ -174,12 +183,6 @@
           @include dataurlicon("arrowleft", $color-base-blue-medium);
         }
       }
-    }
-  }
-
-  .right-to-left & {
-    * {
-      text-align: right;
     }
   }
 }


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Related component :- 

* The footer uses a linklist component so it will be included in this as well. 

Investigation

* In linklist the right to left class needs to be changed to dir attribute
* There was a design bug found when the rtl toggle has been done which existed in the component previously

<img width="739" alt="Screenshot 2023-11-16 at 01 26 36" src="https://github.com/international-labour-organization/designsystem/assets/32934169/27c9f2ca-9866-420d-b7ee-5b0aeffd3482">

Development

* Modified css to use dir attribute selector instead of right-to-left class
* Fixed arrow positioning and side using css styling

Screenshot

**LinkList**

* LTR

<img width="500" alt="Screenshot 2023-11-15 at 21 42 19" src="https://github.com/international-labour-organization/designsystem/assets/32934169/08652b62-56e2-41aa-8e58-96263716bf49">

* RTL

<img width="500" alt="Screenshot 2023-11-15 at 21 42 33" src="https://github.com/international-labour-organization/designsystem/assets/32934169/4b275adf-7a44-4789-8014-3633bfdf3703">

**Footer**

* LTR

<img width="500" alt="Screenshot 2023-11-16 at 01 48 52" src="https://github.com/international-labour-organization/designsystem/assets/32934169/67998b4d-16c3-4d82-8e25-6270c508181d">

* RTL

<img width="500" alt="Screenshot 2023-11-16 at 01 48 44" src="https://github.com/international-labour-organization/designsystem/assets/32934169/47d0c58b-658f-4019-b550-31dbe9293ff8">
