### PR TITLE
fix(twig) - Make language selector optional in nav/ local nav

### DIFF
--- a/.changeset/metal-horses-promise.md
+++ b/.changeset/metal-horses-promise.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Make language selector optional in nav/local nav

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -118,7 +118,7 @@
 
   &--utility-bar {
     display: none;
-
+    min-height: px-to-rem(24px);
     &--local {
       background: $brand-ilo-blue;
       display: flex;

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -619,6 +619,11 @@
     position: relative;
   }
 
+  &--empty {
+    height: px-to-rem(26);
+    width: px-to-rem(100);
+  }
+
   &--button {
     @include font-styles("image-credit");
     @include dataurlicon("global", $brand-ilo-white);

--- a/packages/twig/src/patterns/components/localnav/localnav.twig
+++ b/packages/twig/src/patterns/components/localnav/localnav.twig
@@ -27,14 +27,16 @@
             <a href="{{mainlink.url}}" class="{{prefix}}--language-switcher--link">{{mainlink.label}}</a>
           </span>
         {% endif %}
-        <button class="{{prefix}}--language-switcher--button" type="button">
+        {% if languagecontextmenu.links is not empty %}
+          <button class="{{prefix}}--language-switcher--button" type="button">
           {{languagelabel}}
-        </button>
-        {% include '@components/contextmenu/contextmenu.twig' with {
+          </button>
+          {% include '@components/contextmenu/contextmenu.twig' with {
             links: languagecontextmenu.links,
             prefix: prefix
           }
         %}
+        {% endif %}
       </div> <!-- /.{{prefix}}--language-switcher--wrap -->
     </div> <!-- /.{{prefix}}--language-switcher -->
     <button class="{{prefix}}--header--menu">Menu</button>
@@ -49,7 +51,7 @@
           </a>
           <button class="{{prefix}}--header--menu--close">{{menucloselabel}}</button>
         </div> <!-- /.{{prefix}}--mobile--logo -->
-
+      {% if languagecontextmenu.links is not empty %}
         <div class="{{prefix}}--mobile--nav--language--switcher">
           <button class="{{prefix}}--mobile--nav--language--switcher--button" type="button">{{languagelabel}}</button>
         </div> <!-- /.{{prefix}}--mobile--nav--language--switcher -->
@@ -69,6 +71,7 @@
             </ul>
           </div>
         </div>
+      {% endif %}
       </div> <!-- /.{{prefix}}--mobile--nav -->
       <nav class="{{prefix}}--nav" aria-labelledby="primary-navigation">
         <h2 class="{{prefix}}--nav--label" id="primary-navigation">{{primarynav.navlabel}}</h2>

--- a/packages/twig/src/patterns/components/navigation/navigation.twig
+++ b/packages/twig/src/patterns/components/navigation/navigation.twig
@@ -7,6 +7,7 @@
 	<div class="{{prefix}}--header--utility-bar">
 		<div class="{{prefix}}--language-switcher">
 			<div class="{{prefix}}--language-switcher--wrap">
+			{% if languagecontextmenu.links is not empty %}
 				<button class="{{prefix}}--language-switcher--button" type="button">
 					{{languagelabel}}
 				</button>
@@ -15,6 +16,9 @@
             prefix: prefix
           }
         %}
+		    {% else %}
+		 		<div class="{{prefix}}--language-switcher--empty"></div>
+		    {% endif %}  
 			</div>
 			<!-- /.{{prefix}}--language-switcher--wrap -->
 		</div>
@@ -67,29 +71,33 @@
 					{% endblock %}
 				</div>
 				<!-- /.{{prefix}}--mobile--search -->
-
-				<div class="{{prefix}}--mobile--nav--language--switcher">
-					<button class="{{prefix}}--mobile--nav--language--switcher--button" type="button">{{languagelabel}}</button>
-				</div>
-				<!-- /.{{prefix}}--mobile--nav--language--switcher -->
-				<div class="{{prefix}}--mobile--nav--language--select">
-					<div class="{{prefix}}--header--inner {{ prefix }}--container">
-						<div class="{{prefix}}--mobile--subnav--menu">
-							<button class="{{prefix}}--mobile--subnav--back" type="button">{{subnav.mobilebacklabel}}</button>
-							<button class="{{prefix}}--header--menu--close">{{subnav.mobilecloselabel}}</button>
-							<h6 class="{{prefix}}--mobile--subnav--label">{{languagelabel}}</h6>
+				{% if languagecontextmenu.links is not empty %}
+					<div class="{{prefix}}--mobile--nav--language--switcher">
+						<button class="{{prefix}}--mobile--nav--language--switcher--button" type="button">{{languagelabel}}</button>
+					</div>
+				{% endif %}
+					<!-- /.{{prefix}}--mobile--nav--language--switcher -->
+					<div class="{{prefix}}--mobile--nav--language--select">
+						<div class="{{prefix}}--header--inner {{ prefix }}--container">
+							<div class="{{prefix}}--mobile--subnav--menu">
+								<button class="{{prefix}}--mobile--subnav--back" type="button">{{subnav.mobilebacklabel}}</button>
+								<button class="{{prefix}}--header--menu--close">{{subnav.mobilecloselabel}}</button>
+								<h6 class="{{prefix}}--mobile--subnav--label">{{languagelabel}}</h6>
+							</div>
+							<!-- /{{prefix}}--mobile--subnav--menu -->
+							<ul class="{{prefix}}--nav--set">
+								{% for item in languagecontextmenu.links %}
+									<li class="{{prefix}}--nav--items">
+										<a href="{{item.url}}" class="{{prefix}}--nav--link {{prefix}}--nav--language">
+											{{item.label}}
+										</a>
+									</li>
+								{% endfor %}
+							</ul>
 						</div>
-						<!-- /{{prefix}}--mobile--subnav--menu -->
-						<ul class="{{prefix}}--nav--set">
-							{% for item in languagecontextmenu.links %}
-								<li class="{{prefix}}--nav--items">
-									<a href="{{item.url}}" class="{{prefix}}--nav--link {{prefix}}--nav--language">{{item.label}}</a>
-								</li>
-							{% endfor %}
-						</ul>
 					</div>
 				</div>
-			</div>
+			
 			<!-- /.{{prefix}}--mobile--nav -->
 			<nav class="{{prefix}}--nav" aria-labelledby="primary-navigation">
 				<h2 class="{{prefix}}--nav--label" id="primary-navigation">{{primarynav.navlabel}}</h2>

--- a/packages/twig/src/patterns/components/navigation/navigation.twig
+++ b/packages/twig/src/patterns/components/navigation/navigation.twig
@@ -5,24 +5,22 @@
 
 <header class="{{prefix}}--header" data-loadcomponent="Navigation" data-prefix="{{prefix}}">
 	<div class="{{prefix}}--header--utility-bar">
-		<div class="{{prefix}}--language-switcher">
-			<div class="{{prefix}}--language-switcher--wrap">
-			{% if languagecontextmenu.links is not empty %}
-				<button class="{{prefix}}--language-switcher--button" type="button">
-					{{languagelabel}}
-				</button>
-				{% include '@components/contextmenu/contextmenu.twig' with {
+		{% if languagecontextmenu.links is not empty %}
+			<div class="{{prefix}}--language-switcher">
+				<div class="{{prefix}}--language-switcher--wrap">
+					<button class="{{prefix}}--language-switcher--button" type="button">
+						{{languagelabel}}
+					</button>
+		{% include '@components/contextmenu/contextmenu.twig' with {
             links: languagecontextmenu.links,
             prefix: prefix
           }
         %}
-		    {% else %}
-		 		<div class="{{prefix}}--language-switcher--empty"></div>
-		    {% endif %}  
+				</div>
+				<!-- /.{{prefix}}--language-switcher--wrap -->
 			</div>
-			<!-- /.{{prefix}}--language-switcher--wrap -->
-		</div>
-		<!-- /.{{prefix}}--language-switcher -->
+			<!-- /.{{prefix}}--language-switcher -->
+		{% endif %}  
 	</div>
 	<!-- /.{{prefix}}--header--utility-bar -->
 	<div class="{{prefix}}--header--logo-bar">


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/740

Notes :- 

* Currently nav and local nav will always display the language selector this needs to be made optional.

Screenshots :- 

### Nav

Before Big screen

<img width="847" alt="Screenshot 2023-12-20 at 15 16 30" src="https://github.com/international-labour-organization/designsystem/assets/32934169/1f9b8282-e4d6-4fd1-9af8-08c05648d0f2">

After Big screen

<img width="864" alt="Screenshot 2023-12-20 at 15 42 13" src="https://github.com/international-labour-organization/designsystem/assets/32934169/1253dffb-93b0-41df-b7db-0c0a77982853">

Before Small screen

<img width="291" alt="Screenshot 2023-12-20 at 15 19 47" src="https://github.com/international-labour-organization/designsystem/assets/32934169/9eb55c3c-5cce-4088-b5c2-f6cb621fa40d">

After Small screen

<img width="290" alt="Screenshot 2023-12-20 at 15 47 04" src="https://github.com/international-labour-organization/designsystem/assets/32934169/0902ef9e-0bdf-4bac-a298-f1e770c6f280">

### Local Nav

Before Big screen

<img width="851" alt="Screenshot 2023-12-20 at 15 35 29" src="https://github.com/international-labour-organization/designsystem/assets/32934169/72575305-f199-4a41-b1f8-57120f8b8f50">

After Big screen
<img width="864" alt="Screenshot 2023-12-20 at 15 35 02" src="https://github.com/international-labour-organization/designsystem/assets/32934169/f458f130-a5a0-4ed0-b65c-9ef018c33885">


Before Small screen

<img width="290" alt="Screenshot 2023-12-20 at 15 34 35" src="https://github.com/international-labour-organization/designsystem/assets/32934169/6cb058d0-20c3-4361-920f-fea9c7f3cef6">

After Small screen

<img width="293" alt="Screenshot 2023-12-20 at 15 35 13" src="https://github.com/international-labour-organization/designsystem/assets/32934169/a18cb57d-c4a9-4cd9-8e69-47707c2e04f8">

