### PR TITLE
fix(style) : Remove gap between forward and end button

### DIFF
--- a/.changeset/sweet-feet-grow.md
+++ b/.changeset/sweet-feet-grow.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Remove gap between forward and end button in pagination

--- a/packages/styles/scss/components/_pagination.scss
+++ b/packages/styles/scss/components/_pagination.scss
@@ -185,8 +185,6 @@
   }
 
   &--last-page {
-    margin: 0 0 0 spacing(2);
-
     &::before {
       @include dataurlicon(
         "doublearrow",
@@ -227,7 +225,7 @@
 
   &--page {
     @include font-styles("nav-md-sm");
-
+    margin-inline-end: spacing(2);
     font-family: $fonts-copy;
     font-weight: 400;
     line-height: 45px;

--- a/packages/twig/src/patterns/components/pagination/pagination.wingsuit.yml
+++ b/packages/twig/src/patterns/components/pagination/pagination.wingsuit.yml
@@ -2,7 +2,7 @@ pagination:
   namespace: Components/Navigation
   use: "@components/pagination/pagination.twig"
   label: Pagination
-  description: The Pagination component presents a dismissible alert.
+  description: The Pagination component breaks content into pages for easier navigation with intuitive controls like 'Previous' and 'Next' buttons.
   fields:
     currentPage:
       type: numeric


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/809

### Notes :- 

* There is a gap between the forward and end button. The reason this was added is to center the pagination count.

### Fix :- 

* Remove gap between forward and end button and center the pagination count.

### Screenshot :- 

<img width="1062" alt="Screenshot 2024-02-10 at 00 15 18" src="https://github.com/international-labour-organization/designsystem/assets/32934169/c8f4bdca-df39-47c8-a311-a916bfc08b01">






