### PR TITLE
fix(twig/react) - Refactor option label as a child in dropdown

### DIFF
--- a/.changeset/mean-apes-check.md
+++ b/.changeset/mean-apes-check.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/twig": patch
+---
+
+Refactor option label to be a child component instead of an attribute to improve screen reader experience

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -65,7 +65,9 @@ const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>((props, ref) => {
               label={option.label}
               value={option.value}
               key={`${baseClass}--option--${i}`}
-            />
+            >
+              {option.label}
+            </option>
           ))}
       </select>
     </div>

--- a/packages/twig/src/patterns/components/dropdown/dropdown.twig
+++ b/packages/twig/src/patterns/components/dropdown/dropdown.twig
@@ -10,11 +10,13 @@
 {% endif %}
 
 {% block formfield %}
-	<div class="{{ baseClass }}--wrapper" {% if style %} style="{{ style }}" {% endif %}>
-		<select id="{{ id|default(name) }}" autocomplete="{{ autocomplete|default('off') }}" name="{{ name }}" {% if required %} required {% endif %} {% if onBlur %} onblur="{{ onBlur }}" {% endif %} {% if disabled %} disabled {% endif %} class="{{ dropdownClasses|join(' ') }}" value="{{ currentvalue|default(value) }}" {% if form %} form="{{ form }}" {% endif %} {% if multiple %} multiple {% endif %} {% if selectSize %} size="{{ selectSize }}" {% endif %} {% if ariaDescribedBy %} aria-describedby="{{ ariaDescribedBy }}" {% endif %}>
-			{% for option in options %}
-				<option {% if option.disabled %} disabled {% endif %} label="{{ option.label }}" value="{{ option.value }}" {% if defaultOption and defaultOption == option.value%}} selected {% endif %}></option>
-			{% endfor %}
-		</select>
-	</div>
+    <div class="{{ baseClass }}--wrapper" {% if style %} style="{{ style }}" {% endif %}>
+        <select id="{{ id|default(name) }}" autocomplete="{{ autocomplete|default('off') }}" name="{{ name }}" {% if required %} required {% endif %} {% if onBlur %} onblur="{{ onBlur }}" {% endif %} {% if disabled %} disabled {% endif %} class="{{ dropdownClasses|join(' ') }}" value="{{ currentvalue|default(value) }}" {% if form %} form="{{ form }}" {% endif %} {% if multiple %} multiple {% endif %} {% if selectSize %} size="{{ selectSize }}" {% endif %} {% if ariaDescribedBy %} aria-describedby="{{ ariaDescribedBy }}" {% endif %}>
+            {% for option in options %}
+                <option {% if option.disabled %} disabled {% endif %} value="{{ option.value }}" {% if defaultOption and defaultOption == option.value %} selected {% endif %}>
+                    {{ option.label }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/766

### Notes :- 

* Moved option label within the option tag instead of an attribute so that it can be read by screen readers.

