### PR TITLE
Refactor(styles): Clean up and modify content spacing

### DIFF
--- a/.changeset/new-weeks-roll.md
+++ b/.changeset/new-weeks-roll.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+reworked spacing values for content category and fix design bugs.

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -14,8 +14,7 @@
 
     width: 100%;
     margin: 0;
-    padding: px-to-rem(calc($spacing-ui-padding-lg - 6px)) px-to-rem(36px)
-      px-to-rem(calc($spacing-ui-padding-lg - 6px)) 0;
+    padding: spacing(4) spacing(4) spacing(4) 0;
 
     background-color: $color-ux-background-default;
     background-position: calc(100% - px-to-rem(6px)) center;
@@ -36,8 +35,7 @@
 
     &--large {
       @include font-styles("headline-6");
-      padding: px-to-rem(calc($spacing-ui-padding-lg - 3px)) px-to-rem(36px)
-        px-to-rem(calc($spacing-ui-padding-lg - 3px)) 0;
+      padding: spacing(5) spacing(4) spacing(5) 0;
     }
 
     &:hover,
@@ -59,13 +57,11 @@
 
     @include breakpoint("medium") {
       @include font-styles("label-medium");
-      padding: px-to-rem(calc($spacing-ui-padding-xl - 14px)) px-to-rem(36px)
-        px-to-rem(calc($spacing-ui-padding-xl - 14px)) 0;
+      padding: spacing(4) spacing(4) spacing(4) 0;
 
       &--large {
         @include font-styles("headline-6");
-        padding: px-to-rem(calc($spacing-ui-padding-lg - 3px)) px-to-rem(36px)
-          px-to-rem(calc($spacing-ui-padding-lg - 3px)) 0;
+        padding: spacing(5) spacing(4) spacing(5) 0;
       }
     }
 
@@ -86,8 +82,8 @@
     overflow: hidden;
 
     .ilo--accordion--innerpanel {
-      padding-bottom: px-to-rem($spacing-ui-padding-sm);
-      padding-top: px-to-rem(8px);
+      padding-bottom: spacing(3);
+      padding-top: spacing(2);
     }
 
     &--open {
@@ -97,7 +93,7 @@
       &#{$panel}__scroll {
         max-height: $scroll-max-height;
         overflow-y: auto;
-        padding-right: px-to-rem($spacing-ui-padding-xl);
+        padding-right: spacing(8);
       }
     }
   }

--- a/packages/styles/scss/components/_list.scss
+++ b/packages/styles/scss/components/_list.scss
@@ -22,9 +22,8 @@
         width: px-to-rem(12px);
         @include dataurlicon("listarrow", $color-base-neutrals-light);
       }
-      margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
-      margin-left: px-to-rem(12px);
-      padding-left: px-to-rem(12px);
+      margin-left: spacing(3);
+      padding-left: spacing(2);
       position: relative;
     }
   }
@@ -39,33 +38,37 @@
   }
 
   &--horizontal {
+    li {
+      &::before {
+        content: none;
+      }
+    }
     align-items: center;
     display: flex;
     flex-wrap: wrap;
     list-style: none;
 
     .ilo--list__title {
-      margin-bottom: px-to-rem(map-get($spacing, "base"));
-      margin-right: px-to-rem(map-get($spacing, "ui-padding-xxl") - 3px);
+      margin-bottom: spacing(2);
+      margin-right: spacing(9);
     }
 
     .ilo--list__item {
-      margin-bottom: px-to-rem(map-get($spacing, "base"));
+      margin-bottom: spacing(2);
       margin-left: 0;
-      margin-right: px-to-rem(map-get($spacing, "ui-padding-xxl") - 3px);
+      margin-right: spacing(10);
       padding-left: 0;
     }
   }
 
   &__title {
     @include font-styles("headline-6");
-    margin-bottom: px-to-rem(21px);
+    margin-bottom: spacing(6);
     font-family: $fonts-display;
     font-weight: 700;
 
     @include breakpoint("medium") {
       @include font-styles("headline-5");
-      margin-bottom: px-to-rem(27px);
     }
   }
 
@@ -73,16 +76,9 @@
     @include font-styles("body-small");
 
     font-family: $fonts-copy;
