### PR TITLE
Fix(Style): Refactor rtl to use dir in richtext

### DIFF
--- a/.changeset/nine-kangaroos-matter.md
+++ b/.changeset/nine-kangaroos-matter.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor rtl to use dir in richtext

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -396,9 +396,7 @@
     }
   }
 
-  .right-to-left & {
-    direction: rtl;
-
+  [dir="rtl"] & {
     figcaption {
       border-left: none;
       border-right: 3px solid #b8c4cc;


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Used dir selector instead of right to left class 


LTR

<img width="387" alt="Screenshot 2023-11-19 at 12 45 36" src="https://github.com/international-labour-organization/designsystem/assets/32934169/45b4a81e-c241-4ca3-94b2-428c1409a81f">


RTL

<img width="390" alt="Screenshot 2023-11-19 at 12 45 25" src="https://github.com/international-labour-organization/designsystem/assets/32934169/20310031-67ac-4dba-88c2-870350d167cb">


