### PR TITLE
New spacing for transitions & user interface category 

### DIFF
--- a/.changeset/nice-icons-scream.md
+++ b/.changeset/nice-icons-scream.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+reworked spacing for user interface and transition components

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -20,8 +20,8 @@
 
     .ilo--icon {
       height: 100%;
-      max-height: calc($spacing-icons-icon-height-lg * 2);
-      max-width: calc($spacing-icons-icon-height-lg * 2);
+      max-height: px-to-rem(32px);
+      max-width: px-to-rem(32px);
       position: absolute;
       width: 100%;
     }
@@ -29,24 +29,24 @@
     &.icon__position--left {
       .link__label,
       .button__label {
-        padding-left: $spacing-boxpadding-button-icon-large-left;
+        padding-left: spacing(12);
       }
 
       .ilo--icon {
-        left: calc($spacing-icons-icon-padding-lg - 9px);
-        top: calc($spacing-boxpadding-button-icon-large-top - 3px);
+        left: px-to-rem(13px);
+        top: px-to-rem(7px);
       }
     }
 
     &.icon__position--right {
       .link__label,
       .button__label {
-        padding-right: $spacing-boxpadding-button-icon-large-right;
+        padding-right: spacing(12);
       }
 
       .ilo--icon {
-        right: calc($spacing-icons-icon-padding-lg - 9px);
-        top: calc($spacing-boxpadding-button-icon-large-top - 3px);
+        right: px-to-rem(13px);
+        top: px-to-rem(7px);
       }
     }
 
@@ -60,7 +60,7 @@
   &--large {
     .link__label,
     .button__label {
-      @include boxpadding("button", "large");
+      padding: spacing(3) spacing(6);
       @include font-styles("button-large");
     }
 
@@ -78,38 +78,38 @@
   &--medium {
     .link__label,
     .button__label {
-      @include boxpadding("button", "medium");
+      padding: spacing(2) spacing(5);
       @include font-styles("button-medium");
     }
 
     &.icon {
       .ilo--icon {
-        max-height: calc($spacing-icons-icon-height-m * 2);
-        max-width: calc($spacing-icons-icon-height-m * 2);
+        max-height: px-to-rem(30px);
+        max-width: px-to-rem(30px);
         position: absolute;
       }
 
       &.icon__position--left {
         .link__label,
         .button__label {
-          padding-left: $spacing-boxpadding-button-icon-medium-left;
+          padding-left: spacing(11);
         }
 
         .ilo--icon {
-          left: calc($spacing-icons-icon-padding-m - 9px);
-          top: calc($spacing-boxpadding-button-icon-medium-top - 6px);
+          left: px-to-rem(10px);
+          top: px-to-rem(3px);
         }
       }
 
       &.icon__position--right {
         .link__label,
         .button__label {
-          padding-right: $spacing-boxpadding-button-icon-medium-right;
+          padding-right: spacing(11);
         }
 
         .ilo--icon {
-          right: calc($spacing-icons-icon-padding-m - 9px);
-          top: calc($spacing-boxpadding-button-icon-medium-top - 6px);
+          right: px-to-rem(10px);
+          top: px-to-rem(3px);
         }
       }
     }
@@ -128,38 +128,38 @@
   &--small {
     .link__label,
     .button__label {
-      @include boxpadding("button", "small");
+      padding: spacing(1) spacing(4);
       @include font-styles("button-small");
     }
 
     &.icon {
       .ilo--icon {
-        max-height: calc($spacing-icons-icon-height-sm * 2);
-        max-width: calc($spacing-icons-icon-height-sm * 2);
+        max-height: px-to-rem(28px);
+        max-width: px-to-rem(28px);
         position: absolute;
       }
 
       &.icon__position--left {
         .link__label,
         .button__label {
-          padding-left: $spacing-boxpadding-button-icon-small-left;
+          padding-left: spacing(9);
         }
 
         .ilo--icon {
-          left: calc($spacing-icons-icon-padding-sm - 9px);
-          top: calc($spacing-boxpadding-button-icon-small-top - 4px);
+          left: px-to-rem(6px);
+          top: px-to-rem(1px);
         }
       }
 
       &.icon__position--right {
         .link__label,
         .button__label {
-          padding-right: $spacing-boxpadding-button-icon-small-right;
+          padding-right: spacing(9);
         }
 
         .ilo--icon {
-          right: calc($spacing-icons-icon-padding-sm - 9px);
-          top: calc($spacing-boxpadding-button-icon-small-top - 4px);
+          right: px-to-rem(6px);
+          top: px-to-rem(1px);
         }
       }
     }

--- a/packages/styles/scss/components/_loading.scss
+++ b/packages/styles/scss/components/_loading.scss
@@ -36,8 +36,8 @@
         background-size: contain;
         content: "";
         display: block;
-        height: px-to-rem($spacing-padding-12);
-        width: px-to-rem($spacing-padding-12);
+        height: spacing(24);
+        width: spacing(24);
       }
     }
   }
