### PR TITLE
Breadcrumbs text wraping

### DIFF
--- a/.changeset/odd-eggs-camp.md
+++ b/.changeset/odd-eggs-camp.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+separated labels for breadcrumbs

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -48,6 +48,10 @@
       font-family: $fonts-copy;
       font-weight: 400;
       @include font-styles("body-xxs");
+
+      &--dropdown {
+        font-family: $fonts-copy;
+      }
     }
 
     &:hover,
@@ -186,7 +190,7 @@
           content: "";
           height: px-to-rem(12px);
           position: absolute;
-          // left: 50%;
+          left: 50%;
           top: -#{px-to-rem(6px)};
           transform: translateX(-50%) rotate(135deg);
           width: px-to-rem(12px);

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -24,7 +24,7 @@
 						{% if not loop.first and not loop.last %}
 							<li class="{{prefix}}--breadcrumb--item">
 								<a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
-									<span class="{{prefix}}--breadcrumb--link--label">{{link.label}}</span>
+									<span class="{{prefix}}--breadcrumb--link--label--dropdown">{{link.label}}</span>
 								</a>
 							</li>
 						{% endif %}

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.wingsuit.yml
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.wingsuit.yml
@@ -22,7 +22,7 @@ breadcrumb:
           url: "/linkone"
         - label: "Link Two"
           url: "/linktwo"
-        - label: "Link Three"
+        - label: "Link Three a long link that will wrap to the next line"
           url: "/linkthree"
         - label: "Link Four"
           url: "/linkfour"


### PR DESCRIPTION
# Root Cause

Breadcrumbs should have 2 types of labels, one that is displayed every time and the second that is inside of the context menu.  The current implementation had no separation for those labels, the main one has a max set of characters, and the context one was using it too. 

This PR creates a separate class for the context label that wraps text.


![image](https://github.com/international-labour-organization/designsystem/assets/36326203/cbc850cd-229e-4ef4-bd25-63d3e97e5d24)


🔔 `contextmenu` component isn't affected by the issue