### PR TITLE
Refactor RTL style using dir in searchfield

### DIFF
--- a/.changeset/silly-taxis-travel.md
+++ b/.changeset/silly-taxis-travel.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in seachfield

--- a/packages/styles/scss/components/_searchfield.scss
+++ b/packages/styles/scss/components/_searchfield.scss
@@ -68,9 +68,7 @@
     }
   }
 
-  .right-to-left & {
-    direction: rtl;
-
+  [dir="rtl"] & {
     .ilo--searchfield--button {
       border-left: $spacing-formelements-inputbutton-default-borderrtl-left
         solid $color-formelements-inputbutton-default-border-left;


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Modified css to use dir attribute selector instead of right-to-left class

Screenshot

* LTR

<img width="770" alt="Screenshot 2023-11-16 at 02 03 11" src="https://github.com/international-labour-organization/designsystem/assets/32934169/02fc851e-a924-4b14-895c-c847aad7546e">


* RTL

<img width="761" alt="Screenshot 2023-11-16 at 02 03 19" src="https://github.com/international-labour-organization/designsystem/assets/32934169/a1316e8b-1d0e-405b-800f-4811cad83a9d">