-    @include textmargin(
-      "margin-bottom",
-      map-get($spacing, "ui-padding-lg"),
-      "body-small",
-      "copy",
-      0,
-      0
-    );
-    margin-left: px-to-rem(map-get($spacing, "ui-padding-lg"));
-    padding-left: px-to-rem(map-get($spacing, "base") - 5px);
+    margin-bottom: spacing(4);
+    margin-left: spacing(5);
+    padding-left: spacing(1);
 
     b,
     strong {
@@ -92,7 +88,6 @@
 
     @include breakpoint("medium") {
       @include font-styles("base");
-      @include textmargin("margin-bottom", 20px, "base", "copy", 0, 0);
     }
   }
 }

--- a/packages/styles/scss/components/_profile.scss
+++ b/packages/styles/scss/components/_profile.scss
@@ -154,7 +154,7 @@ $avatar-size-lg: $row-1-lg;
       #{$c}--avatar {
         width: px-to-rem($avatar-size-lg);
         height: px-to-rem($avatar-size-lg);
-        margin-inline-end: px-to-rem(15px);
+        margin-inline-end: spacing(4);
       }
 
       #{$c}--name {
@@ -168,12 +168,12 @@ $avatar-size-lg: $row-1-lg;
 
       #{$c}--description {
         @include font-styles("body-xs");
-        padding-block-start: px-to-rem(21px);
+        padding-block-start: spacing(5);
       }
 
       #{$c}--link {
         @include font-styles("body-small");
-        padding-block-start: px-to-rem(21px);
+        padding-block-start: spacing(6);
       }
     }
   }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -16,7 +16,7 @@
   }
 
   p {
-    margin-bottom: px-to-rem(map-get($spacing, "padding-3"));
+    margin-bottom: spacing(6);
   }
 
   p + figure,
@@ -42,15 +42,15 @@
 
   figure {
     width: 100%;
-    margin-bottom: px-to-rem(map-get($spacing, "padding-7"));
+    margin-bottom: spacing(14);
   }
 
   figcaption {
     border-left: 3px solid #b8c4cc;
     color: $color-font-caption;
     font-weight: 400;
-    margin-top: px-to-rem(map-get($spacing, "padding-2"));
-    padding-left: px-to-rem(map-get($spacing, "padding-1"));
+    margin-top: spacing(4);
+    padding-left: spacing(2);
     @include font-styles("image-caption");
   }
 
@@ -67,8 +67,8 @@
   hr {
     background-color: $color-ux-horizontal-rule-default;
     border: none;
-    height: px-to-rem(map-get($spacing, "horizontal-rule"));
-    margin-bottom: px-to-rem(map-get($spacing, "padding-7"));
+    height: px-to-rem(4px);
+    margin-bottom: spacing(14);
   }
 
   h1,
