### PR TITLE
fix(react/twig) - Change heading from h5 to h3 in cards

### DIFF
--- a/.changeset/neat-ducks-flow.md
+++ b/.changeset/neat-ducks-flow.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/twig": patch
+---
+
+Refactor card heading from h5 to h3 to ensure headings are in sequential order to improve accessibility

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -67,7 +67,7 @@ const Card: FC<CardProps> = ({
         )}
         <div className={`${baseClass}--content`}>
           {eyebrow && <p className={`${baseClass}--eyebrow`}>{eyebrow}</p>}
-          {title && <h5 className={`${baseClass}--title`}>{title}</h5>}
+          {title && <h3 className={`${baseClass}--title`}>{title}</h3>}
           {(variant == "multilink" || (variant == "data" && image)) && (
             <div className={`${baseClass}--image--wrapper`}>
               <picture>

--- a/packages/twig/src/patterns/components/card_detail/card_detail.twig
+++ b/packages/twig/src/patterns/components/card_detail/card_detail.twig
@@ -21,7 +21,7 @@
         <p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>
       {% endif %}
       {% if title %}
-        <h5 class="{{prefix}}--card--title">{{title}}</h5>
+        <h3 class="{{prefix}}--card--title">{{title}}</h3>
       {% endif %}
       {% if intro %}
         <p class="{{prefix}}--card--intro">{{intro}}</p>

--- a/packages/twig/src/patterns/components/card_factlist/card_factlist.twig
+++ b/packages/twig/src/patterns/components/card_factlist/card_factlist.twig
@@ -5,7 +5,7 @@
   <div class="{{prefix}}--card--wrap">
     <div class="{{prefix}}--card--content">
       {% if title %}
-        <h5 class="{{prefix}}--card--title">{{title}}</h5>
+        <h3 class="{{prefix}}--card--title">{{title}}</h3>
       {% endif %}
       {% if list %}
         {% include "@components/list/list.twig" with {

--- a/packages/twig/src/patterns/components/card_feature/card_feature.twig
+++ b/packages/twig/src/patterns/components/card_feature/card_feature.twig
@@ -21,7 +21,7 @@
         <p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>
       {% endif %}
       {% if title %}
-        <h5 class="{{prefix}}--card--title">{{title}}</h5>
+        <h3 class="{{prefix}}--card--title">{{title}}</h3>
       {% endif %}
       {% if date %}
         <time class="{{prefix}}--card--date" datetime="{{date.unix}}">{{date.human}}</time>

--- a/packages/twig/src/patterns/components/card_multilink/card_multilink.twig
+++ b/packages/twig/src/patterns/components/card_multilink/card_multilink.twig
@@ -21,7 +21,7 @@
         <p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>
       {% endif %}
       {% if title %}
-        <h5 class="{{prefix}}--card--title">{{title}}</h5>
+        <h3 class="{{prefix}}--card--title">{{title}}</h3>
       {% endif %}
       {% if image %}
         <div class="{{prefix}}--card--image--wrapper">

--- a/packages/twig/src/patterns/components/card_promo/card_promo.twig
+++ b/packages/twig/src/patterns/components/card_promo/card_promo.twig
@@ -13,7 +13,7 @@
           <p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>
         {% endif %}
         {% if title %}
-          <h5 class="{{prefix}}--card--title">{{title}}</h5>
+          <h3 class="{{prefix}}--card--title">{{title}}</h3>
         {% endif %}
         {% if intro %}
           <p class="{{prefix}}--card--intro">{{intro}}</p>

--- a/packages/twig/src/patterns/components/card_stat/card_stat.twig
+++ b/packages/twig/src/patterns/components/card_stat/card_stat.twig
@@ -5,7 +5,7 @@
 	<div class="{{prefix}}--card--wrap">
 		<div class="{{prefix}}--card--content">
 			{% if title %}
-				<h5 class="{{prefix}}--card--title">{{title}}</h5>
+				<h3 class="{{prefix}}--card--title">{{title}}</h3>
 			{% endif %}
 			{% if intro %}
 				<p class="{{prefix}}--card--intro">{{intro}}</p>

--- a/packages/twig/src/patterns/components/card_text/card_text.twig
+++ b/packages/twig/src/patterns/components/card_text/card_text.twig
@@ -13,7 +13,7 @@
           <p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>
         {% endif %}
         {% if title %}
-          <h5 class="{{prefix}}--card--title">{{title}}</h5>
+          <h3 class="{{prefix}}--card--title">{{title}}</h3>
         {% endif %}
         {% if date %}
           <time class="{{prefix}}--card--date" datetime="{{date.unix}}">{{date.human}}</time>


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/769

### Notes :- 

* Refactor headings of cards from h5 to h3 to ensure headings are in sequential order to improve accessibility.