### PR TITLE
Fix(Style): Refactor rtl to use dir in video

### DIFF
--- a/.changeset/smart-flies-thank.md
+++ b/.changeset/smart-flies-thank.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor rtl to use dir in video

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -119,6 +119,10 @@
       }
     }
 
+    [dir="rtl"] & {
+      justify-content: flex-end;
+    }
+
     button span {
       @include isVisuallyHidden();
     }
@@ -702,6 +706,11 @@
         justify-content: flex-start;
         left: 0;
         width: 80px;
+
+        [dir="rtl"] & {
+          left: auto;
+          right: 0;
+        }
       }
     }
 
@@ -771,11 +780,10 @@
   position: relative;
 }
 
-.right-to-left {
+[dir="rtl"] {
   .ilo--video--caption {
     border-left: none;
     border-right: 3px solid #b8c4cc;
-    direction: rtl;
     padding-left: 0;
     padding-right: px-to-rem(map-get($spacing, "padding-1"));
   }


### PR DESCRIPTION
Issue :- [#524](https://github.com/international-labour-organization/designsystem/issues/524)

Development

* Convert right to left class to use dir selector attribute
* Fix styles to align play button and duration to the right when rtl is set. (Small/Large screen)


LTR (Small screen)

<img width="500" alt="Screenshot 2023-11-20 at 00 42 35" src="https://github.com/international-labour-organization/designsystem/assets/32934169/9a751aad-874c-4d94-b76d-287089032351">


RTL (Small screen)

<img width="500" alt="Screenshot 2023-11-20 at 00 42 43" src="https://github.com/international-labour-organization/designsystem/assets/32934169/6aa14569-a6ae-441d-a158-922eb83a8e91">


LTR (Large screen)

<img width="500" alt="Screenshot 2023-11-20 at 00 35 34" src="https://github.com/international-labour-organization/designsystem/assets/32934169/8dd7ce30-ea1c-45fe-803f-23810e4efb91">

RTL (Large screen)

<img width="500" alt="Screenshot 2023-11-20 at 00 35 45" src="https://github.com/international-labour-organization/designsystem/assets/32934169/80a9fe4b-e491-4780-a012-23c5d6f4899f">


