### PR TITLE
fix(style) - Refactor alignment on mobile and fix RTL in accordion

### DIFF
--- a/.changeset/weak-games-promise.md
+++ b/.changeset/weak-games-promise.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor text alignment on accordion on small devices and fix rtl design bug

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -12,10 +12,11 @@
     align-items: center;
     flex-direction: row;
     justify-content: space-between;
-
+    text-align: start;
     width: 100%;
     margin: 0;
-    padding: spacing(4) spacing(4) spacing(4) 0;
+    padding: spacing(4) 0;
+    padding-inline-end: spacing(4);
 
     background-color: $color-ux-background-default;
     background-position: calc(100% - px-to-rem(6px)) center;
@@ -36,7 +37,8 @@
 
     &--large {
       @include font-styles("headline-6");
-      padding: spacing(5) spacing(4) spacing(5) 0;
+      padding: spacing(5) 0;
+      padding-inline-end: spacing(4);
     }
 
     &:hover,
@@ -58,11 +60,11 @@
 
     @include breakpoint("medium") {
       @include font-styles("label-medium");
-      padding: spacing(4) spacing(4) spacing(4) 0;
 
       &--large {
         @include font-styles("headline-6");
-        padding: spacing(5) spacing(4) spacing(5) 0;
+        padding: spacing(5) 0;
+        padding-inline-end: spacing(4);
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/785

### Notes :- 

* Currently the text in the accordion is center aligned on mobile devices
* There is also an issue in RTL where long text overflows the icon

### Fix :- 

* Aligned text to be at the start of the accordion which supports both LTR and RTL
* Added padding-inline-end instead of traditional padding as it supports RTL as well.

### Screenshots :- 

**Iphone SE**

<img width="338" alt="Screenshot 2024-02-07 at 11 11 04" src="https://github.com/international-labour-organization/designsystem/assets/32934169/4fe85078-e999-44c4-aa46-f4399fcedbdb">





