### PR TITLE
fix(twig) - Fix padding between arrow and label

### DIFF
--- a/.changeset/silly-beans-reflect.md
+++ b/.changeset/silly-beans-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix padding between arrow and label content in table of contents to prevent overlap

--- a/packages/styles/scss/components/_tableofcontents.scss
+++ b/packages/styles/scss/components/_tableofcontents.scss
@@ -135,6 +135,7 @@
     font-weight: 500;
     margin: 0 spacing(2) 0 spacing(2);
     padding: spacing(4) spacing(2) spacing(4);
+    padding-inline-end: spacing(12);
     position: relative;
     text-decoration: none;
     width: calc(100% - 16px);


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/771

### Notes :- 

* Add padding with consideration of the design to prevent overflow between text and arrow

### Screenshots :- 

<img width="411" alt="Screenshot 2024-01-12 at 00 12 45" src="https://github.com/international-labour-organization/designsystem/assets/32934169/2c159588-e994-4a1c-bf75-9fa245f1f310">



