### PR TITLE
Fix(style) - Tooltip icon not showing on hero caption 

### DIFF
--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -377,7 +377,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
 
   &::after {
     content: "";

--- a/packages/twig/src/patterns/components/hero/hero.twig
+++ b/packages/twig/src/patterns/components/hero/hero.twig
@@ -55,7 +55,7 @@
 					{% include '@components/tooltip/tooltip.twig' with {
 						prefix: prefix,
 						label: caption.label,
-						icon: true,
+						icon: "true",
 						theme: "dark",
 						icontheme: "dark"
 					} only %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/792

### Notes :- 

* Currently the tooltip icon is not shown in the hero caption section which breaks the hover as well

### Fix :- 

* Passed in appropriate prop to display icon
* Removed small gap between caption and hero card

### Screenshots

Before

<img width="717" alt="Screenshot 2024-02-21 at 20 08 57" src="https://github.com/international-labour-organization/designsystem/assets/32934169/8373a5b5-f968-4578-a234-b9bd28a00c16">

After

<img width="698" alt="Screenshot 2024-02-21 at 20 32 24" src="https://github.com/international-labour-organization/designsystem/assets/32934169/62fc8207-0e3a-46b6-b457-1d66441a4a72">
