### PR TITLE
Ended video play button size 

### DIFF
--- a/.changeset/rare-points-clean.md
+++ b/.changeset/rare-points-clean.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+reduced play button size for ended video

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -186,7 +186,8 @@
         }
       }
 
-      &.vjs-paused {
+      &.vjs-paused,
+      &.vjs-ended {
         @include iconbutton(
           "play",
           px-to-rem(24px),


### PR DESCRIPTION
# Ended video play button size 

Fix the play button size for the ended video.

### Issue

Luckily we don't have a Drupal CSS re-bundled issue 🤞.

The problem is that the storybook is running in dev mode and the ended video still has paused class 

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/fa4bb95d-a83b-4daa-93d7-14e649fb1bac)

But the production bundle has a `playing` class on the ended video
![image](https://github.com/international-labour-organization/designsystem/assets/36326203/54b1b270-6ef1-4918-91c9-f27ef97fbe96)

And the style targeted the `paused` state 
![image](https://github.com/international-labour-organization/designsystem/assets/36326203/5eff4fe8-078f-4b7a-8ef9-24b0559cd354)

I can investigate more into `video.js` implementation if we want to solve it on the library level @justintemps 

### Demo 

> Demo is running on local Drupal install 

https://github.com/international-labour-organization/designsystem/assets/36326203/78cea777-c2b5-4f7b-bfc2-5ae0139034c3


