### PR TITLE
Refactor RTL style using dir in tabs

### DIFF
--- a/.changeset/tough-jobs-repeat.md
+++ b/.changeset/tough-jobs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in tabs

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -179,8 +179,4 @@
       }
     }
   }
-
-  .right-to-left & {
-    direction: rtl;
-  }
 }


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Modified css to use dir attribute selector instead of right-to-left class.

Screenshot

* LTR

<img width="967" alt="Screenshot 2023-11-17 at 17 17 13" src="https://github.com/international-labour-organization/designsystem/assets/32934169/8ef73db4-a288-44f7-bcf7-56981adc26ab">


* RTL

<img width="1000" alt="Screenshot 2023-11-17 at 17 17 05" src="https://github.com/international-labour-organization/designsystem/assets/32934169/b788ba1b-b58e-4e2c-beb6-2fd112b3410a">


