### PR TITLE
feat(twig) - Add clear button to search

### DIFF
--- a/.changeset/gold-worms-relate.md
+++ b/.changeset/gold-worms-relate.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add clear button to search input field

--- a/packages/styles/scss/components/_searchfield.scss
+++ b/packages/styles/scss/components/_searchfield.scss
@@ -6,7 +6,12 @@
   display: flex;
 
   .ilo--fieldset {
+    position: relative;
     width: 100%;
+  }
+
+  .ilo--input {
+    padding-inline-end: spacing(14);
   }
 
   &--button {
@@ -68,11 +73,38 @@
     }
   }
 
+  &--clear-button {
+    display: none;
+    align-items: center;
+    cursor: pointer;
+
+    &.show {
+      display: inline;
+      position: absolute;
+      top: 12px;
+      right: 2%;
+    }
+  }
+
+  // Remove the default clear button in search
+  [type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+
   [dir="rtl"] & {
-    .ilo--searchfield--button {
-      border-left: px-to-rem(2px) solid
-        $color-formelements-inputbutton-default-border-left;
-      border-right: 0 solid $color-formelements-inputbutton-default-border-right;
+    .ilo--searchfield {
+      &--button {
+        border-left: px-to-rem(2px) solid
+          $color-formelements-inputbutton-default-border-left;
+        border-right: 0;
+      }
+      &--clear-button {
+        &.show {
+          right: 95%;
+        }
+      }
     }
   }
 }

--- a/packages/twig/src/patterns/components/search/index.js
+++ b/packages/twig/src/patterns/components/search/index.js
@@ -4,3 +4,4 @@
 // Module template
 import "./search.twig";
 import "./search.wingsuit.yml";
+import "./search.behavior";

--- a/packages/twig/src/patterns/components/search/search.behavior.js
+++ b/packages/twig/src/patterns/components/search/search.behavior.js
@@ -1,0 +1,15 @@
+import Search from "./search";
+
+Drupal.behaviors.search = {
+  attach() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll(`[data-loadcomponent="Search"]`),
+      (element) => {
+        if (!element.dataset.jsProcessed) {
+          new Search(element);
+          element.dataset.jsProcessed = true;
+        }
+      }
+    );
+  },
+};

--- a/packages/twig/src/patterns/components/search/search.js
+++ b/packages/twig/src/patterns/components/search/search.js
@@ -1,0 +1,103 @@
+import { EVENTS, ARIA } from "@ilo-org/utils";
+
+/**
+ * The Search module which handles the clear button.
+ *
+ * @class Search
+ */
+export default class Search {
+  /**
+   * Search constructor which assigns the element passed into the constructor
+   * to the `this.element` property for later reference
+   *
+   * @param {HTMLElement} element - REQUIRED - the module's container
+   */
+  constructor(element) {
+    /**
+     * Reference to the DOM element that is the root of the component
+     * @property {Object}
+     */
+    this.element = element;
+    this.multipleExpanded = false;
+
+    // Initialize the view
+    this.init();
+  }
+
+  /**
+   * Initializes the view by calling the functions to
+   * create DOM references, setup event handlers and
+   * then create the event listeners
+   *
+   * @return {Object} Search A reference to the instance of the class
+   * @chainable
+   */
+  init() {
+    this.cacheDomReferences().setupHandlers().enable();
+
+    return this;
+  }
+
+  /**
+   * Find all necessary DOM elements used in the view and cache them
+   *
+   * @return {Object} Search A reference to the instance of the class
+   * @chainable
+   */
+  cacheDomReferences() {
+    /**
+     * The field that a user interacts with on a form
+     * @type {Object}
+     */
+    this.searchButton = this.element.querySelector(
+      ".ilo--searchfield--clear-button"
+    );
+    this.searchInputField = this.element.querySelector(".ilo--input");
+    return this;
+  }
+
+  /**
+   * Bind event handlers with the proper context of `this`.
+   *
+   * @return {Object} Search A reference to the current instance of the class
+   * @chainable
+   */
+  setupHandlers() {
+    this.onClick = this.onClick.bind(this);
+    this.KeyPressHandler = this.onKeyPress.bind(this);
+    return this;
+  }
+
+  /**
+   * Creates event listeners to enable interaction with view
+   *
+   * @return {Object} Search A reference to the instance of the class
+   * @chainable
+   */
+  enable() {
+    this.searchButton.addEventListener(EVENTS.CLICK, this.onClick.bind(this));
+    this.searchInputField.addEventListener(
+      "keyup",
+      this.onKeyPress.bind(this, this.searchButton)
+    );
+
+    return this;
+  }
+
+  /**
+   * Onclick interaction with the clear button
+   */
+  onClick(e) {
+    this.searchInputField.value = "";
+    this.searchButton.classList.remove("show");
+  }
+
+  onKeyPress(searchButton, e) {
+    const inputValue = e.target.value.trim();
+    if (inputValue !== "") {
+      this.searchButton.classList.add("show");
+    } else {
+      this.searchButton.classList.remove("show");
+    }
+  }
+}

--- a/packages/twig/src/patterns/components/search/search.twig
+++ b/packages/twig/src/patterns/components/search/search.twig
@@ -6,17 +6,26 @@
 {% set searchClass = [baseClass, class] %}
 {% set inputClass = prefix ~ "--input" %}
 {% set buttonClass = baseClass ~ "--button" %}
+{% set fieldSetClass = prefix ~ "--fieldset" %}
+{% set clearButtonClass = baseClass ~ "--clear-button" %}
 
 {% if error %}
 	{% set inputClass = inputClass|merge([baseClass ~ "__error"]) %}
 {% endif %}
 
-
 {% block formfield %}
-
-	<div class="{{ searchClass|join(" ") }}" {% if style %} style={{ style }} {% endif %}>
+	<div data-loadcomponent="Search" class="{{ searchClass|join(" ") }}" {% if style %} style={{ style }} {% endif %}>
+		<div class="{{fieldSetClass}}">
 		<input name="{{name}}" type="{{type}}" class="{{ inputClass }}{% if error %} error{% endif %}" {% if placeholder %} placeholder="{{placeholder}}" {% endif %} {% if disabled %} disabled {% endif %} {% if required %} required {% endif %} id="{% if id %}{{id}}{% else %}{{name}}{% endif %}"/>
+		<span class="{{clearButtonClass}}" >
+			{% include "@components/icon/icon.twig" with {
+  				"name": "Close",
+  				"size": "24",
+  				"color": "#230050"
+			} %}
+		</span>
+		</div>
 		<input class="{{ buttonClass }}" type="submit"/>
-	</div>
 
+	</div>
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/708

### Notes :- 

* Currently there is no clear button in the search textfield

### Fix :- 

* Add X icon to search field when text is entered

### Screenshots :- 

<img width="977" alt="Screenshot 2024-02-22 at 17 45 20" src="https://github.com/international-labour-organization/designsystem/assets/32934169/061a4457-eda0-4116-a6e1-e503fc90286f">

<img width="975" alt="Screenshot 2024-02-22 at 17 30 07" src="https://github.com/international-labour-organization/designsystem/assets/32934169/acf9ff81-6a2f-40ea-ac11-d693e1fbb6bf">




