### PR TITLE
Refactor rtl to use dir in social media

### DIFF
--- a/.changeset/slimy-seas-drive.md
+++ b/.changeset/slimy-seas-drive.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor rtl to use dir in social media

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -26,28 +26,12 @@
   flex-flow: column nowrap;
   align-items: flex-start;
 
-  &__justify__center {
-    align-items: center;
+  [dir="rtl"] {
+    align-items: flex-end;
   }
 
-  .right-to-left & {
-    direction: rtl;
-
-    .social--links {
-      flex-direction: row-reverse;
-    }
-
-    #{$c}--list {
-      &--item {
-        &--icon {
-          text-indent: 999px;
-        }
-      }
-    }
-
-    * {
-      text-align: right;
-    }
+  &__justify__center {
+    align-items: center;
   }
 
   &--headline {


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Used dir selector instead of right to left class 
* Remove unwanted css 


LTR

<img width="847" alt="Screenshot 2023-11-19 at 13 41 16" src="https://github.com/international-labour-organization/designsystem/assets/32934169/86c6558a-8de6-4ed3-a835-4db092bd783c">



RTL

<img width="852" alt="Screenshot 2023-11-19 at 13 40 56" src="https://github.com/international-labour-organization/designsystem/assets/32934169/60c40b91-a3c2-45b1-ac75-6c40b3291984">


