### PR TITLE
refactor(styles): reworked bare padding values with new spacing tokens

### DIFF
--- a/.changeset/odd-melons-nail.md
+++ b/.changeset/odd-melons-nail.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+refatored bare padding values with new spacing tokens for card components

--- a/packages/styles/scss/_functions.scss
+++ b/packages/styles/scss/_functions.scss
@@ -49,17 +49,17 @@
 }
 
 // =========================================
-// Vertical Spacing
+// Spacing Helper
 //
-// ensure that everything increments by 0.5
-// @param {Number} $size - number of times to multiply $padding-base
-// @return {*} - desired size, rounded to nearest 0.5, multiplied by $padding-base, in rems
+// spacing will be calculated by multiples of 4
+// @param {Number} $size - number of times to multiply $padding-root, check tokens/spacing/base.json
+// @return {*} - desired size, rounded to nearest integer, multiplied by $padding-base, in rems
 // =========================================
 
 @function spacing($size) {
-  $scaled: $size * $padding-base;
-  @if ($size % 0.5 != 0) {
-    $scaled: round($size) * $padding-base;
+  $scaled: $size * $spacing-root;
+  @if ($size % 1 != 0) {
+    $scaled: round($size) * $spacing-root;
   }
   @return px-to-rem($scaled);
 }

--- a/packages/styles/scss/components/_datacard.scss
+++ b/packages/styles/scss/components/_datacard.scss
@@ -14,7 +14,7 @@
 
       background: $brand-ilo-light-blue;
       border-bottom: px-to-rem(3px) solid $brand-ilo-ramp-blue;
-      padding: map-get($spacing, "spacing-12") map-get($spacing, "spacing-13");
+      padding: spacing(12) spacing(10) spacing(14);
       position: relative;
       width: 100%;
 
@@ -26,7 +26,7 @@
       }
 
       @include breakpoint("medium") {
-        padding: map-get($spacing, "spacing-12");
+        padding: spacing(12);
 
         &__columns {
           &__two {
@@ -90,8 +90,7 @@
         &__narrow {
           --max-width: #{px-to-rem(301px)};
           @include cornercut(72px, 40px);
-          padding: map-get($spacing, "spacing-10")
-            map-get($spacing, "spacing-6") map-get($spacing, "spacing-13");
+          padding: spacing(10) spacing(6) spacing(14);
 
           @include breakpoint("medium", true) {
             --max-width: 100%;
@@ -102,13 +101,11 @@
           --max-width: #{px-to-rem(778px)};
 
           &#{$c}__columns__one {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-13");
+            padding: spacing(12) spacing(10) spacing(14);
           }
 
           &#{$c}__columns__two {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-13") map-get($spacing, "spacing-27");
+            padding: spacing(12) spacing(12) spacing(14) spacing(28);
           }
         }
 

--- a/packages/styles/scss/components/_datacard.scss
+++ b/packages/styles/scss/components/_datacard.scss
@@ -14,7 +14,7 @@
 
       background: $brand-ilo-light-blue;
       border-bottom: px-to-rem(3px) solid $brand-ilo-ramp-blue;
-      padding: px-to-rem(48px) px-to-rem(52px);
+      padding: map-get($spacing, "spacing-12") map-get($spacing, "spacing-13");
       position: relative;
       width: 100%;
 
@@ -26,7 +26,7 @@
       }
 
       @include breakpoint("medium") {
-        padding: px-to-rem(48px);
+        padding: map-get($spacing, "spacing-12");
 
         &__columns {
           &__two {
@@ -90,7 +90,8 @@
         &__narrow {
           --max-width: #{px-to-rem(301px)};
           @include cornercut(72px, 40px);
-          padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(53px);
+          padding: map-get($spacing, "spacing-10")
+            map-get($spacing, "spacing-6") map-get($spacing, "spacing-13");
 
           @include breakpoint("medium", true) {
             --max-width: 100%;
@@ -101,11 +102,13 @@
           --max-width: #{px-to-rem(778px)};
 
           &#{$c}__columns__one {
-            padding: px-to-rem(48px) px-to-rem(52px);
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-13");
           }
 
           &#{$c}__columns__two {
-            padding: px-to-rem(48px) max(px-to-rem(52px), px-to-rem(109px));
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-13") map-get($spacing, "spacing-27");
           }
         }
 

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -11,11 +11,11 @@
       --max-width: #{px-to-rem(343px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-light;
-      padding: px-to-rem(24px) 0;
+      padding: map-get($spacing, "spacing-6") 0;
       position: relative;
 
       @include breakpoint("large") {
-        padding: px-to-rem(32px) 0;
+        padding: map-get($spacing, "spacing-8") 0;
       }
 
       @include breakpoint("medium", true) {
@@ -127,13 +127,13 @@
       }
 
       #{$self}--content {
-        padding: 0 px-to-rem(24px);
+        padding: 0 map-get($spacing, "spacing-6");
       }
 
       #{$self}--date-extra {
         @include font-styles("body-small");
         margin-bottom: 0;
-        padding-left: px-to-rem(24px);
+        padding-left: map-get($spacing, "spacing-6");
         position: relative;
 
         &::before {

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -11,11 +11,11 @@
       --max-width: #{px-to-rem(343px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-light;
-      padding: map-get($spacing, "spacing-6") 0;
+      padding: spacing(6) 0;
       position: relative;
 
       @include breakpoint("large") {
-        padding: map-get($spacing, "spacing-8") 0;
+        padding: spacing(8) 0;
       }
 
       @include breakpoint("medium", true) {
@@ -127,13 +127,13 @@
       }
 
       #{$self}--content {
-        padding: 0 map-get($spacing, "spacing-6");
+        padding: 0 spacing(6);
       }
 
       #{$self}--date-extra {
         @include font-styles("body-small");
         margin-bottom: 0;
-        padding-left: map-get($spacing, "spacing-6");
+        padding-left: spacing(6);
         position: relative;
 
         &::before {

--- a/packages/styles/scss/components/_factlistcard.scss
+++ b/packages/styles/scss/components/_factlistcard.scss
@@ -11,7 +11,6 @@
       --max-width: #{px-to-rem(375px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
-      // padding: px-to-rem(24px) px-to-rem(48px);
       padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
 
       @include cornercut(72px, 40px);

--- a/packages/styles/scss/components/_factlistcard.scss
+++ b/packages/styles/scss/components/_factlistcard.scss
@@ -11,47 +11,30 @@
       --max-width: #{px-to-rem(375px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
-      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
+      padding: spacing(10) spacing(6) spacing(12);
 
       @include cornercut(72px, 40px);
 
       @include breakpoint("large") {
-        padding: map-get($spacing, "spacing-10") map-get($spacing, "spacing-14");
+        padding: spacing(12) spacing(10) spacing(14);
       }
 
       &#{$self}__size {
         &__wide {
           --max-width: #{px-to-rem(856px)};
 
-          padding: map-get($spacing, "spacing-10")
-            map-get($spacing, "spacing-13");
+          padding: spacing(12) spacing(10) spacing(14);
 
           @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-10")
-              map-get($spacing, "spacing-15");
             @include cornercut(87px, 48px);
           }
         }
 
-        // &__standard {
-        //   padding: px-to-rem(40px) px-to-rem(52px);
-
-        //   @include breakpoint("medium") {
-        //     padding: px-to-rem(40px) px-to-rem(60px);
-        //   }
-        // }
-
         &__narrow {
           --max-width: #{px-to-rem(375px)};
 
-          padding: map-get($spacing, "spacing-6")
-            map-get($spacing, "spacing-12");
+          padding: spacing(10) spacing(6) spacing(12);
           @include cornercut(72px, 40px);
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-6")
-              map-get($spacing, "spacing-12");
-          }
         }
       }
 