@@ -79,7 +79,7 @@
   h6 {
     font-family: $fonts-display;
     font-weight: 700;
-    margin-top: px-to-rem(map-get($spacing, "padding-7"));
+    margin-top: spacing(14);
   }
 
   h1 {
@@ -157,17 +157,18 @@
   ul,
   ol {
     li {
-      margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
-      margin-left: px-to-rem(20px);
-      padding-left: px-to-rem(12px);
+      margin-bottom: spacing(8);
+      margin-left: spacing(5);
+      padding-left: spacing(3);
       position: relative;
     }
-    margin-bottom: px-to-rem(map-get($spacing, "padding-4"));
+
+    margin-bottom: spacing(8);
   }
 
   ul {
     li {
-      margin-left: px-to-rem(12px);
+      margin-left: spacing(3);
 
       &::before {
         content: "";
@@ -189,10 +190,8 @@
     background-size: px-to-rem(72px) px-to-rem(40px);
     display: block;
     font-family: $fonts-display;
-    margin: px-to-rem(map-get($spacing, "padding-3")) 0
-      px-to-rem(map-get($spacing, "padding-5")) 0;
-    padding: px-to-rem(54px) 0 px-to-rem(34px)
-      px-to-rem(map-get($spacing, "padding-4"));
+    margin: spacing(6) 0 spacing(10) 0;
+    padding: spacing(19) 0 spacing(9) spacing(8); // check
     position: relative;
     width: 100%;
     @include dataurlicon("triangle", $color-ux-background-default);
@@ -200,8 +199,8 @@
     p {
       color: $color-font-blockquote;
       font-weight: 300;
-      margin-bottom: px-to-rem(map-get($spacing, "padding-3"));
-      padding: 0 px-to-rem(map-get($spacing, "padding-6")) 0 0;
+      margin-bottom: spacing(6);
+      padding: 0 spacing(12) 0 0;
       position: relative;
       @include font-styles("pull-quote-sm");
 
@@ -247,7 +246,7 @@
     h4,
     h5,
     h6 {
-      margin-top: px-to-rem(map-get($spacing, "padding-8"));
+      margin-top: spacing(16);
     }
 
     h1 {
@@ -355,7 +354,7 @@
     }
 
     hr {
-      margin-bottom: px-to-rem(map-get($spacing, "padding-8"));
+      margin-bottom: spacing(19);
     }
 
     figure {
@@ -372,14 +371,12 @@
 
     blockquote {
       background-size: px-to-rem(86px) px-to-rem(48px);
-      margin: px-to-rem(map-get($spacing, "padding-4")) 0
-        px-to-rem(map-get($spacing, "padding-8")) 0;
-      padding: px-to-rem(62px) 0 px-to-rem(map-get($spacing, "padding-6"))
-        px-to-rem(map-get($spacing, "padding-6"));
+      margin: spacing(8) 0 spacing(19) 0;
+      padding: spacing(16) 0 spacing(12) spacing(12);
 
       p {
-        margin-bottom: px-to-rem(map-get($spacing, "padding-3"));
-        padding: 0 px-to-rem(map-get($spacing, "padding-6")) 0 0;
+        margin-bottom: spacing(6);
+        padding: 0 spacing(12) 0 0;
         position: relative;
         @include font-styles("pull-quote-lg");
 
@@ -401,22 +398,23 @@
       border-left: none;
       border-right: 3px solid #b8c4cc;
       padding-left: 0;
-      padding-right: px-to-rem(map-get($spacing, "padding-1"));
+      padding-right: spacing(2);
     }
 
     ul,
     ol {
       li {
         margin-left: 0;
-        margin-right: px-to-rem(20px);
+        margin-right: spacing(5);
         padding-left: 0;
-        padding-right: px-to-rem(12px);
+        padding-right: spacing(3);
       }
     }
 
     ul {
       li {
-        margin-right: px-to-rem(12px);
+        margin-right: spacing(3);
+
         &::before {
           left: auto;
           right: px-to-rem(-12px);
@@ -427,12 +425,11 @@
 
     blockquote {
       background-position: -1px -1px;
-      padding: px-to-rem(54px) px-to-rem(map-get($spacing, "padding-4"))
-        px-to-rem(34px) 0;
+      padding: spacing(14) spacing(8) spacing(9) 0;
       @include dataurlicon("trianglereverse", $color-ux-background-default);
 
       p {
-        padding: 0 0 0 px-to-rem(map-get($spacing, "padding-6"));
+        padding: 0 0 0 spacing(12);
 
         &:after {
           left: 0;
@@ -448,8 +445,7 @@
       }
 
       @include breakpoint("medium") {
-        padding: px-to-rem(62px) px-to-rem(map-get($spacing, "padding-6"))
-          px-to-rem(map-get($spacing, "padding-6")) 0;
+        padding: spacing(15) spacing(12) spacing(12) 0;
       }
     }
   }

--- a/packages/styles/scss/components/_table.scss
+++ b/packages/styles/scss/components/_table.scss
@@ -4,17 +4,13 @@
 
 .ilo--table {
   background-color: $color-ux-table-background;
-  padding: $spacing-ux-table-padding-top $spacing-ux-table-padding-right
-    $spacing-ux-table-padding-bottom $spacing-ux-table-padding-left;
+  padding: spacing(20);
   position: relative;
 
   &--header {
     background-color: $color-ux-table-content-background;
     border-bottom: px-to-rem(2px) solid $color-base-neutrals-lighter;
-    padding: $spacing-ux-table-content-padding-top
-      $spacing-ux-table-content-padding-right
-      $spacing-ux-table-content-padding-bottom
-      $spacing-ux-table-content-padding-left;
+    padding: spacing(4) spacing(2) spacing(5) spacing(2);
   }
 
   &--wrapper {
@@ -50,18 +46,12 @@
       font-weight: 700;
       @include font-styles("body-xs");
       letter-spacing: -0.02em;
-      padding: $spacing-ux-table-head-padding-top
-        $spacing-ux-table-head-padding-right
-        $spacing-ux-table-head-padding-bottom
-        $spacing-ux-table-head-padding-left;
+      padding: spacing(4) spacing(2);
       pointer-events: none;
       text-align: left;
 
       .ilo--table--small & {
-        padding: $spacing-ux-table-smallhead-padding-top
-          $spacing-ux-table-smallhead-padding-right
-          $spacing-ux-table-smallhead-padding-bottom
-          $spacing-ux-table-smallhead-padding-left;
+        padding: spacing(2);
       }
 
       &:first-of-type {
@@ -80,10 +70,10 @@
           background-size: 75%;
           content: "";
           display: block;
-          height: px-to-rem($spacing-padding-3);
+          height: px-to-rem(24px);
           position: absolute;
           right: px-to-rem(9px);
-          width: px-to-rem($spacing-padding-3);
+          width: px-to-rem(24px);
           top: 50%;
           transform: translateY(-50%);
         }
@@ -123,17 +113,11 @@
       font-weight: 400;
       @include font-styles("body-xs");
       outline: 0;
-      padding: $spacing-ux-table-cell-padding-top
-        $spacing-ux-table-cell-padding-right
-        $spacing-ux-table-cell-padding-bottom
-        $spacing-ux-table-cell-padding-left;
+      padding: spacing(4) spacing(2) spacing(5);
       position: relative;
 
       .ilo--table--small & {
-        padding: $spacing-ux-table-smallcell-padding-top
-          $spacing-ux-table-smallcell-padding-right
-          $spacing-ux-table-smallcell-padding-bottom
-          $spacing-ux-table-smallcell-padding-left;
+        padding: spacing(3) spacing(2);
       }
 
       &:first-of-type {
@@ -172,11 +156,11 @@
     display: flex;
     font-family: $fonts-display;
     font-weight: 700;
-    margin-bottom: px-to-rem(7px);
+    margin-bottom: spacing(2);
     @include font-styles("headline-6");
 
     .ilo--tooltip--wrapper {
-      margin-left: px-to-rem(6px);
+      margin-left: spacing(1);
     }
   }
 


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/638

# New spacing for content components

 Content category is refactored with new spacing token implementations.

### Component List:

- [x] Accordion
- [ ] Hero
- [ ] Hero card
- [x] List
- [x] Profile
- [x] Rich text
- [x] Table

## Notes

* Refactored all of the components above to use new spacing.

**The following components styles had to be modified (Non breaking) to be intact with the multiple of 4px styling.**

* Accordion
* Profile _(Figma designs too have values that are not matching the criteria)_
* Rich text
* Table 

##  Design bugs identified

### Accordian

* Accordian styles were not in sync with the design. Padding was refactored to match the design.

### Before

<img width="1029" alt="Screenshot 2023-11-28 at 15 27 03" src="https://github.com/international-labour-organization/designsystem/assets/32934169/4b54e248-8aab-480f-8f8b-c8319c68cc85">

### After

* Long text
<img width="1025" alt="Screenshot 2023-11-28 at 15 26 53" src="https://github.com/international-labour-organization/designsystem/assets/32934169/ee570023-1631-4787-a0a9-d04e7475dddc">

* Short text
<img width="1025" alt="Screenshot 2023-11-28 at 15 24 27" src="https://github.com/international-labour-organization/designsystem/assets/32934169/92cfb4eb-33ac-4514-b706-3dce0e64a975">

### List

* List styles were not in sync with the design. Padding and margins had to be adjusted accordingly.

### Before

<img width="1000" alt="Screenshot 2023-11-28 at 20 07 30" src="https://github.com/international-labour-organization/designsystem/assets/32934169/b621241c-b306-4fca-9d7f-1a26314af356">

### After

<img width="1000" alt="Screenshot 2023-11-28 at 20 07 46" src="https://github.com/international-labour-organization/designsystem/assets/32934169/3cf96780-e80e-4af2-8b01-82738e8982ed">

### Table

* Table styles were not in sync with the design. Padding and margins had to be adjusted accordingly.

### Before

<img width="1299" alt="Screenshot 2023-11-30 at 01 01 40" src="https://github.com/international-labour-organization/designsystem/assets/32934169/42807b42-2ea9-4b05-86f6-fbe085eed06d">

### After

<img width="1275" alt="Screenshot 2023-11-30 at 01 03 52" src="https://github.com/international-labour-organization/designsystem/assets/32934169/b4db6a83-bfcb-430a-8a56-496a89bba217">

