### PR TITLE
fix(style) - Add spacing to iframe in rich text

### DIFF
--- a/.changeset/four-experts-allow.md
+++ b/.changeset/four-experts-allow.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Add spacing to iframes in richtext

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -22,6 +22,7 @@
   p + figure,
   p + img,
   p + blockquote,
+  p + iframe,
   ul + img,
   ol + img,
   dl + img,
@@ -38,6 +39,10 @@
       0,
       0
     );
+  }
+
+  iframe {
+    margin-bottom: spacing(14);
   }
 
   figure {
@@ -335,6 +340,7 @@
     p + figure,
     p + img,
     p + blockquote,
+    p + iframe,
     ul + img,
     ol + img,
     dl + img,


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/773

### Notes :- 

* Added the same spacing as figure to iframe in richtext component

### Screenshot :- 

<img width="1212" alt="Screenshot 2024-01-13 at 00 56 45" src="https://github.com/international-labour-organization/designsystem/assets/32934169/24993d0e-07cd-4136-930b-8bf3c5556d15">

