### PR TITLE
feat(twig): Add block to wrap label, as required in Drupal development

### DIFF
--- a/.changeset/shy-pumas-dream.md
+++ b/.changeset/shy-pumas-dream.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add block to wrap label, as required in Drupal development.

--- a/packages/twig/src/patterns/components/form/formcontrol.twig
+++ b/packages/twig/src/patterns/components/form/formcontrol.twig
@@ -62,7 +62,9 @@
 <div class="{{ formControlClass|join(' ') }}" {% if style %} style="{{ style }}" {% endif %}>
 	{% if label %}
 		<span class="{{ labelClass|join(' ') }}">
-			<label for="{{ id }}">{{ label }}</label>
+			{% block label %}
+				<label for="{{ id }}">{{ label }}</label>
+			{% endblock %}
 			{% if tooltip %}
 				{% include '@components/tooltip/tooltip.twig' with {
 				"icon": true,


### PR DESCRIPTION
https://zoocha.atlassian.net/browse/ILO-631

This change is requested to fix an accessibility issue on the ILO Drupal site.
**Form elements do not have associated label elements**

The label need to be linked to the inputs by the _for_ attribute of the label and the _id/name_ of the input. 
Drupal handles it from different levels, so to add those attributes to the label correctly it need to be printed on its own template.

Adding a block to the label item on the formcontrol.twig (which is used in Drupal for the parent level - form-element.twig) it's possible to print the label inside with their own attributes and still respecting ILO Design system styling.