### PR TITLE
New spacing for navigation components

### DIFF
--- a/.changeset/red-beans-learn.md
+++ b/.changeset/red-beans-learn.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+rewroked spacing for navigation components

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -12,7 +12,7 @@
     background-color: $color-base-neutrals-white;
     display: inline-flex;
     justify-content: flex-start;
-    padding-block: px-to-rem(16px);
+    padding-block: spacing(4);
     padding-inline-end: 0;
     padding-inline-start: var(--card-padding-start);
     position: relative;
@@ -27,15 +27,15 @@
     background-repeat: no-repeat;
     color: map-get($color, "link", "text", "default");
     display: inline-flex;
-    height: px-to-rem($spacing-padding-2);
-    padding: 0 px-to-rem($spacing-padding-3) 0 px-to-rem(10px);
+    height: px-to-rem(16px);
+    padding: 0 spacing(6) 0 px-to-rem(10px);
     text-decoration: none;
     text-decoration-thickness: px-to-rem($borders-base);
     @include dataurlicon("breadcrumbdivider", $color-link-text-default);
 
     [dir="rtl"] & {
       background-position: 0 52%;
-      padding: 0 px-to-rem(10px) 0 px-to-rem($spacing-padding-3);
+      padding: 0 px-to-rem(10px) 0 spacing(6);
       @include dataurlicon("breadcrumbdividerrtl", $color-link-text-default);
     }
 
@@ -65,7 +65,7 @@
   &--item {
     align-items: center;
     display: flex;
-    height: px-to-rem($spacing-padding-2);
+    height: px-to-rem(16px);
 
     &.home {
       align-items: center;
@@ -86,11 +86,11 @@
           background-repeat: no-repeat;
           content: "";
           display: block;
-          height: px-to-rem($spacing-padding-2);
+          height: px-to-rem(16px);
           left: 0;
           position: absolute;
           top: 0;
-          width: px-to-rem($spacing-padding-2);
+          width: px-to-rem(16px);
           @include dataurlicon("home", $color-link-text-default);
         }
       }
