### PR TITLE
fix(twig): Remove link from multicard when its not available

### DIFF
--- a/.changeset/tame-nails-float.md
+++ b/.changeset/tame-nails-float.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Remove link from multicard when its not available

--- a/packages/twig/src/patterns/components/card_multilink/card_multilink.twig
+++ b/packages/twig/src/patterns/components/card_multilink/card_multilink.twig
@@ -2,10 +2,12 @@
   MULTILINK CARD COMPONENT
 #}
 
-<div class="{{prefix}}--card {{prefix}}--card__type__multilink {{prefix}}--card__action {{prefix}}--card__size__{{size}} {% if isvideo %} {{prefix}}--card__isvideo {% endif %} {% if linklist %} {{prefix}}--card__linklist {% endif %} {% if size == "wide" %} {{prefix}}--card__align__{{alignment}} {% endif %}">
-  <a class="{{prefix}}--card--link" href="{{link}}" title="{{title}}">
-    <span class="{{prefix}}--card--link--text">{{title}}</span>
-  </a>
+<div class="{{prefix}}--card {{prefix}}--card__type__multilink {% if link|length > 0 %} {{prefix}}--card__action {% endif %} {{prefix}}--card__size__{{size}} {% if isvideo %} {{prefix}}--card__isvideo {% endif %} {% if linklist %} {{prefix}}--card__linklist {% endif %} {% if size == "wide" %} {{prefix}}--card__align__{{alignment}} {% endif %}">
+  {% if link|length > 0 %}
+    <a class="{{prefix}}--card--link" href="{{link}}" title="{{title}}">
+      <span class="{{prefix}}--card--link--text">{{title}}</span>
+    </a>
+  {% endif %}
   <div class="{{prefix}}--card--wrap">
     <div class="{{prefix}}--card--image--wrapper">
       {% include "@components/picture/picture.twig" with {


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/678

Development

* Check and conditionally render the link if a link arg is passed only.
* Removed the action(hover) states when a link is not available as it could confuse the user.

Notes 

* When a link is not available it comes as an empty string so the length should be checked to ensure if a link is available or not.