@@ -65,9 +65,9 @@
         background-size: contain;
         content: "";
         display: block;
-        height: px-to-rem($spacing-padding-3);
-        margin-right: px-to-rem($spacing-padding-1-5);
-        width: px-to-rem($spacing-padding-3);
+        height: spacing(6);
+        margin-right: spacing(3);
+        width: spacing(6);
       }
     }
 
@@ -79,9 +79,9 @@
         background-size: contain;
         content: "";
         display: block;
-        height: px-to-rem($spacing-padding-3);
-        margin-right: px-to-rem($spacing-padding-1-5);
-        width: px-to-rem($spacing-padding-3);
+        height: spacing(6);
+        margin-right: spacing(3);
+        width: spacing(6);
       }
     }
   }

--- a/packages/styles/scss/components/_loading.scss
+++ b/packages/styles/scss/components/_loading.scss
@@ -36,8 +36,8 @@
         background-size: contain;
         content: "";
         display: block;
-        height: spacing(24);
-        width: spacing(24);
+        height: px-to-rem(96px);
+        width: px-to-rem(96px);
       }
     }
   }
@@ -65,9 +65,9 @@
         background-size: contain;
         content: "";
         display: block;
-        height: spacing(6);
+        height: px-to-rem(24px);
         margin-right: spacing(3);
-        width: spacing(6);
+        width: px-to-rem(24px);
       }
     }
 
@@ -79,9 +79,9 @@
         background-size: contain;
         content: "";
         display: block;
-        height: spacing(6);
+        height: px-to-rem(24px);
         margin-right: spacing(3);
-        width: spacing(6);
+        width: px-to-rem(24px);
       }
     }
   }