@@ -115,7 +115,7 @@
   .ilo--breadcrumb--item--context {
     align-items: flex-start;
     display: flex;
-    height: px-to-rem($spacing-padding-2);
+    height: px-to-rem(16px);
   }
 
   &.contextmenu {
@@ -137,11 +137,11 @@
         background-repeat: no-repeat;
         content: "";
         display: block;
-        height: px-to-rem($spacing-padding-2);
+        height: px-to-rem(16px);
         right: -7px;
         position: absolute;
         top: 0;
-        width: px-to-rem($spacing-padding-2);
+        width: px-to-rem(16px);
         @include dataurlicon("breadcrumbdivider", $color-link-text-default);
 
         [dir="rtl"] & {
@@ -180,12 +180,12 @@
             $color-ux-background-highlight
           );
           content: "";
-          height: px-to-rem($spacing-padding-1-5);
+          height: px-to-rem(12px);
           position: absolute;
           left: 50%;
           top: -#{px-to-rem(6px)};
           transform: translateX(-50%) rotate(135deg);
-          width: px-to-rem($spacing-padding-1-5);
+          width: px-to-rem(12px);
         }
 
         &:hover {
@@ -195,7 +195,7 @@
         .ilo--breadcrumb--item {
           display: inline-block;
           height: auto;
-          padding: 0 px-to-rem($spacing-padding-1);
+          padding: 0 spacing(2);
           position: relative;
           width: 100%;
 
@@ -233,7 +233,7 @@
           font-family: $fonts-copy;
           font-weight: map-get($type, "weights", "section");
           height: auto;
-          padding: px-to-rem($spacing-padding-2) 0;
+          padding: spacing(4) 0;
           text-decoration: none;
           width: 100%;
           @include font-styles("body-xxs");

--- a/packages/styles/scss/components/_contextmenu.scss
+++ b/packages/styles/scss/components/_contextmenu.scss
@@ -15,16 +15,16 @@
     background-size: contain;
     @include dataurlicon("halfsquaretriangle", $color-ux-background-highlight);
     content: "";
-    height: px-to-rem($spacing-padding-1-5);
+    height: px-to-rem(12px);
     position: absolute;
     left: 50%;
     top: -#{px-to-rem(6px)};
     transform: translateX(-50%) rotate(135deg);
-    width: px-to-rem($spacing-padding-1-5);
+    width: px-to-rem(12px);
   }
 
   &--item {
-    padding: 0 px-to-rem($spacing-padding-1);
+    padding: 0 spacing(2);
 
     &:first-of-type {
       border-top-left-radius: 2px;
@@ -60,7 +60,7 @@
     display: inline-block;
     font-family: $fonts-copy;
     font-weight: map-get($type, "weights", "section");
-    padding: px-to-rem($spacing-padding-2) px-to-rem($spacing-padding-1);
+    padding: spacing(4) spacing(2);
     text-decoration: none;
     width: 100%;
     @include font-styles("body-xxs");

--- a/packages/styles/scss/components/_footer.scss
+++ b/packages/styles/scss/components/_footer.scss
@@ -69,7 +69,7 @@
   overflow: hidden;
 
   &--main {
-    padding: px-to-rem(40px) px-to-rem(32px);
+    padding: spacing(10) spacing(8) spacing(12);
     position: relative;
 
     @include footer-triangle(bottom-right);
@@ -95,11 +95,13 @@
   }
 
   &--secondary {
+    [class*="container"] {
+      padding: 0;
+    }
+
     background-color: $color-base-neutrals-lighter;
-    padding-top: px-to-rem(36px);
-    min-height: px-to-rem(
-      map-get($spacing, "ux", "readmore", "default", "height")
-    );
+    padding: spacing(8) spacing(4) 0;
+    min-height: px-to-rem(56px);
   }
 
   &--headline {
@@ -116,21 +118,21 @@
       "body-xxs",
       "display"
     );
-    margin-top: px-to-rem(22px);
+    margin-top: spacing(5);
   }
 
   &--subhead {
     color: #bedcfa;
     font-family: $fonts-display;
     font-weight: map-get($type, "weights", "section");
-    margin-top: px-to-rem(10px);
+    margin-top: spacing(1);
     @include font-styles("body-xxs");
     line-height: px-to-rem(18.56px);
-    margin-bottom: px-to-rem(45px);
+    margin-bottom: spacing(12);
   }
 
   .address {
-    margin-bottom: px-to-rem(39px);
+    margin-bottom: spacing(5);
   }
 
   .address--line {
@@ -147,11 +149,11 @@
   }
 
   .connect {
-    margin: px-to-rem(55px) 0;
+    margin: spacing(12) 0 spacing(10);
   }
 
   .social--links {
-    margin-bottom: px-to-rem(45px);
+    margin-bottom: spacing(10);
   }
 
   .legal,
@@ -171,7 +173,7 @@
   .secondarylinks--list--item {
     &:before {
       content: "|";
-      margin: px-to-rem(4px);
+      margin: spacing(1);
     }
   }
 
@@ -216,16 +218,15 @@
     // Mobile styles
     justify-content: center;
     border-bottom: 0.1071811361rem solid $brand-ilo-grey-light;
-    margin: px-to-rem(12px) auto 0 auto;
-    padding: px-to-rem($spacing-padding-2) px-to-rem($spacing-padding-2)
-      px-to-rem($spacing-padding-2) px-to-rem($spacing-padding-2);
+    margin: spacing(3) auto 0 auto;
+    padding: spacing(4);
 
     &:after {
       background-repeat: no-repeat;
       content: "";
       height: px-to-rem(24px);
       position: relative;
-      margin-left: px-to-rem(8px);
+      margin-left: spacing(2);
       bottom: px-to-rem(3px);
       transform: rotateX(180deg);
       transform-origin: center;
@@ -250,7 +251,7 @@
     &--main {
       display: grid;
       grid-template-columns: minmax(0, 50%) minmax(0, 50%);
-      gap: 0px 64px;
+      gap: 0px spacing(16);
       grid-template-areas:
         "site-info address"
         "site-info links"
@@ -258,7 +259,7 @@
         "site-info subscribe";
       align-content: start;
       align-items: start;
-      padding: px-to-rem(40px) px-to-rem(20px);
+      padding: spacing(10) spacing(18) spacing(24);
     }
 
     .site--info {
@@ -283,8 +284,8 @@
     }
 
     &--secondary {
-      padding-top: px-to-rem(18px);
-      padding-bottom: px-to-rem(18px);
+      padding-top: spacing(4);
+      padding-bottom: spacing(4);
       position: relative;
       z-index: 1;
     }
@@ -301,13 +302,13 @@
       display: grid;
       grid-template-columns: 0.25fr 0.33fr 0.09fr 0.33fr;
       grid-template-rows: auto auto;
-      gap: 0px 64px;
+      gap: 0px spacing(16);
       grid-template-areas:
         "site-info address  .  connect"
         "site-info links    .  subscribe";
 
-      padding-top: px-to-rem(44px);
-      padding-bottom: px-to-rem(51px);
+      padding-top: spacing(10);
+      padding-bottom: spacing(24);
 
       &:before {
         content: none;
@@ -333,9 +334,17 @@
       justify-self: start;
     }
 
+    .address {
+      margin-bottom: spacing(5);
+    }
+
+    .links {
+      margin-top: -#{spacing(16)};
+    }
+
     &--secondary {
-      padding-top: px-to-rem(18px);
-      padding-bottom: px-to-rem(18px);
+      padding-top: spacing(4);
+      padding-bottom: spacing(4);
       position: relative;
 
       [class*="container"] {
@@ -354,7 +363,7 @@
 
       .secondarylinks--list--item {
         &:before {
-          margin: px-to-rem(8px);
+          margin: spacing(2);
         }
       }
     }
@@ -362,7 +371,7 @@
     .anchorlink {
       margin: 0;
       border: none;
-      padding: 0.25rem;
+      padding: spacing(1);
 
       &:hover {
         margin-bottom: -0.1071811361rem;
@@ -383,7 +392,7 @@
 
       &:after {
         content: "|";
-        margin: px-to-rem(4px);
+        margin: spacing(1);
       }
     }
 

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -19,7 +19,7 @@
       @include textmargin("margin-bottom", 27px, "headline-6", "display", 0, 0);
       @include textmargin(
         "margin-top",
-        $spacing-padding-6,
+        $spacing-spacing-12,
         "headline-6",
         "display",
         0,
@@ -30,11 +30,11 @@
 
   &--links--item {
     &.indented {
-      padding-left: px-to-rem($spacing-padding-4);
+      padding-left: spacing(8);
 
       .ilo--link-list--label {
         display: block;
-        padding-left: px-to-rem($spacing-padding-3);
+        padding-left: spacing(5);
         position: relative;
 
         &:before {
@@ -43,13 +43,13 @@
           background-size: contain;
           content: "";
           display: block;
-          height: px-to-rem($spacing-padding-1-5);
+          height: px-to-rem(12px);
           left: 0;
           position: absolute;
           top: 50%;
           transform: translateY(-50%) rotate(-90deg);
           transform-origin: center;
-          width: px-to-rem($spacing-padding-1-5);
+          width: px-to-rem(12px);
           @include dataurlicon(
             "equilateraltriangle",
             $color-base-neutrals-light
@@ -78,18 +78,18 @@
   }
 
   &--link {
-    background-position: calc(100% - $spacing-padding-0-5) center;
+    background-position: calc(100% - 4px) center;
     background-repeat: no-repeat;
-    background-size: px-to-rem($spacing-padding-3) px-to-rem($spacing-padding-3);
+    background-size: px-to-rem(24px) px-to-rem(24px);
     border-bottom: px-to-rem($borders-base) solid $color-base-neutrals-lighter;
     color: map-get($color, "link", "text", "default");
     display: block;
     font-family: $fonts-display;
     font-weight: map-get($type, "weights", "section");
     @include font-styles("body-small");
-    @include textmargin("padding-bottom", 25px, "body-small", "display", 0, 0);
-    @include textmargin("padding-top", 25px, "body-small", "display", 0, 0);
-    padding-right: px-to-rem($spacing-padding-4);
+    padding-top: spacing(4);
+    padding-bottom: spacing(4);
+    padding-right: spacing(8);
     text-decoration: none;
     @include dataurlicon("arrowright", $color-link-text-default);
     @include globaltransition("color, background-color, border-color");
@@ -117,7 +117,7 @@
     }
 
     [dir="rtl"] & {
-      background-position: $spacing-padding-0-5 center;
+      background-position: px-to-rem(4px) center;
       @include dataurlicon("arrowleft", $color-link-text-default);
 
       &:hover,
@@ -175,7 +175,7 @@
       }
 
       [dir="rtl"] & {
-        background-position: $spacing-padding-0-5 center;
+        background-position: px-to-rem(4px) center;
         @include dataurlicon("arrowleft", $color-base-neutrals-white);
 
         &:hover,

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -123,7 +123,7 @@
       background: $brand-ilo-blue;
       display: flex;
       justify-content: space-between;
-      padding: 0 20px;
+      padding: 0 spacing(5);
 
       .ilo--language-switcher {
         display: none;
@@ -141,7 +141,7 @@
           cursor: pointer;
           font-family: $fonts-display;
           font-weight: 500;
-          padding: 16px 16px 16px 36px;
+          padding: spacing(4) spacing(4) spacing(4) spacing(9);
           text-decoration: none;
           transition: all 150ms ease-out;
           width: 100%;
@@ -211,7 +211,7 @@
     @include breakpoint("large") {
       display: flex;
       justify-content: space-between;
-      padding: 0 20px;
+      padding: 0 spacing(5);
 
       .ilo--subnav--open & {
         visibility: visible;
@@ -258,7 +258,7 @@
     display: none;
     font-family: $fonts-display;
     font-weight: 700;
-    padding: 16px 0;
+    padding: spacing(4) 0;
     text-align: right;
 
     @include breakpoint("large") {
@@ -310,7 +310,7 @@
       align-items: center;
 
       &:first-of-type {
-        margin-left: -20px;
+        margin-left: -#{spacing(5)};
       }
     }
   }
@@ -318,7 +318,7 @@
   &--link {
     color: $brand-ilo-dark-blue;
     display: block;
-    padding: 16px 36px 16px 8px;
+    padding: spacing(4) spacing(9) spacing(4) spacing(2);
     text-decoration: none;
     transition: color 150ms ease-out, background 150ms ease-out;
 
@@ -333,7 +333,7 @@
       background: $brand-ilo-dark-blue;
       color: $brand-ilo-white;
       display: inline-block;
-      padding: 21.5px 24px 20.5px;
+      padding: 21.5px spacing(6) 20.5px;
 
       &:hover,
       &:focus {
@@ -360,7 +360,7 @@
     display: block;
     font-family: $fonts-display;
     font-weight: 500;
-    padding: 16px 36px 16px 8px;
+    padding: spacing(4) spacing(9) spacing(4) spacing(2);
     line-height: 24px;
     text-align: left;
     transition: all 150ms ease-out;
@@ -403,8 +403,8 @@
       cursor: pointer;
       display: inline-block;
       font-weight: 700;
-      margin-left: 20px;
-      padding: 7px 32px 5px 15px;
+      margin-left: spacing(5);
+      padding: 7px spacing(8) 5px 15px;
       text-align: center;
       transition: all 150ms ease-out;
       width: auto;
@@ -423,7 +423,7 @@
         background-repeat: no-repeat;
         background-size: 20px;
         background-position: 10% 55%;
-        padding: 7px 15px 5px 32px;
+        padding: 7px 15px 5px spacing(8);
 
         &:focus,
         &:hover {
@@ -454,7 +454,7 @@
 
     &--logo-wrapper {
       display: flex;
-      padding: 16px 0;
+      padding: spacing(4) 0;
     }
 
     &--logo {
@@ -485,7 +485,7 @@
     &--link {
       background: inherit;
       color: $brand-ilo-white;
-      padding: 0 24px;
+      padding: 0 spacing(6);
       height: 100%;
       text-decoration: none;
       text-align: center;
@@ -506,8 +506,8 @@
 
 .ilo--mobile--nav {
   border-bottom: 3px solid $brand-ilo-grey-light;
-  margin-bottom: 16px;
-  padding-bottom: 16px;
+  margin-bottom: spacing(4);
+  padding-bottom: spacing(4);
 
   &--logo {
     align-items: center;
@@ -519,7 +519,7 @@
     background: $brand-ilo-white;
     left: 0;
     height: 100%;
-    padding: 0 0 px-to-rem(32px);
+    padding: 0 0 spacing(8);
     position: absolute;
     top: 0;
     transform: translateX(100%);
@@ -547,7 +547,7 @@
     display: block;
     font-family: $fonts-display;
     font-weight: 500;
-    padding: 16px 36px 16px 8px;
+    padding: spacing(4) spacing(9) spacing(4) spacing(2);
     line-height: 16px;
     text-align: left;
     transition: all 150ms ease-out;
@@ -567,7 +567,7 @@
   }
 
   &--search {
-    padding: px-to-rem(32px) 0 px-to-rem(24px);
+    padding: spacing(8) 0 spacing(6);
 
     .ilo--searchfield,
     .ilo--form,
@@ -633,7 +633,7 @@
     display: block;
     font-family: $fonts-display;
     font-weight: 500;
-    padding: 8px 30px 8px 40px;
+    padding: spacing(2) 30px spacing(2) spacing(10);
     transition: all 150ms ease-out;
 
     &:hover,
@@ -644,7 +644,7 @@
     }
 
     [dir="rtl"] & {
-      padding: 8px 40px 8px 30px;
+      padding: spacing(2) spacing(10) spacing(2) 30px;
       background-position: calc(100% - 15px) center;
     }
   }
@@ -678,7 +678,7 @@
   background: $brand-ilo-white;
   height: 100%;
   left: 0;
-  padding: 0 0 32px;
+  padding: 0 0 spacing(8);
   position: absolute;
   top: 0;
   transform: translateX(100%);
@@ -692,7 +692,7 @@
   @include breakpoint("large") {
     height: auto;
     left: 0;
-    padding: 32px 0;
+    padding: spacing(8) 0;
     top: auto;
     transform: translateY(-100%);
     transition: transform 225ms ease-out;
@@ -742,7 +742,7 @@
     display: flex;
     font-family: $fonts-display;
     font-weight: 500;
-    padding: 18px 8px;
+    padding: 18px spacing(2);
     text-decoration: none;
     transition: all 150ms ease-out;
 
@@ -775,7 +775,7 @@
     cursor: pointer;
     font-family: $fonts-display;
     font-weight: 500;
-    padding: 16px 16px 16px 32px;
+    padding: spacing(4) spacing(4) spacing(4) spacing(8);
     position: relative;
     transition: all 150ms ease-out;
 
@@ -840,8 +840,8 @@
     color: $brand-ilo-grey-charcoal;
     font-family: $fonts-display;
     font-weight: 700;
-    margin-bottom: 16px;
-    padding: 20px 8px;
+    margin-bottom: spacing(4);
+    padding: spacing(5) spacing(2);
     width: 100%;
   }
 }
@@ -864,7 +864,7 @@
       drop-shadow(0px 4px 8px rgba(30, 45, 190, 0.054))
       drop-shadow(0px 10px 20px rgba(30, 45, 190, 0.08));
     left: 0;
-    padding: 32px 0;
+    padding: spacing(8) 0;
     top: auto;
     transform: translateY(-100%);
     transition: transform 225ms ease-out;
@@ -883,7 +883,7 @@
   .ilo--header--inner {
     align-items: center;
     justify-content: center;
-    padding: 80px 20px;
+    padding: spacing(20) spacing(5);
   }
 
   .ilo--form,

--- a/packages/styles/scss/components/_pagination.scss
+++ b/packages/styles/scss/components/_pagination.scss
@@ -5,12 +5,8 @@
 .ilo--pagination {
   display: flex;
   justify-content: space-between;
-  margin-bottom: px-to-rem(
-    map-get($spacing, "ux", "pagination", "padding", "top")
-  );
-  margin-top: px-to-rem(
-    map-get($spacing, "ux", "pagination", "padding", "top")
-  );
+  margin-bottom: spacing(10);
+  margin-top: spacing(10);
   $self: &;
 
   &--link {
@@ -20,12 +16,12 @@
     color: map-get($color, "ux", "pagination", "default", "icon");
     display: inline-block;
     font-family: $fonts-display;
-    height: px-to-rem(map-get($spacing, "ux", "pagination", "width"));
+    height: px-to-rem(40px);
     overflow: hidden;
     position: relative;
     text-align: left;
     text-indent: -999%;
-    width: px-to-rem(map-get($spacing, "ux", "pagination", "width"));
+    width: px-to-rem(40px);
     @include font-styles("label-medium");
 
     &::before {
@@ -63,8 +59,7 @@
   }
 
   &--first-page {
-    margin: 0
-      px-to-rem(map-get($spacing, "ux", "pagination", "padding", "left")) 0 0;
+    margin: 0 spacing (2) 0 0;
     &::before {
       transform: translate(-50%, -50%) rotate(180deg);
 
@@ -190,8 +185,7 @@
   }
 
   &--last-page {
-    margin: 0 0 0
-      px-to-rem(map-get($spacing, "ux", "pagination", "padding", "right"));
+    margin: 0 0 0 spacing(2);
 
     &::before {
       @include dataurlicon(

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -6,7 +6,7 @@
 .ilo--social-media {
   $c: &;
   $default-theme: "light";
-  $icon-size: map-get($spacing, "icons", "icon-height-lg");
+  $icon-size: $spacing-spacing-4;
 
   @mixin get-icon($icon, $theme: $default-theme) {
     @include dataurlicon(
@@ -49,7 +49,7 @@
   &--list {
     display: inline-flex;
     flex-flow: row wrap;
-    gap: map-get($spacing, "icons", "icon-padding-lg");
+    gap: spacing(4);
 
     &--item {
       display: inline-block;

--- a/packages/styles/scss/components/_tableofcontents.scss
+++ b/packages/styles/scss/components/_tableofcontents.scss
@@ -27,12 +27,12 @@
 
   &--headline {
     border-bottom: px-to-rem(3px) solid $color-base-neutrals-lighter;
-    margin-bottom: px-to-rem($spacing-padding-3);
-    margin-top: px-to-rem(9px);
+    margin-bottom: spacing(6);
+    margin-top: spacing(2);
     @include font-styles("base");
     font-family: $fonts-display;
     font-weight: 700;
-    padding-bottom: px-to-rem($spacing-padding-2);
+    padding-bottom: spacing(4);
   }
 
   &--wrapper {
@@ -40,7 +40,7 @@
       display: block;
       height: 100vh;
       left: 0;
-      padding: px-to-rem(26px);
+      padding: spacing(6);
       position: fixed;
       top: 0;
       width: 100vw;
@@ -56,7 +56,7 @@
     align-items: center;
     display: flex;
     justify-content: center;
-    margin: px-to-rem($spacing-padding-3) auto;
+    margin: spacing(6) auto;
 
     &.hide {
       display: none;
@@ -127,24 +127,17 @@
     background-position: calc(100% - 11px) center;
     background-repeat: no-repeat;
     background-size: px-to-rem(24px) px-to-rem(24px);
-    border-bottom: $color-ux-tableofcontents-items-default-border
-      $spacing-ux-tableofcontents-items-border-bottom solid;
+    border-bottom: $color-ux-tableofcontents-items-default-border px-to-rem(2px)
+      solid;
     color: $color-ux-labels-actionable;
     display: block;
     font-family: $fonts-display;
     font-weight: 500;
-    margin: 0 $spacing-ux-tableofcontents-padding-right 0
-      $spacing-ux-tableofcontents-padding-left;
-    padding: $spacing-ux-tableofcontents-items-padding-top
-      $spacing-ux-tableofcontents-items-padding-right
-      $spacing-ux-tableofcontents-items-padding-bottom
-      $spacing-ux-tableofcontents-items-padding-left;
+    margin: 0 spacing(2) 0 spacing(2);
+    padding: spacing(4) spacing(2) spacing(4);
     position: relative;
     text-decoration: none;
-    width: calc(
-      100% - $spacing-ux-tableofcontents-padding-right -
-        $spacing-ux-tableofcontents-padding-left
-    );
+    width: calc(100% - 16px);
     @include dataurlicon("stemarrow", $color-ux-labels-actionable);
     @include font-styles("label-medium");
     @include globaltransition("background-color, border, color");
@@ -152,22 +145,13 @@
     &:hover,
     &:focus {
       background-color: $color-ux-tableofcontents-items-hover-background;
-      border-bottom: $color-ux-tableofcontents-items-hover-border
-        $spacing-ux-tableofcontents-items-border-bottom solid;
+      border-bottom: $color-ux-tableofcontents-items-hover-border px-to-rem(2px)
+        solid;
       background-position: calc(100% - 19px) center;
       color: $color-ux-labels-hover;
       margin: 0;
       outline: none;
-      padding: $spacing-ux-tableofcontents-items-padding-top
-        calc(
-          $spacing-ux-tableofcontents-items-padding-right +
-            $spacing-ux-tableofcontents-padding-right
-        )
-        $spacing-ux-tableofcontents-items-padding-bottom
-        calc(
-          $spacing-ux-tableofcontents-items-padding-left +
-            $spacing-ux-tableofcontents-padding-left
-        );
+      padding: spacing(4) spacing(4) spacing(4);
       width: 100%;
       @include dataurlicon("stemarrow", $color-ux-labels-hover);
       @include globaltransition("background-color, border, color");
@@ -176,22 +160,13 @@
     &:active {
       background-color: $color-ux-tableofcontents-items-active-background;
       border-bottom: $color-ux-tableofcontents-items-active-border
-        $spacing-ux-tableofcontents-items-border-bottom solid;
-      border-top: $color-ux-tableofcontents-items-default-border
-        $spacing-ux-tableofcontents-items-border-bottom solid;
+        px-to-rem(2px) solid;
+      border-top: $color-ux-tableofcontents-items-default-border px-to-rem(2px)
+        solid;
       color: $color-ux-tableofcontents-items-active-color;
       margin: -2px 0 0 0;
       outline: none;
-      padding: $spacing-ux-tableofcontents-items-padding-top
-        calc(
-          $spacing-ux-tableofcontents-items-padding-right +
-            $spacing-ux-tableofcontents-padding-right
-        )
-        $spacing-ux-tableofcontents-items-padding-bottom
-        calc(
-          $spacing-ux-tableofcontents-items-padding-left +
-            $spacing-ux-tableofcontents-padding-left
-        );
+      padding: spacing(4) spacing(4) spacing(4);
       width: 100%;
       @include dataurlicon(
         "stemarrow",
@@ -207,7 +182,7 @@
 
       &:hover {
         border-bottom: $color-ux-tableofcontents-items-hover-border
-          $spacing-ux-tableofcontents-items-border-bottom solid;
+          px-to-rem(2px) solid;
       }
     }
   }


### PR DESCRIPTION
# New spacing for navigation components

### Components
- [x]  Breadcrumb
- [x]  Context menu
- [x]  Footer
- [x]  Link
- [x]  Link list
- [x]  Local nav
- [x]  Pagination
- [x]  Social media
- [ ]  Table of contents (has no spacing tokens)
- [x]  Navigation

### Demonstration 
One of the biggest changes you can see for the footer component 

> Old Implementation

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/eb46bbe7-ef8b-4d51-8ee5-98a21f2b1dd8)

> New One 

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/f059c046-533d-4c13-8f4a-a1ef063e9162)

