### PR TITLE
Styles: Make logo appear at standard height in nav

### DIFF
--- a/.changeset/fresh-jars-rule.md
+++ b/.changeset/fresh-jars-rule.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Force logo to appear a standard height in Navigation

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -86,17 +86,19 @@
 
   &--logo {
     display: block;
-    width: 100%;
+    height: spacing(14);
+
+    @include breakpoint("large") {
+      height: spacing(18);
+    }
 
     &-link {
       display: block;
-      padding: 16px 0;
-      max-width: 150px;
-      width: 100%;
+      padding: spacing(4) 0;
+      width: auto;
 
       @include breakpoint("large") {
-        padding: 0 0 24px;
-        max-width: 200px;
+        padding: 0 0 spacing(6);
       }
     }
   }


### PR DESCRIPTION
#813 interested new logos with standard height, but the varying widths made it so they were still appearing at different heights in the Navigation component.

This sets a standard height on logos in the Nav so that no matter how wide they are, they'll all appear at the same height.

## Before

https://github.com/international-labour-organization/designsystem/assets/12401179/dd57ad68-bafa-4446-9b09-28cdb0bc84e8

## After

Uploading Screen Recording 2024-02-20 at 11.22.16.mov…