--- a/packages/styles/scss/components/_readmore.scss
+++ b/packages/styles/scss/components/_readmore.scss
@@ -6,15 +6,16 @@
 .ilo--read-more {
   &--button {
     background: map-get($color, "ux", "readmore", "default", "background");
-    @include bordervalues("readmore", "ux");
+    border: none;
+    border-top: solid $borders-base $color-base-blue-light;
     color: $color-ux-labels-actionable;
     font-family: $fonts-display;
-    height: px-to-rem(map-get($spacing, "ux", "readmore", "default", "height"));
-    @include spacingvalues("margin", "readmore", "ux");
-    @include spacingvalues("padding", "readmore", "ux");
+    height: px-to-rem(56px);
+    margin-top: spacing(8);
+    padding: spacing(4) spacing(7) spacing(4) spacing(0);
     position: relative;
     text-align: left;
-    width: $spacing-ux-readmore-default-width;
+    width: auto;
     @include font-styles("label-medium");
 
     &:after {
@@ -33,7 +34,7 @@
 
     &:hover {
       background: map-get($color, "ux", "readmore", "hover", "background");
-      @include bordervalues("readmore", "ux", "hover");
+      border-top: solid $borders-base $color-base-blue-medium;
       color: $color-ux-labels-hover;
       cursor: pointer;
       @include globaltransition("color, background-color, border-color");

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -10,7 +10,7 @@
 
   &:not(.tabs--js) {
     .ilo--tabs--selection {
-      margin-bottom: px-to-rem(24px);
+      margin-bottom: spacing(6);
 
       &--button {
         background: map-get($color, "link", "background", "default");
@@ -73,8 +73,8 @@
         display: flex;
         height: px-to-rem(60px);
         justify-content: flex-start;
-        padding-left: $spacing-padding-1;
-        padding-right: $spacing-padding-3;
+        padding-left: spacing(2);
+        padding-right: spacing(6);
         text-decoration: none;
         @include font-styles("label-medium");
         @include globaltransition("color, background-color, border-color");
@@ -87,10 +87,10 @@
 
         &.icon {
           .ilo--icon {
-            height: px-to-rem($spacing-padding-2);
+            height: px-to-rem(16px);
             margin-right: px-to-rem(5px);
             order: 1;
-            width: px-to-rem($spacing-padding-2);
+            width: px-to-rem(16px);
           }
 
           .ilo--tabs--selection--label {
@@ -136,8 +136,7 @@
 
     .ilo--tabs--content {
       background-color: $color-base-neutrals-white;
-      padding: px-to-rem($spacing-padding-5) px-to-rem($spacing-padding-3)
-        px-to-rem($spacing-padding-7) px-to-rem($spacing-padding-3);
+      padding: spacing(10) spacing(6) spacing(14) spacing(6);
 
       [aria-expanded="false"] {
         display: none;
@@ -150,8 +149,7 @@
 
     @include breakpoint("medium") {
       .ilo--tabs--content {
-        padding: px-to-rem($spacing-padding-5) px-to-rem($spacing-padding-8)
-          px-to-rem($spacing-padding-8) px-to-rem($spacing-padding-8);
+        padding: spacing(10) spacing(16) spacing(16) spacing(16);
       }
 
       .ilo--tabs--selection {

--- a/packages/styles/scss/components/_tag.scss
+++ b/packages/styles/scss/components/_tag.scss
@@ -12,7 +12,7 @@
 
   &__item {
     display: inline-block;
-    margin: map-get($spacing, "horizontal-rule");
+    margin: spacing(1);
   }
 }
 
@@ -25,8 +25,7 @@
   display: inline-block;
   font-family: map-get($fonts, "display");
   font-weight: 500;
-  padding: px-to-rem(7px) px-to-rem(map-get($spacing, "ui-padding-sm"))
-    px-to-rem(5px) px-to-rem(map-get($spacing, "ui-padding-sm"));
+  padding: spacing(2) spacing(3);
   text-decoration: none;
   $self: &;
   @include globaltransition("color, background-color, border-color");
@@ -77,7 +76,7 @@
     cursor: pointer;
     display: none;
     opacity: 0;
-    padding-right: 36px;
+    padding-right: spacing(9);
     position: relative;
     visibility: hidden;
 


### PR DESCRIPTION
## New spacing for transitions & user interface category 
#### 🔔 Merge after #674, and change destination to `develop`  ,because of `spacing` helper 🔔

User Interface Category and Transition categories got new spacing token implementations.

Component List 
-  Loading
-  Button
-  Read more
-  Tabs
- Tags

### Implementations
Spacing values for all mentioned components were checked with the design system and refactored using the new `spacing` helper. Those components have no dependency on other spacing files (`boxpadding.json`, `icon.json`);

 By definition of **Spacing** we should only consider `margin` and `padding` properties. So current implementation uses a `spacing` helper only with those properties. But spacing values were used for properties like `width` `height`, `top`, `bottom` etc. For places like this I used literal `pixel-to-rem` to remove the dependency, example

```diff
.ilo--icon {
-  right: calc($spacing-icons-icon-padding-lg - 9px);
-  top: calc($spacing-boxpadding-button-icon-large-top - 3px);
+  right: px-to-rem(13px);
+  top: px-to-rem(7px);
}
```

For future implementation, as a component library, we should come up with a `sizing` guide and use those values for places like this. 

 Also, current implementation has `mixins` like `border values`  that reads `border` values from the `spacing` file which is counterintuitive and ruins the theme separation concept.

```scss
@mixin bordervalues($mappath, $location, $state: "default") {
  border-bottom: px-to-rem(
      map-get($spacing, $location, $mappath, $state, "border", "bottom")
    )
    solid map-get($color, $location, $mappath, $state, "border", "bottom");
  border-left: px-to-rem(
      map-get($spacing, $location, $mappath, $state, "border", "left")
    )
    solid map-get($color, $location, $mappath, $state, "border", "left");
  border-right: px-to-rem(
      map-get($spacing, $location, $mappath, $state, "border", "right")
    )
    solid map-get($color, $location, $mappath, $state, "border", "right");
  border-top: px-to-rem(
      map-get($spacing, $location, $mappath, $state, "border", "top")
    )
    solid map-get($color, $location, $mappath, $state, "border", "top");
}
```
The mentioned components have no dependency on `bordervalus` anymore, border color is picked by `scss` variable and is `100%` backward compatible  

```diff
.ilo--read-more {
  &--button {
    background: map-get($color, "ux", "readmore", "default", "background");
-    @include bordervalues("readmore", "ux");
+    border: none;
+    border-top: solid $borders-base $color-base-blue-light;
}
```