--- a/packages/styles/scss/components/_factlistcard.scss
+++ b/packages/styles/scss/components/_factlistcard.scss
@@ -11,22 +11,25 @@
       --max-width: #{px-to-rem(375px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
-      padding: px-to-rem(24px) px-to-rem(48px);
+      // padding: px-to-rem(24px) px-to-rem(48px);
+      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
 
       @include cornercut(72px, 40px);
 
       @include breakpoint("large") {
-        padding: px-to-rem(40px) px-to-rem(56px);
+        padding: map-get($spacing, "spacing-10") map-get($spacing, "spacing-14");
       }
 
       &#{$self}__size {
         &__wide {
           --max-width: #{px-to-rem(856px)};
 
-          padding: px-to-rem(40px) px-to-rem(52px);
+          padding: map-get($spacing, "spacing-10")
+            map-get($spacing, "spacing-13");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(40px) px-to-rem(60px);
+            padding: map-get($spacing, "spacing-10")
+              map-get($spacing, "spacing-15");
             @include cornercut(87px, 48px);
           }
         }
@@ -42,11 +45,13 @@
         &__narrow {
           --max-width: #{px-to-rem(375px)};
 
-          padding: px-to-rem(24px) px-to-rem(48px);
+          padding: map-get($spacing, "spacing-6")
+            map-get($spacing, "spacing-12");
           @include cornercut(72px, 40px);
 
           @include breakpoint("medium") {
-            padding: px-to-rem(24px) px-to-rem(48px);
+            padding: map-get($spacing, "spacing-6")
+              map-get($spacing, "spacing-12");
           }
         }
       }

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -72,8 +72,8 @@
         &--link,
         &--link:hover {
           border-bottom: none;
-          padding-left: map-get($spacing, "spacing-6");
-          padding-right: map-get($spacing, "spacing-6");
+          padding-left: spacing(6);
+          padding-right: spacing(6);
         }
       }
 
