### PR TITLE
Refactor RTL style using dir in text area

### DIFF
--- a/.changeset/gold-turkeys-change.md
+++ b/.changeset/gold-turkeys-change.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor rtl style using dir in text area

--- a/packages/styles/scss/components/_formcontrol.scss
+++ b/packages/styles/scss/components/_formcontrol.scss
@@ -170,6 +170,10 @@
 
     div[class*="tooltip"] {
       margin-left: px-to-rem(math.div($spacing-padding-1, 2));
+
+      [dir="rtl"] & {
+        margin-right: px-to-rem(math.div($spacing-padding-1, 2));
+      }
     }
   }
 

--- a/packages/styles/scss/components/_textarea.scss
+++ b/packages/styles/scss/components/_textarea.scss
@@ -59,8 +59,4 @@
     );
     @include bordervalues("input", "formelements", "error");
   }
-
-  .right-to-left & {
-    direction: rtl;
-  }
 }


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Modified css to use dir attribute selector instead of right-to-left class.
* Fixed styling issue in rtl.

Screenshot

* LTR

<img width="986" alt="Screenshot 2023-11-16 at 22 50 59" src="https://github.com/international-labour-organization/designsystem/assets/32934169/d8846391-f0ad-46fa-bbad-72d92a8ecc9a">


* RTL

<img width="984" alt="Screenshot 2023-11-16 at 22 51 09" src="https://github.com/international-labour-organization/designsystem/assets/32934169/26033f41-2ebe-4f0d-b02f-bc1b7f9fe0db">


