### PR TITLE
Fix(Style): Clean up unwanted RTL style in tag

### DIFF
--- a/.changeset/popular-carpets-protect.md
+++ b/.changeset/popular-carpets-protect.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor RTL style in tag

--- a/packages/styles/scss/components/_tag.scss
+++ b/packages/styles/scss/components/_tag.scss
@@ -6,10 +6,6 @@
 .ilo--tag-set {
   list-style: none;
 
-  .right-to-left & {
-    direction: rtl;
-  }
-
   &__item {
     display: inline-block;
     margin: map-get($spacing, "horizontal-rule");


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Removed unnecessary right to left style that sets dir


LTR

<img width="1071" alt="Screenshot 2023-11-19 at 03 23 24" src="https://github.com/international-labour-organization/designsystem/assets/32934169/058e1c98-5950-495a-8d3f-d7e753cc76cf">


RTL
<img width="1058" alt="Screenshot 2023-11-19 at 03 23 33" src="https://github.com/international-labour-organization/designsystem/assets/32934169/b0f88e3d-6679-4861-8c53-2b3bc3802897">