@@ -178,8 +178,7 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-6")
-          map-get($spacing, "spacing-10");
+        padding: spacing(6) spacing(6) spacing(10);
       }
 
       &#{$self}__linklist {

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -72,8 +72,8 @@
         &--link,
         &--link:hover {
           border-bottom: none;
-          padding-left: px-to-rem(24px);
-          padding-right: px-to-rem(24px);
+          padding-left: map-get($spacing, "spacing-6");
+          padding-right: map-get($spacing, "spacing-6");
         }
       }
 
@@ -178,7 +178,8 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        padding: px-to-rem(24px) px-to-rem(24px) px-to-rem(40px);
+        padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-6")
+          map-get($spacing, "spacing-10");
       }
 
       &#{$self}__linklist {

--- a/packages/styles/scss/components/_multilinkcard.scss
+++ b/packages/styles/scss/components/_multilinkcard.scss
@@ -11,7 +11,7 @@
       // Defaults to standard size
       --max-width: #{px-to-rem(536px)};
 
-      padding: map-get($spacing, "spacing-6");
+      padding: spacing(6);
 
       #{$self}--image--wrapper {
         display: none;
@@ -24,11 +24,11 @@
       }
 
       @include breakpoint("medium") {
-        padding: map-get($spacing, "spacing-10");
+        padding: spacing(10);
       }
 
       @include breakpoint("large") {
-        padding: map-get($spacing, "spacing-14") map-get($spacing, "spacing-12");
+        padding: spacing(14) spacing(12);
       }
 
       #{$self}--title {
@@ -71,36 +71,13 @@
         &__standard {
           --max-width: #{px-to-rem(536px)};
 
-          padding: map-get($spacing, "spacing-12")
-            map-get($spacing, "spacing-10");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-10");
-          }
-
-          @include breakpoint("large") {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-10");
-          }
+          padding: spacing(12) spacing(10);
         }
 
         &__narrow {
           --max-width: #{px-to-rem(375px)};
 
-          padding: map-get($spacing, "spacing-10")
-            map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-10")
-              map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
-          }
-
-          @include breakpoint("large") {
-            padding: map-get($spacing, "spacing-10")
-              map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
-          }
-
+          padding: spacing(10) spacing(6) spacing(12);
           #{$self}--image--wrapper {
             display: none;
           }
