### PR TITLE
New spacing for feedback components

### DIFF
--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+reworked spacing for feedback components

--- a/packages/styles/scss/components/_callout.scss
+++ b/packages/styles/scss/components/_callout.scss
@@ -8,7 +8,7 @@
   $self: &;
 
   &--collapse:not(.ilo--callout--open) {
-    max-height: 78px;
+    max-height: 64px;
     overflow: hidden;
   }
 
@@ -22,18 +22,19 @@
   }
 
   &--sidebar {
-    padding: px-to-rem($spacing-padding-3 + 2) px-to-rem(12px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: spacing(5) spacing(2);
     width: px-to-rem(40px);
 
     #{$self}--icon {
-      position: relative;
-      top: px-to-rem(1.5px);
+      margin: spacing(1);
     }
   }
 
   &--content {
-    padding: px-to-rem($spacing-padding-3 + 2) px-to-rem($spacing-padding-3 - 2)
-      px-to-rem($spacing-padding-3);
+    padding: spacing(6);
     width: 100%;
     font-size: px-to-rem(14.93px);
   }
@@ -41,7 +42,7 @@
   &--header {
     display: flex;
     justify-content: space-between;
-    padding: 0 0 px-to-rem(24px);
+    padding-bottom: spacing(3);
   }
 
   &--title {
@@ -60,7 +61,7 @@
     cursor: pointer;
     font-family: $fonts-display;
     font-weight: 500;
-    padding-right: 32px;
+    padding-right: spacing(8);
     position: relative;
 
     &--icon {
@@ -80,7 +81,7 @@
   }
 
   &--footer {
-    padding: px-to-rem(24px) 0 0 0;
+    padding-top: spacing(5);
   }
 
   .icon {

--- a/packages/styles/scss/components/_notification.scss
+++ b/packages/styles/scss/components/_notification.scss
@@ -21,8 +21,7 @@
     }
 
     .ilo--notification--content {
-      padding: calc(px-to-rem($spacing-padding-3) + 2px)
-        px-to-rem($spacing-padding-3);
+      padding: spacing(6);
     }
   }
 
