### PR TITLE
fix(style) - Feature card RTL link 

### DIFF
--- a/.changeset/thirty-steaks-melt.md
+++ b/.changeset/thirty-steaks-melt.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix link position on RTL on feature card

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -80,12 +80,7 @@
         &--link,
         &--link:hover {
           border-bottom: none;
-          padding-left: spacing(6);
-          padding-right: spacing(6);
-
-          [dir="rtl"] & {
-            padding-right: spacing(6);
-          }
+          padding-inline: spacing(6) spacing(2);
         }
       }
 

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -82,6 +82,10 @@
           border-bottom: none;
           padding-left: spacing(6);
           padding-right: spacing(6);
+
+          [dir="rtl"] & {
+            padding-right: spacing(6);
+          }
         }
       }
 

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -89,7 +89,7 @@
     @include font-styles("body-small");
     padding-top: spacing(4);
     padding-bottom: spacing(4);
-    padding-right: spacing(8);
+    padding-inline-end: spacing(8);
     text-decoration: none;
     @include dataurlicon("arrowright", $color-link-text-default);
     @include globaltransition("color, background-color, border-color");
@@ -119,7 +119,6 @@
     [dir="rtl"] & {
       background-position: px-to-rem(4px) center;
       @include dataurlicon("arrowleft", $color-link-text-default);
-      padding-right: 0;
 
       &:hover,
       &:focus {


### PR DESCRIPTION
Fixes :- https://github.com/international-labour-organization/designsystem/issues/716

Notes :- 

* Currently the feature card does not have padding assigned to link in RTL. This needs to be refactored.

Fix :- 

* Add appropriate padding for RTL 

Recording :- 

https://github.com/international-labour-organization/designsystem/assets/32934169/02cda9d7-b600-4c16-b9fb-015f6766ea09