@@ -145,12 +122,11 @@
         &__fluid {
           --max-width: #{px-to-rem(1104px)};
 
-          padding: map-get($spacing, "spacing-10")
-            map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
+          padding: spacing(10) spacing(6) spacing(12);
 
           @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-14")
-              map-get($spacing, "spacing-12");
+            padding: spacing(14) spacing(12);
+
             &#{$self}__align__right {
               #{$self}--wrap {
                 flex-direction: row-reverse;

--- a/packages/styles/scss/components/_multilinkcard.scss
+++ b/packages/styles/scss/components/_multilinkcard.scss
@@ -11,7 +11,7 @@
       // Defaults to standard size
       --max-width: #{px-to-rem(536px)};
 
-      padding: px-to-rem(24px);
+      padding: map-get($spacing, "spacing-6");
 
       #{$self}--image--wrapper {
         display: none;
@@ -24,11 +24,11 @@
       }
 
       @include breakpoint("medium") {
-        padding: px-to-rem(40px);
+        padding: map-get($spacing, "spacing-10");
       }
 
       @include breakpoint("large") {
-        padding: px-to-rem(56px) px-to-rem(48px);
+        padding: map-get($spacing, "spacing-14") map-get($spacing, "spacing-12");
       }
 
       #{$self}--title {
@@ -71,28 +71,34 @@
         &__standard {
           --max-width: #{px-to-rem(536px)};
 
-          padding: px-to-rem(48px) px-to-rem(40px);
+          padding: map-get($spacing, "spacing-12")
+            map-get($spacing, "spacing-10");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(48px) px-to-rem(40px);
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-10");
           }
 
           @include breakpoint("large") {
-            padding: px-to-rem(48px) px-to-rem(40px);
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-10");
           }
         }
 
         &__narrow {
           --max-width: #{px-to-rem(375px)};
 
-          padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(48px);
+          padding: map-get($spacing, "spacing-10")
+            map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(48px);
+            padding: map-get($spacing, "spacing-10")
+              map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
           }
 
           @include breakpoint("large") {
-            padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(48px);
+            padding: map-get($spacing, "spacing-10")
+              map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
           }
 
           #{$self}--image--wrapper {
