### PR TITLE
Breadcrumbs context check

### DIFF
--- a/.changeset/pretty-roses-tell.md
+++ b/.changeset/pretty-roses-tell.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+breadcrumbs: added check for context items

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.js
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.js
@@ -76,7 +76,9 @@ export default class Breadcrumb {
    */
   enable() {
     window.addEventListener(EVENTS.RESIZE, (e) => this.onResize(e));
-    this.ContextButton.addEventListener(EVENTS.CLICK, () => this.onClick());
+    if (this.ContextButton) {
+      this.ContextButton.addEventListener(EVENTS.CLICK, () => this.onClick());
+    }
 
     return this;
   }
@@ -88,14 +90,15 @@ export default class Breadcrumb {
    * @chainable
    */
   onResize() {
-    if (this.breadcrumbwidth > this.element.offsetWidth / 2) {
-      this.element.classList.add("contextmenu");
-      this.ContextMenu.classList.remove("open");
-    } else {
-      this.element.classList.remove("contextmenu");
-      this.ContextMenu.classList.remove("open");
+    if (this.ContextMenu) {
+      if (this.breadcrumbwidth > this.element.offsetWidth / 2) {
+        this.element.classList.add("contextmenu");
+        this.ContextMenu.classList.remove("open");
+      } else {
+        this.element.classList.remove("contextmenu");
+        this.ContextMenu.classList.remove("open");
+      }
     }
-
     return this;
   }
 
@@ -106,7 +109,7 @@ export default class Breadcrumb {
    * @chainable
    */
   onClick() {
-    if (this.element.classList.contains("contextmenu")) {
+    if (this.ContextMenu) {
       if (this.ContextMenu.classList.contains("open")) {
         this.ContextMenu.classList.remove("open");
       } else {


### PR DESCRIPTION
# Root Couse 

For pages that were rendering breadcrumbs, we had the error like this 

<img width="704" alt="image" src="https://github.com/international-labour-organization/designsystem/assets/36326203/84f93412-bf59-4399-bee3-4e49ee1923a0">

the problem was that the storybook example always renders the context menu, but due to breadcrumbs behavior, the context menu is not required
<img width="479" alt="image" src="https://github.com/international-labour-organization/designsystem/assets/36326203/5e1c0819-6317-4707-9ef2-1dcb67dc2343">

Here is an example of a breadcrumb component without a context menu, not throwing any errors

https://github.com/international-labour-organization/designsystem/assets/36326203/67f133ae-f242-4381-8186-ae3b8ac539f6