@@ -30,38 +29,37 @@
     max-width: 340px;
 
     .ilo--notification--content {
-      padding: calc(px-to-rem($spacing-padding-3) + 2px)
-        px-to-rem($spacing-padding-3);
+      padding: spacing(6);
     }
 
     @include breakpoint("medium") {
       max-width: 100%;
-      width: 100%;
 
       .ilo--notification--content {
-        align-items: start;
+        max-width: 100%;
         display: flex;
-        justify-items: space-between;
-        padding: px-to-rem(14px) px-to-rem($spacing-padding-3);
+        justify-content: space-evenly;
+        align-items: center;
+        padding: spacing(4) spacing(16) spacing(4) spacing(6);
       }
     }
   }
 
   &--content {
-    margin-left: px-to-rem($spacing-padding-5);
+    margin-left: spacing(10);
     position: relative;
     width: calc(100% - 40px);
 
     &:before {
-      background-position: center $spacing-padding-3;
+      background-position: center px-to-rem(24px);
       background-repeat: no-repeat;
-      background-size: px-to-rem($spacing-padding-2);
+      background-size: px-to-rem(16px);
       content: "";
       display: block;
       height: 100%;
       left: -40px;
       position: absolute;
-      width: px-to-rem($spacing-padding-5);
+      width: px-to-rem(40px);
       top: 0;
 
       @include breakpoint("medium") {
@@ -96,7 +94,7 @@
     font-weight: 700;
     @include font-styles("body-small");
 
-    margin-bottom: px-to-rem($spacing-padding-1-5);
+    margin-bottom: spacing(3);
 
     @include breakpoint("medium") {
       .ilo--notification--inline & {
@@ -111,21 +109,14 @@
 
     @include breakpoint("medium") {
       .ilo--notification--inline & {
-        margin-left: px-to-rem($spacing-padding-3);
+        margin-left: spacing(6);
       }
     }
 
     &:not(:last-child) {
-      margin-bottom: px-to-rem($spacing-padding-3);
-
       @include breakpoint("medium") {
         .ilo--notification--inline & {
-          margin-bottom: 0;
-          max-width: 24%;
-
-          @include breakpoint("large") {
-            max-width: 40%;
-          }
+          flex-grow: 1;
         }
       }
     }
@@ -139,12 +130,12 @@
 
     @include breakpoint("medium") {
       .ilo--notification--inline & {
-        margin-left: px-to-rem($spacing-padding-2);
+        margin-left: spacing(4);
       }
     }
 
     &:not(:last-child) {
-      margin-bottom: px-to-rem(19px);
+      margin-bottom: spacing(5);
     }
 
     @include breakpoint("medium") {
@@ -157,7 +148,7 @@
   &--cta {
     @include breakpoint("medium") {
       .ilo--notification--inline & {
-        margin-left: px-to-rem($spacing-padding-3);
+        margin-left: spacing(6);
       }
     }
   }
@@ -166,13 +157,13 @@
     background-color: $color-ux-background-highlight;
     background-position: center;
     background-repeat: no-repeat;
-    background-size: px-to-rem($spacing-padding-3);
+    background-size: px-to-rem(24px);
     border: none;
-    height: px-to-rem($spacing-padding-5);
+    height: px-to-rem(40px);
     position: absolute;
     right: 0;
     top: 0;
-    width: px-to-rem($spacing-padding-5);
+    width: px-to-rem(40px);
     @include dataurlicon("close", $color-ux-labels-actionable);
 
     &:hover,

--- a/packages/styles/scss/components/_tooltip.scss
+++ b/packages/styles/scss/components/_tooltip.scss
@@ -5,6 +5,7 @@
 
 .ilo--tooltip {
   $c: &;
+  $arrow-width: calc(spacing(2) - px-to-rem(1));
 
   @include font-styles("body-xs");
   background: map-get($color, "tooltip", "default", "background");
@@ -17,7 +18,7 @@
     drop-shadow(0px -4px 16px rgba(30, 45, 190, 0.054));
   color: map-get($color, "tooltip", "default", "text");
   opacity: 0;
-  padding: px-to-rem($spacing-padding-1) px-to-rem($spacing-padding-1-5);
+  padding: spacing(2) spacing(4) spacing(3);
   position: absolute;
   visibility: hidden;
   width: auto;
@@ -42,8 +43,8 @@
     &__icon {
       background-repeat: no-repeat;
       background-size: cover;
-      height: px-to-rem($spacing-padding-2);
-      min-width: px-to-rem($spacing-padding-2);
+      height: spacing(4);
+      min-width: spacing(4);
       @include dataurlicon("info", $color-ux-labels-actionable);
 
       &#{&}__theme__dark {
@@ -58,23 +59,21 @@
     border-style: solid;
     border-width: 0;
     height: 0;
-    margin-top: -#{map-get($spacing, "tooltip", "tooltip-arrow-width")};
+    margin-top: -#{$arrow-width};
     position: absolute;
     width: 0;
   }
 
   &--alignment-top {
     left: 0;
-    top: calc(-100% + map-get($spacing, "tooltip", "tooltip-arrow-height"));
+    top: calc(-100% + 12px);
 
     .ilo--tooltip--arrow {
       border-top-color: map-get($color, "tooltip", "default", "background");
-      border-width: map-get($spacing, "tooltip", "tooltip-arrow-height")
-        map-get($spacing, "tooltip", "tooltip-arrow-width") 0
-        map-get($spacing, "tooltip", "tooltip-arrow-width");
-      bottom: -#{map-get($spacing, "tooltip", "tooltip-arrow-height")};
+      border-width: spacing(3) $arrow-width 0 $arrow-width;
+      bottom: -#{spacing(3)};
       left: 50%;
-      margin-left: -#{map-get($spacing, "tooltip", "tooltip-arrow-width")};
+      margin-left: -#{$arrow-width};
       top: auto;
 
       &--placement-negative {
@@ -93,16 +92,14 @@
   }
 
   &--alignment-right {
-    left: calc(100% + map-get($spacing, "padding-4"));
-    top: calc(50% - map-get($spacing, "tooltip", "tooltip-arrow-width"));
+    left: calc(100% + 32px);
+    top: calc(50% - $arrow-width);
 
     .ilo--tooltip--arrow {
       border-right-color: map-get($color, "tooltip", "default", "background");
-      border-width: map-get($spacing, "tooltip", "tooltip-arrow-width")
-        map-get($spacing, "tooltip", "tooltip-arrow-height")
-        map-get($spacing, "tooltip", "tooltip-arrow-width") 0;
+      border-width: $arrow-width spacing(3) $arrow-width 0;
       left: 0;
-      margin-left: -#{map-get($spacing, "tooltip", "tooltip-arrow-height")};
+      margin-left: -#{spacing(3)};
       top: 50%;
 
       &--placement-negative {
@@ -122,17 +119,15 @@
   }
 
   &--alignment-left {
-    right: calc(100% + map-get($spacing, "padding-4"));
-    top: calc(50% - map-get($spacing, "tooltip", "tooltip-arrow-width"));
+    right: calc(100% + 32px);
+    top: calc(50% - $arrow-width);
 
     .ilo--tooltip--arrow {
       border-left-color: map-get($color, "tooltip", "default", "background");
-      border-width: map-get($spacing, "tooltip", "tooltip-arrow-width") 0
-        map-get($spacing, "tooltip", "tooltip-arrow-width")
-        map-get($spacing, "tooltip", "tooltip-arrow-height");
+      border-width: $arrow-width 0 $arrow-width spacing(3);
       left: auto;
-      margin-top: -#{map-get($spacing, "tooltip", "tooltip-arrow-width")};
-      right: -#{map-get($spacing, "tooltip", "tooltip-arrow-height")};
+      margin-top: -#{$arrow-width};
+      right: -#{spacing(3)};
       top: 50%;
 
       &--placement-negative {
@@ -153,15 +148,13 @@
 
   &--alignment-bottom {
     left: 0;
-    top: calc(100% + map-get($spacing, "tooltip", "tooltip-arrow-height"));
+    top: calc(100% + spacing(3));
 
     .ilo--tooltip--arrow {
-      border-width: 0 map-get($spacing, "tooltip", "tooltip-arrow-width")
-        map-get($spacing, "tooltip", "tooltip-arrow-height")
-        map-get($spacing, "tooltip", "tooltip-arrow-width");
+      border-width: 0 $arrow-width spacing(3) $arrow-width;
       left: 50%;
-      margin-left: -#{map-get($spacing, "tooltip", "tooltip-arrow-width")};
-      margin-top: -#{map-get($spacing, "tooltip", "tooltip-arrow-height")};
+      margin-left: -#{$arrow-width};
+      margin-top: -#{spacing(3)};
       top: 0;
       border-bottom-color: map-get($color, "tooltip", "default", "background");
 


### PR DESCRIPTION
# New spacing for feedback components
#### 🔔 Merge after #674, and change destination to `develop`, because of the `spacing` helper 🔔

Feedback categories got new spacing token implementations.

### Component List:
- Callout
- Notification
- Tooltip

In [#639](https://github.com/international-labour-organization/designsystem/issues/639), the modal component is also mentioned but it has no legacy spacing.

## Improvements

Here are some demos of improved component spacing

### Callout
>  Old Callout

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/cd6e3661-7c8e-4d43-a5cd-054fde7062a0)

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/de3dad57-106f-4cc5-96d6-110fb4de0cd7)


> New Callout

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/d7fd5267-581e-4cef-88d4-4f638c0c0220)

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/59495b7a-0749-4f1c-aa14-0e95969ff917)

- New spacing applied
- The collapsed version is symmetrical


### Notification
> Old Notification

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/89d4226e-4011-4c2b-beaa-498ccec5e303)

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/1a56bd72-52b9-4351-889f-a0bbcc346c17)

> New Notification

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/6389e405-cb46-430e-98d1-a24285b23c06)

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/c2cb27cb-e337-4fcd-ba17-87769a0d6001)