@@ -139,11 +145,12 @@
         &__fluid {
           --max-width: #{px-to-rem(1104px)};
 
-          padding: px-to-rem(40px) px-to-rem(24px) px-to-rem(48px);
+          padding: map-get($spacing, "spacing-10")
+            map-get($spacing, "spacing-6") map-get($spacing, "spacing-12");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(56px) px-to-rem(48px);
-
+            padding: map-get($spacing, "spacing-14")
+              map-get($spacing, "spacing-12");
             &#{$self}__align__right {
               #{$self}--wrap {
                 flex-direction: row-reverse;

--- a/packages/styles/scss/components/_promocard.scss
+++ b/packages/styles/scss/components/_promocard.scss
@@ -36,30 +36,20 @@
     &__promo {
       // --max-width: #{px-to-rem(343px)};
 
-      padding: map-get($spacing, "spacing-10") map-get($spacing, "spacing-6");
+      padding: spacing(10) spacing(6);
       width: 100%;
 
       @include breakpoint("medium") {
-        padding: map-get($spacing, "spacing-12");
+        padding: spacing(12);
       }
 
       @include breakpoint("large") {
-        padding: map-get($spacing, "spacing-16") map-get($spacing, "spacing-18");
+        padding: spacing(16) spacing(18);
       }
 
       &#{$self}__size {
         &__standard {
-          padding: map-get($spacing, "spacing-12");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-12") map-get($spacing, "spacing-16");
-          }
-
-          @include breakpoint("large") {
-            padding: map-get($spacing, "spacing-12")
-              map-get($spacing, "spacing-12") map-get($spacing, "spacing-16");
-          }
+          padding: spacing(12);
 
           &#{$self}__cornercut {
             @include cornercut(87px, 48px);
@@ -68,17 +58,7 @@
 
         &__wide,
         &__fluid {
-          padding: map-get($spacing, "spacing-16")
-            map-get($spacing, "spacing-18");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-16")
-              map-get($spacing, "spacing-18");
-          }
-
-          @include breakpoint("large") {
-            padding: px-to-rem(64px) px-to-rem(72px);
-          }
+          padding: spacing(16) spacing(18);
 
           &#{$self}__cornercut {
             @include cornercut(116px, 64px);
@@ -86,17 +66,7 @@
         }
 
         &__narrow {
-          padding: map-get($spacing, "spacing-10")
-            map-get($spacing, "spacing-6");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-10")
-              map-get($spacing, "spacing-6");
-          }
-
-          @include breakpoint("large") {
-            padding: px-to-rem(40px) px-to-rem(24px);
-          }
+          padding: spacing(10) spacing(6);
 
           &#{$self}__cornercut {
             @include cornercut(72px, 40px);

--- a/packages/styles/scss/components/_promocard.scss
+++ b/packages/styles/scss/components/_promocard.scss
@@ -36,27 +36,29 @@
     &__promo {
       // --max-width: #{px-to-rem(343px)};
 
-      padding: px-to-rem(40px) px-to-rem(24px);
+      padding: map-get($spacing, "spacing-10") map-get($spacing, "spacing-6");
       width: 100%;
 
       @include breakpoint("medium") {
-        padding: px-to-rem(48px);
+        padding: map-get($spacing, "spacing-12");
       }
 
       @include breakpoint("large") {
-        padding: px-to-rem(64px) px-to-rem(72px);
+        padding: map-get($spacing, "spacing-16") map-get($spacing, "spacing-18");
       }
 
       &#{$self}__size {
         &__standard {
-          padding: px-to-rem(48px);
+          padding: map-get($spacing, "spacing-12");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(48px) px-to-rem(48px) px-to-rem(64px);
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-12") map-get($spacing, "spacing-16");
           }
 
           @include breakpoint("large") {
-            padding: px-to-rem(48px) px-to-rem(48px) px-to-rem(64px);
+            padding: map-get($spacing, "spacing-12")
+              map-get($spacing, "spacing-12") map-get($spacing, "spacing-16");
           }
 
           &#{$self}__cornercut {
@@ -66,10 +68,12 @@
 
         &__wide,
         &__fluid {
-          padding: px-to-rem(64px) px-to-rem(72px);
+          padding: map-get($spacing, "spacing-16")
+            map-get($spacing, "spacing-18");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(64px) px-to-rem(72px);
+            padding: map-get($spacing, "spacing-16")
+              map-get($spacing, "spacing-18");
           }
 
           @include breakpoint("large") {
@@ -82,10 +86,12 @@
         }
 
         &__narrow {
-          padding: px-to-rem(40px) px-to-rem(24px);
+          padding: map-get($spacing, "spacing-10")
+            map-get($spacing, "spacing-6");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(40px) px-to-rem(24px);
+            padding: map-get($spacing, "spacing-10")
+              map-get($spacing, "spacing-6");
           }
 
           @include breakpoint("large") {

--- a/packages/styles/scss/components/_statcard.scss
+++ b/packages/styles/scss/components/_statcard.scss
@@ -15,7 +15,8 @@
       }
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-purple;
-      padding: px-to-rem(24px) px-to-rem(40px) px-to-rem(22px);
+      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-10")
+        map-get($spacing, "spacing-6");
       position: relative;
       width: 100%;
 

--- a/packages/styles/scss/components/_statcard.scss
+++ b/packages/styles/scss/components/_statcard.scss
@@ -15,8 +15,7 @@
       }
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-purple;
-      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-10")
-        map-get($spacing, "spacing-6");
+      padding: spacing(10) spacing(6) spacing(8);
       position: relative;
       width: 100%;
 

--- a/packages/styles/scss/components/_textcard.scss
+++ b/packages/styles/scss/components/_textcard.scss
@@ -11,7 +11,7 @@
       --max-width: #{px-to-rem(301px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
-      padding: px-to-rem(24px) px-to-rem(40px);
+      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-10");
 
       @include cornercut(73px, 40px);
 
@@ -35,7 +35,7 @@
 
       @include breakpoint("medium", true) {
         --max-width: 100%;
-        padding: px-to-rem(32px) px-to-rem(40px);
+        padding: map-get($spacing, "spacing-8") map-get($spacing, "spacing-10");
       }
 
       &#{$self}__size {
@@ -43,21 +43,25 @@
         &__fluid {
           --max-width: #{px-to-rem(523px)};
 
-          padding: px-to-rem(32px) px-to-rem(40px);
+          padding: map-get($spacing, "spacing-8")
+            map-get($spacing, "spacing-10");
 
           @include breakpoint("medium") {
-            padding: px-to-rem(32px) px-to-rem(40px);
+            padding: map-get($spacing, "spacing-8")
+              map-get($spacing, "spacing-10");
           }
         }
 
         &__narrow {
           --max-width: #{px-to-rem(301px)};
 
-          padding: px-to-rem(24px) px-to-rem(40px);
+          padding: map-get($spacing, "spacing-6")
+            map-get($spacing, "spacing-10");
 
           @include breakpoint("medium", true) {
             --max-width: 100%;
-            padding: px-to-rem(24px) px-to-rem(40px);
+            padding: map-get($spacing, "spacing-6")
+              map-get($spacing, "spacing-10");
           }
 
           #{$self}--title {

--- a/packages/styles/scss/components/_textcard.scss
+++ b/packages/styles/scss/components/_textcard.scss
@@ -11,7 +11,7 @@
       --max-width: #{px-to-rem(301px)};
 
       border-bottom: px-to-rem(3px) solid $brand-ilo-grey-ui;
-      padding: map-get($spacing, "spacing-6") map-get($spacing, "spacing-10");
+      padding: spacing(10) spacing(6) spacing(8);
 
       @include cornercut(73px, 40px);
 
@@ -35,7 +35,6 @@
 
       @include breakpoint("medium", true) {
         --max-width: 100%;
-        padding: map-get($spacing, "spacing-8") map-get($spacing, "spacing-10");
       }
 
       &#{$self}__size {
@@ -43,25 +42,16 @@
         &__fluid {
           --max-width: #{px-to-rem(523px)};
 
-          padding: map-get($spacing, "spacing-8")
-            map-get($spacing, "spacing-10");
-
-          @include breakpoint("medium") {
-            padding: map-get($spacing, "spacing-8")
-              map-get($spacing, "spacing-10");
-          }
+          padding: spacing(10) spacing(8) spacing(8);
         }
 
         &__narrow {
           --max-width: #{px-to-rem(301px)};
 
-          padding: map-get($spacing, "spacing-6")
-            map-get($spacing, "spacing-10");
+          padding: spacing(10) spacing(6) spacing(8);
 
           @include breakpoint("medium", true) {
             --max-width: 100%;
-            padding: map-get($spacing, "spacing-6")
-              map-get($spacing, "spacing-10");
           }
 
           #{$self}--title {


### PR DESCRIPTION
## Overview

This PR is a follow-up of #654 and aims to refactor padding values with new spacing tokens for all card components. As mentioned in #637 I don't have access to the foundation file but pretty much all refactoring points I have marked were multiples of 4 so I decided to go with it. 

Here is a refactoring table 

| Card Type      | Component name   | Reworked | Multiple of 4 problem | Design off |
| -------------- | ---------------- | -------- | --------------------- | --------- |
| Text Card      | `_textcard`      | ✅       | ❌                    | ✅        |
| Details Card   | `_detailscard`   | ✅       | ❌                    | ✅        |
| Promo Card     | `_promocard`     | ✅       | ❌                    | ✅        |
| Multilink Card | `_multilinkcard` | ✅       | ❌                    | ✅        |
| Data Card      | `_datacard`      | ✅       | ✅                    | ✅        |
| Stat Card      | `_statcard`      | ✅       | ✅                    | ✅        |
| Fact List Card | `_factlistcard`  | ✅       | ❌                    | ✅        |
| Feature Card   | `_featurecard`   | ✅       | ❌                    | ✅        |
| Card Group     | `_groupcard`     | ❌       | ❌                    | ❌        |

## Rework
Cards marked as reworked have their padding refactored, `_cardgroup` has no padding definition. 

## Multiple of 4 problem
As I mentioned above **almost** all refactoring points were multiples of 4 but there were a few exceptions, that I have refactored 

- `_datacard`: line 93 - **53px  - 52px** (1 pixel off )
- `_datacard`: line 110 - **109px - 108px** (1 pixel off)
- `_statcard`: line 18 - **22px - 24px** (2 pixel off )

## 🔔 Design problems
In the current PR, I have just refactored existing values with a new `spacing token` but I was comparing implementation to Figma and they were a bit off, so I decided to document them for follow-up issues 

Example: 
`Stat card`
> Figma Padding

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/35ccac7d-8fcc-4f97-aaee-5f7804433601)

> Twig Implementation

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/2dda6c1a-37a2-4a36-8704-ed5f9a7c74d7)

Also fixes #569
