### PR TITLE
fix(style) : Adjust spacing when date is not shown

### DIFF
--- a/.changeset/famous-pumas-glow.md
+++ b/.changeset/famous-pumas-glow.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix spacing when the date is not shown in the feature card

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -73,7 +73,6 @@
         border-top: px-to-rem(2px) solid $brand-ilo-grey-light;
         margin-left: px-to-rem(-24px);
         margin-right: px-to-rem(-24px);
-        margin-top: px-to-rem(34px);
         position: relative;
         z-index: 2;
 
@@ -181,7 +180,7 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        padding: spacing(6) spacing(6) spacing(10);
+        padding: spacing(6) spacing(6) spacing(2) spacing(6);
       }
 
       &#{$self}__linklist {
@@ -192,14 +191,7 @@
 
       #{$self}--title {
         @include font-styles("headline-5");
-        @include textmargin(
-          "margin-bottom",
-          40px,
-          "headline-5",
-          "display",
-          "body-eyebrow",
-          "copy"
-        );
+        margin-bottom: spacing(6);
         font-family: $fonts-display;
         font-weight: 700;
         flex: 1;
@@ -218,7 +210,7 @@
       }
 
       #{$self}--date {
-        margin-bottom: 0;
+        margin-bottom: spacing(8);
         margin-top: auto;
       }
     }


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/805

### Notes :- 

* Currently when the date is hidden in the feature card there is a massive space rather than the expected bottom spacing from the title

### Fix :- 

* Considered existing padding in the content card and also added spacing for each individual text instead of having it in the link list. 

### Screenshots

<img width="424" alt="Screenshot 2024-02-15 at 02 41 19" src="https://github.com/international-labour-organization/designsystem/assets/32934169/0f0cffc7-e97d-4965-853d-d409a89f520a">

<img width="436" alt="Screenshot 2024-02-15 at 02 41 40" src="https://github.com/international-labour-organization/designsystem/assets/32934169/4341a55d-317a-4541-8a11-08e4c7caa484">
