### PR TITLE
Fix(Style): Support rtl in dropdown

### DIFF
--- a/.changeset/happy-cheetahs-marry.md
+++ b/.changeset/happy-cheetahs-marry.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style using dir in dropdown

--- a/packages/styles/scss/components/_dropdown.scss
+++ b/packages/styles/scss/components/_dropdown.scss
@@ -130,4 +130,18 @@
     );
     @include bordervalues("input", "formelements", "error");
   }
+  [dir="rtl"] & {
+    padding: 0 px-to-rem(16px) 0 px-to-rem(56px);
+    background-position: calc(0% + 14px) center, 0% center;
+    background-image: url("#{colortodataurlicon('arrow', $color-ux-labels-actionable)}"),
+      linear-gradient(
+        to left,
+        transparent 0%,
+        transparent calc(50% - 0.81px),
+        $color-formelements-input-default-border-right calc(50% - 0.8px),
+        $color-formelements-input-default-border-right calc(50% + 0.8px),
+        rgba(237, 240, 242, 1) calc(50% + 0.81px),
+        rgba(237, 240, 242, 1) 100%
+      );
+  }
 }


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Modified css to use dir attribute selector and change the side of the dropdown based on direction

* LTR

<img width="194" alt="Screenshot 2023-11-18 at 03 16 36" src="https://github.com/international-labour-organization/designsystem/assets/32934169/250fb8e8-a878-4f67-b9cb-0d686aaa4f8f">


* RTL

<img width="188" alt="Screenshot 2023-11-18 at 03 17 06" src="https://github.com/international-labour-organization/designsystem/assets/32934169/84a38d2b-c85e-4013-8a61-93e7c0088582">
