### PR TITLE
fix(tag) - Refactor reset tag padding to consider border

### DIFF
--- a/.changeset/eighty-spoons-attack.md
+++ b/.changeset/eighty-spoons-attack.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix reset tag button having a bigger height than other tags

--- a/packages/styles/scss/components/_tag.scss
+++ b/packages/styles/scss/components/_tag.scss
@@ -128,7 +128,7 @@
 
   &--reset {
     @include font-styles("label-small");
-
+    padding: calc(spacing(2) - px-to-rem(1.5)) calc(spacing(3) - px-to-rem(1.5));
     cursor: pointer;
     display: none;
     opacity: 0;


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/780

### Notes :- 

* Currently the reset button looks to be off when compared to the other buttons because it has a border.

### Fix :- 

* Consider the border width when setting the reset button inner padding so that it maintains consistency with other buttons.


