### PR TITLE
Fix/Styles: Hero Card content expanding its width past the limit set by size class

### DIFF
--- a/.changeset/tame-birds-hear.md
+++ b/.changeset/tame-birds-hear.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix bug where long Hero titles would stretch the Hero Card when set to justify start, ignoring the size property of the card.

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -6,7 +6,7 @@
   $c: &;
 
   // Additional offset to add for justify: offset
-  --added-offset: 0;
+  --added-offset: 0px;
 
   // Total offset from the edge of the window
   --base-offset: calc(((100vw - #{$layout-max-width}) / 2));


### PR DESCRIPTION
When the Hero was set to `justify: start`, long content in the Hero Card would push it size passed the width set by the size class. This was happening because the css variable `--added-offset`, which is used for figuring out the padding between the Hero Card content and the edge of the screen, was set to `0` instead of `0px`. Simply adding `px` fixed it.