### PR TITLE
Twig/Styles: Breadcrumb shows first link when condensed

### DIFF
--- a/.changeset/sweet-colts-yawn.md
+++ b/.changeset/sweet-colts-yawn.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Make sure Breadcrumb shows first link when condensed with ellipses

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -71,12 +71,8 @@
       align-items: center;
       display: flex;
       position: relative;
-      width: 17px;
 
       .ilo--breadcrumb--link {
-        padding-left: 0;
-        width: px-to-rem(38px);
-
         &--label {
           @include isVisuallyHidden();
         }

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -2,30 +2,36 @@
   BREADCRUMB COMPONENT
 #}
 {% set lastlink = links|last %}
+{% set firstlink = links|first %}
 <nav class="{{prefix}}--breadcrumb{% if className %} {{className}}{% endif %}" data-prefix="{{prefix}}" data-loadcomponent="Breadcrumb">
-  <ol class="{{prefix}}--breadcrumb--items">
-    <li class="{{prefix}}--breadcrumb--item home">
-      <a class="{{prefix}}--breadcrumb--link" href="{{home.url}}">
-        <span class="{{prefix}}--breadcrumb--link--label">{{home.label}}</span>
-      </a>
-    </li>
-    <li class="{{prefix}}--breadcrumb--item--context">
-      <ul class="{{prefix}}--breadcrumb--items context--menu">
-        {% for link in links %}
-        {% if not loop.last %}
-        <li class="{{prefix}}--breadcrumb--item">
-          <a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
-            <span class="{{prefix}}--breadcrumb--link--label">{{link.label}}</span>
-          </a>
-        </li>
-        {% endif %}
-        {% endfor %}
-      </ul>
-    </li>
-    <li class="{{prefix}}--breadcrumb--item final">
-      <a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
-        <span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
-      </a>
-    </li>
-  </ol>
+	<ol class="{{prefix}}--breadcrumb--items">
+		<li class="{{prefix}}--breadcrumb--item home">
+			<a class="{{prefix}}--breadcrumb--link" href="{{home.url}}">
+				<span class="{{prefix}}--breadcrumb--link--label">{{home.label}}</span>
+			</a>
+		</li>
+		<li class="{{prefix}}--breadcrumb--item first">
+			<a class="{{prefix}}--breadcrumb--link" href="{{firstlink.url}}">
+				<span class="{{prefix}}--breadcrumb--link--label">{{firstlink.label}}</span>
+			</a>
+		</li>
+		<li class="{{prefix}}--breadcrumb--item--context">
+			<ul class="{{prefix}}--breadcrumb--items context--menu">
+				{% for link in links %}
+					{% if not loop.first and not loop.last %}
+						<li class="{{prefix}}--breadcrumb--item">
+							<a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
+								<span class="{{prefix}}--breadcrumb--link--label">{{link.label}}</span>
+							</a>
+						</li>
+					{% endif %}
+				{% endfor %}
+			</ul>
+		</li>
+		<li class="{{prefix}}--breadcrumb--item final">
+			<a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
+				<span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
+			</a>
+		</li>
+	</ol>
 </nav>


### PR DESCRIPTION
Fixes #698

## Before
<img width="286" alt="Screenshot 2023-11-30 at 15 36 02" src="https://github.com/international-labour-organization/designsystem/assets/12401179/16a6d24b-cd38-46a0-a055-d942a469210e">

## After
<img width="381" alt="Screenshot 2023-11-30 at 15 36 30" src="https://github.com/international-labour-organization/designsystem/assets/12401179/5575d848-26c4-413c-a244-87ce2d5a88d0">
