### PR TITLE
Fix(style) - Hover in stat card link

### DIFF
--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -231,7 +231,7 @@
 
   &:hover {
     background: map-get($color, "link", "background", "hover");
-    border-bottom: $widths-border-med solid
+    border-bottom: $widths-border-sm solid
       map-get($color, "link", "underline", "hover");
     color: map-get($color, "link", "text", "hover");
     text-decoration: none;


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/716
Fixes :- https://github.com/international-labour-organization/designsystem/issues/742

Notes :- 

* Currently on hovering the link the card moves down a bit due to the border size changing. 

Recording :- 

https://github.com/international-labour-organization/designsystem/assets/32934169/4cbb6cfc-6a65-4fe7-878c-ec9c32638808




