### PR TITLE
Refactor RTL style using dir in cards

### DIFF
--- a/.changeset/flat-ghosts-invent.md
+++ b/.changeset/flat-ghosts-invent.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in cards

--- a/packages/styles/scss/components/_card.scss
+++ b/packages/styles/scss/components/_card.scss
@@ -6,7 +6,6 @@
 .ilo--card {
   $self: &;
   $transition-timing: 150ms;
-
   box-sizing: border-box;
   position: relative;
   background-color: map-get($color, "base", "neutrals", "white");
@@ -17,10 +16,6 @@
 
   &__size__fluid {
     --max-width: 100% !important;
-  }
-
-  .right-to-left & {
-    text-align: right;
   }
 
   &__action:hover,

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -48,10 +48,6 @@
     row-gap: $gap-size;
     margin: auto;
     width: 100%;
-
-    .right-to-left & {
-      flex-direction: row-reverse;
-    }
   }
 
   .ilo--card,

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -107,10 +107,6 @@
 
       #{$self}--wrap {
         display: flex;
-
-        .right-to-left & {
-          flex-direction: row-reverse;
-        }
       }
 
       #{$self}--title {

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -24,6 +24,10 @@
           &--link {
             color: $brand-ilo-white;
             @include dataurlicon("arrowright", $brand-ilo-white);
+
+            [dir="rtl"] & {
+              @include dataurlicon("arrowleft", $brand-ilo-white);
+            }
           }
         }
 
@@ -34,6 +38,10 @@
             &--link {
               color: $brand-ilo-blue;
               @include dataurlicon("arrowright", $brand-ilo-blue);
+
+              [dir="rtl"] & {
+                @include dataurlicon("arrowleft", $brand-ilo-blue);
+              }
             }
           }
         }
@@ -101,10 +109,6 @@
           @include breakpoint("medium") {
             #{$self}--wrap {
               flex-direction: row;
-
-              .right-to-left & {
-                flex-direction: row-reverse;
-              }
             }
 
             #{$self}--content {

--- a/packages/styles/scss/components/_multilinkcard.scss
+++ b/packages/styles/scss/components/_multilinkcard.scss
@@ -147,20 +147,12 @@
             &#{$self}__align__right {
               #{$self}--wrap {
                 flex-direction: row-reverse;
-
-                .right-to-left & {
-                  flex-direction: row;
-                }
               }
             }
 
             #{$self}--wrap {
               display: flex;
               column-gap: px-to-rem(32px);
-
-              .right-to-left & {
-                flex-direction: row-reverse;
-              }
             }
 
             #{$self}--image--wrapper {

--- a/packages/styles/scss/components/_promocard.scss
+++ b/packages/styles/scss/components/_promocard.scss
@@ -61,6 +61,10 @@
 
           &#{$self}__cornercut {
             @include cornercut(87px, 48px);
+
+            [dir="rtl"] & {
+              @include cornercut(87px, 48px, left);
+            }
           }
         }
 
@@ -78,6 +82,10 @@
 
           &#{$self}__cornercut {
             @include cornercut(116px, 64px);
+
+            [dir="rtl"] & {
+              @include cornercut(116px, 64px, left);
+            }
           }
         }
 
@@ -94,6 +102,10 @@
 
           &#{$self}__cornercut {
             @include cornercut(72px, 40px);
+
+            [dir="rtl"] & {
+              @include cornercut(72px, 40px left);
+            }
           }
 
           #{$self}--title {

--- a/packages/styles/scss/components/_textcard.scss
+++ b/packages/styles/scss/components/_textcard.scss
@@ -13,7 +13,11 @@
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
       padding: px-to-rem(24px) px-to-rem(40px);
 
-      @include cornercut(73px, 40px);
+      @include cornercut(72px, 40px);
+
+      [dir="rtl"] & {
+        @include cornercut(72px, 40px, left);
+      }
 
       [class$="profile--contents--light"] * {
         color: $color-base-neutrals-dark;


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Related components used

* Cards
* Card group
* Detail card
* Feature card
* Multi link card
* Promo card
* Text card

Development

* Modified css to use dir attribute selector instead of right-to-left class.
* Removed unnecessary styling 
* Modified arrow side based on rtl in feature card.
* Modified cornercut on promo card and text card to support RTL

Screenshot (Excluded the minor change ones)

**Feature card**

* LTR

<img width="300" alt="Screenshot 2023-11-17 at 02 12 50" src="https://github.com/international-labour-organization/designsystem/assets/32934169/cde6f460-1383-4d05-8ad0-4df59131a56d">

* RTL

<img width="300" alt="Screenshot 2023-11-17 at 02 12 41" src="https://github.com/international-labour-organization/designsystem/assets/32934169/2903317d-f965-4240-90b9-1d0f04ffca7c">

**Promo card**

*LTR

<img width="350" alt="Screenshot 2023-11-17 at 02 38 36" src="https://github.com/international-labour-organization/designsystem/assets/32934169/6da11ffa-8c3e-4799-9738-3bf3a4f10374">

*RTL

<img width="350" alt="Screenshot 2023-11-17 at 02 38 27" src="https://github.com/international-labour-organization/designsystem/assets/32934169/82599a5f-0ec7-4a32-82aa-a07d35671001">

