### PR TITLE
fix(style) - Ending pullquote missing and padding

### DIFF
--- a/.changeset/selfish-cups-vanish.md
+++ b/.changeset/selfish-cups-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix padding and ending quote missing issue in pullquote

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -185,7 +185,7 @@
     margin: spacing(6) 0 spacing(10) 0;
     padding: spacing(19) 0 spacing(9) spacing(8); // check
     position: relative;
-    width: 100%;
+    width: fit-content;
     @include dataurlicon("triangle", $color-ux-background-default);
 
     p {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/784

### Notes :- 

* Currently in small widths the ending pullquote and padding is off

### Screenshot of changes done on website 

**Before** 

<img width="818" alt="Screenshot 2024-02-14 at 00 59 56" src="https://github.com/international-labour-organization/designsystem/assets/32934169/93b8e5c1-7fd9-49d1-9b1d-10ec3bf07ccc">

**After**

<img width="824" alt="Screenshot 2024-02-14 at 00 58 20" src="https://github.com/international-labour-organization/designsystem/assets/32934169/d3acc50e-1860-4d77-b43f-2ee3fdac4296">

