### PR TITLE
fix(twig) - Add condition to check for single link breadcrumb

### DIFF
--- a/.changeset/healthy-crabs-double.md
+++ b/.changeset/healthy-crabs-double.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Fix breadcrumb for single link

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -3,6 +3,8 @@
 #}
 {% set lastlink = links|last %}
 {% set firstlink = links|first %}
+{% set length = links|length %}
+
 <nav class="{{prefix}}--breadcrumb{% if className %} {{className}}{% endif %}" data-prefix="{{prefix}}" data-loadcomponent="Breadcrumb">
 	<ol class="{{prefix}}--breadcrumb--items">
 		<li class="{{prefix}}--breadcrumb--item home">
@@ -10,11 +12,14 @@
 				<span class="{{prefix}}--breadcrumb--link--label">{{home.label}}</span>
 			</a>
 		</li>
-		<li class="{{prefix}}--breadcrumb--item first">
-			<a class="{{prefix}}--breadcrumb--link" href="{{firstlink.url}}">
-				<span class="{{prefix}}--breadcrumb--link--label">{{firstlink.label}}</span>
-			</a>
-		</li>
+		{% if length %}
+			{% if length > 1 %}
+				<li class="{{prefix}}--breadcrumb--item first">
+					<a class="{{prefix}}--breadcrumb--link" href="{{firstlink.url}}">
+						<span class="{{prefix}}--breadcrumb--link--label">{{firstlink.label}}</span>
+					</a>
+				</li>
+			{% endif %}
 		<li class="{{prefix}}--breadcrumb--item--context">
 			<ul class="{{prefix}}--breadcrumb--items context--menu">
 				{% for link in links %}
@@ -28,10 +33,11 @@
 				{% endfor %}
 			</ul>
 		</li>
-		<li class="{{prefix}}--breadcrumb--item final">
-			<a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
-				<span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
-			</a>
-		</li>
+			<li class="{{prefix}}--breadcrumb--item final">
+				<a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
+					<span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
+				</a>
+			</li>
+		{% endif %}
 	</ol>
 </nav>


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/728

### Notes 

* Modified condition to show the links if they are available if not just show the home button.
* Added condition to check if only one link is available.

### Screenshots

Breadcrumb with multiple links

<img width="490" alt="Screenshot 2023-12-17 at 13 40 34" src="https://github.com/international-labour-organization/designsystem/assets/32934169/8c1739b9-c7e0-4a85-848b-7cfc68538a1c">


Breadcrumb with 1 link

<img width="181" alt="Screenshot 2023-12-17 at 13 40 54" src="https://github.com/international-labour-organization/designsystem/assets/32934169/713f9fc3-9f56-42c6-9537-c0116f9aeb2f">


Breadcrumb with no links (Home button only)

<img width="119" alt="Screenshot 2023-12-17 at 13 41 05" src="https://github.com/international-labour-organization/designsystem/assets/32934169/6ffbdbeb-35f6-4106-a952-75695f197a50">








