### PR TITLE
fix(style)- Support RTL for accordion

### DIFF
--- a/.changeset/famous-drinks-enjoy.md
+++ b/.changeset/famous-drinks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Support RTL for accordion

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -72,6 +72,10 @@
     &[aria-expanded="false"] {
       @include dataurlicon("add", $color-ux-labels-actionable);
     }
+
+    [dir="rtl"] & {
+      background-position: calc(0% + px-to-rem(6px)) center;
+    }
   }
 
   &--panel {


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/723

### Notes 

* The icon is in a fixed position and it needs to do mirror when we change to RTL.

### Screenshot

**Before** 

<img width="1088" alt="Screenshot 2023-12-12 at 23 10 16" src="https://github.com/international-labour-organization/designsystem/assets/32934169/04b161d2-736f-4386-a126-60ac4df955eb">


**After**

<img width="1066" alt="Screenshot 2023-12-12 at 23 04 17" src="https://github.com/international-labour-organization/designsystem/assets/32934169/f27ceb77-ff5a-462f-adce-eba396394b21">
