### PR TITLE
fix(twig) - Tooltip label issue

### DIFF
--- a/.changeset/great-pugs-appear.md
+++ b/.changeset/great-pugs-appear.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Modify tooltip label and icon condition

--- a/packages/twig/src/patterns/components/tooltip/tooltip.twig
+++ b/packages/twig/src/patterns/components/tooltip/tooltip.twig
@@ -3,7 +3,7 @@
 {% set icontheme = icontheme|default("light") %}
 {% set theme = theme|default("dark") %}
 
-<div class="{{prefix}}--tooltip--wrapper {% if icon %} {{prefix}}--tooltip--wrapper__icon {{prefix}}--tooltip--wrapper__icon__theme__{{icontheme}} {% endif %}" role="status" aria-live="polite" aria-relevant="additions" data-loadcomponent="Tooltip" data-prefix="{{prefix}}">
+<div class="{{prefix}}--tooltip--wrapper {% if icon and icon != "false" %} {{prefix}}--tooltip--wrapper__icon {{prefix}}--tooltip--wrapper__icon__theme__{{icontheme}} {% endif %}" role="status" aria-live="polite" aria-relevant="additions" data-loadcomponent="Tooltip" data-prefix="{{prefix}}">
 	{% if not icon or icon == "false" %}
 		{{ children|raw }}
 	{% endif %}


### PR DESCRIPTION
Problem :- 

* Currently there is a design bug in the twig when the icon is set to false

<img width="320" alt="Screenshot 2023-12-20 at 13 28 36" src="https://github.com/international-labour-organization/designsystem/assets/32934169/fe3b1464-964f-471b-b635-120e52437702">


Note :- 

* The value false is set a string so it needs to check if the value is "false" 

Screenshot :-

<img width="277" alt="Screenshot 2023-12-20 at 13 28 28" src="https://github.com/international-labour-organization/designsystem/assets/32934169/cd72174d-f109-4ad5-8faf-484b5ee0f0f1">




