### PR TITLE
feat(twig): add aria-label attribute to modal

### DIFF
--- a/.changeset/quiet-ears-applaud.md
+++ b/.changeset/quiet-ears-applaud.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add optional string modalLabel parameter to be used as aria-label attribute in modal

--- a/packages/twig/src/patterns/components/modal/modal.twig
+++ b/packages/twig/src/patterns/components/modal/modal.twig
@@ -7,7 +7,7 @@
 {% if component != 'modal' %}
 	<div class="{{prefix}}--modal" data-loadcomponent="Modal" data-prefix="{{prefix}}">
 		{% include '@components/button/button.twig' with openbutton %}
-		<div class="{{prefix}}--modal--wrapper" aria-modal="true" role="alertdialog">
+		<div class="{{prefix}}--modal--wrapper" {% if modalLabel %} aria-label="{{modalLabel}}" {% endif %} aria-modal="true" role="alertdialog">
 			<div class="{{prefix}}--modal--background" role="presentation"></div>
 			<div class="{{prefix}}--modal--contents">
 				{% block modal_content %}

--- a/packages/twig/src/patterns/components/modal/modal.wingsuit.yml
+++ b/packages/twig/src/patterns/components/modal/modal.wingsuit.yml
@@ -55,7 +55,7 @@ modal:
     modalLabel:
       type: string
       label: Modal Label
-      description: The modal label
+      description: A modal label added to aria-label attribute to improve accessibility 
       preview: "modal"
       required: false
   visibility: storybook

--- a/packages/twig/src/patterns/components/modal/modal.wingsuit.yml
+++ b/packages/twig/src/patterns/components/modal/modal.wingsuit.yml
@@ -52,4 +52,10 @@ modal:
         className: "modal--open"
         opensmodal: true
       required: true
+    modalLabel:
+      type: string
+      label: Modal Label
+      description: The modal label
+      preview: "modal"
+      required: false
   visibility: storybook


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/765

### Notes :- 

* Added aria label attribute to modal in twig.
* **Added modalLabel as an optional param as it would break the existing implementation**



