### PR TITLE
Twig: Fix Table of Contents close button not showing on mobile

### DIFF
--- a/.changeset/many-mails-punch.md
+++ b/.changeset/many-mails-punch.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Enable Button to use newly refactored Icon component

--- a/.changeset/neat-trains-study.md
+++ b/.changeset/neat-trains-study.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Correct the way the Table of Contents passes properties to the Open and Close buttons.

--- a/contributing.md
+++ b/contributing.md
@@ -135,6 +135,12 @@ Build React Storybook and dependent packages
 pnpm react:build:docs
 ```
 
+Shortcut to only install and build React deps for development
+
+```bash
+pnpm react:dev:prep
+```
+
 Start React storybook in dev mode
 
 ```bash
@@ -145,6 +151,12 @@ Build Twig Storybook and dependent packages
 
 ```bash
 pnpm twig:build:docs
+```
+
+Shortcut to only install and build Twig deps for development
+
+```bash
+pnpm twig:dev:prep
 ```
 
 Start Twig storybook in dev mode

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "react:build:docs": "pnpm turbo run build:docs --filter=@ilo-org/react...",
     "react:build:lib": "pnpm turbo run build:lib --filter react... ",
     "react:dev:docs": "pnpm --filter react storybook",
+    "react:dev:prep": "pnpm react:install && pnpm react:build:lib",
     "test:all": "pnpm turbo run test",
     "twig:install": "pnpm clean && pnpm config set dedupe-peer-dependents=false && pnpm --filter twig... install",
     "fix:pnpm-filter": "pnpm config set dedupe-peer-dependents=false",
     "twig:build:docs": "pnpm fix:pnpm-filter && pnpm turbo run build:docs --filter twig...",
     "twig:build:lib": "pnpm turbo run build:lib --filter twig... ",
-    "twig:dev:docs": "pnpm --filter twig storybook"
+    "twig:dev:docs": "pnpm --filter twig storybook",
+    "twig:dev:prep": "pnpm twig:install && pnpm twig:build:lib"
   },
   "postinstall": "manypkg check",
   "repository": {

--- a/packages/twig/src/patterns/components/button/button.twig
+++ b/packages/twig/src/patterns/components/button/button.twig
@@ -3,18 +3,20 @@
 #}
 {% if url %}
 	<a class="{{prefix}}--button ilo--button--{{size}} {{prefix}}--button--{{type}}{% if icon %} icon icon__position--{{iconPosition}}{% endif %}{% if icononly %} icon--only{% endif %}{% if className %} {{className}}{% endif %}" href="{{url}}" {% if target is defined and target != 'false' %} target="{{target}}" rel="noopener noreferrer" {% endif %} {% if disabled is defined and disabled == 'true' %} disabled {% endif %}>
-
 		<span class="link__label">{{label}}</span>
-		{% if icon %}
-			{% include '@components/icon/icon.twig' with {icon: icon} %}
-		{% endif %}
+		{% block button_icon %}
+			{% if icon %}
+				{% include '@components/icon/icon.twig' with {
+					name: icon.name,
+					size: icon.size,
+					color: icon.color
+				} only %}
+			{% endif %}
+		{% endblock %}
 	</a>
 {% else %}
 	<button class="{{prefix}}--button ilo--button--{{size}} {{prefix}}--button--{{type}}{% if icon %} icon icon__position--{{iconPosition}}{% endif %}{% if icononly %} icon--only{% endif %}{% if className %} {{className}}{% endif %}" {% if kind %} type="{{kind}}" {% endif %} {% if opensmodal %} aria-haspopup="dialog" {% endif %} {% if disabled is defined and disabled == 'true' %} disabled {% endif %} {% if name %} name="{{name}}" {% endif %}>
-
 		<span class="button__label">{{label}}</span>
-		{% if icon %}
-			{% include '@components/icon/icon.twig' with {icon: icon} %}
-		{% endif %}
+		{{ block("button_icon") }}
 	</button>
 {% endif %}

--- a/packages/twig/src/patterns/components/tableofcontents/tableofcontents.twig
+++ b/packages/twig/src/patterns/components/tableofcontents/tableofcontents.twig
@@ -1,23 +1,45 @@
-{#
-  TABLE OF CONTENTS COMPONENT
-#}
+{# tableofcontents.twig #}
+
+{% set openbutton_size = openbutton.size|default("medium") %}
+{% set openbutton_type = openbutton.type|default("secondary") %}
+{% set openbutton_label = openbutton.label|default("Open") %}
+{% set openbutton_label = openbutton.label|default("Open") %}
+{% set closebutton_label = closebutton.label|default("Close") %}
+
 {% if items %}
-  <div class="{{prefix}}--table-of-contents--wrapper" data-loadcomponent="TableOfContents" data-prefix="{{prefix}}">
-    <div class="{{prefix}}--table-of-contents--trigger">
-      {% include '@components/button/button.twig' with openbutton %}
-    </div>
-    <div class="{{prefix}}--table-of-contents--modal">
-      <h3 class="{{prefix}}--table-of-contents--headline">{{headline}}</h3>
-      {% include '@components/button/button.twig' with closebutton %}
-    </div>
-    <nav class="{{prefix}}--table-of-contents">
-      <ul class="{{prefix}}--table-of-contents--list">
-        {% for item in items %}
-          <li class="{{prefix}}--table-of-contents--list--item">
-            <a class="{{prefix}}--table-of-contents--link" href="{{item.href}}">{{item.label}}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
+	<div class="{{prefix}}--table-of-contents--wrapper" data-loadcomponent="TableOfContents" data-prefix="{{prefix}}">
+		<div class="{{prefix}}--table-of-contents--trigger">
+			{% include '@components/button/button.twig' with {
+				size: openbutton_size,
+				type: openbutton_type,
+				label: openbutton_label,
+				opensmodal: true,
+        className: "toc--modal--open"
+			} %}
+		</div>
+		<div class="{{prefix}}--table-of-contents--modal">
+			<h3 class="{{prefix}}--table-of-contents--headline">{{headline}}</h3>
+			{% include '@components/button/button.twig' with {
+        size: "large",
+        type: "tertiary",
+				label: closebutton_label,
+        icon: {
+          name: "close",
+          size: 24,
+        },
+        iconPos: "center",
+        icononly: true,
+        className: "toc--modal--close"
+      } %}
+		</div>
+		<nav class="{{prefix}}--table-of-contents">
+			<ul class="{{prefix}}--table-of-contents--list">
+				{% for item in items %}
+					<li class="{{prefix}}--table-of-contents--list--item">
+						<a class="{{prefix}}--table-of-contents--link" href="{{item.href}}">{{item.label}}</a>
+					</li>
+				{% endfor %}
+			</ul>
+		</nav>
+	</div>
 {% endif %}

--- a/packages/twig/src/patterns/components/tableofcontents/tableofcontents.twig
+++ b/packages/twig/src/patterns/components/tableofcontents/tableofcontents.twig
@@ -10,16 +10,18 @@
 	<div class="{{prefix}}--table-of-contents--wrapper" data-loadcomponent="TableOfContents" data-prefix="{{prefix}}">
 		<div class="{{prefix}}--table-of-contents--trigger">
 			{% include '@components/button/button.twig' with {
+				prefix: prefix,
 				size: openbutton_size,
 				type: openbutton_type,
 				label: openbutton_label,
 				opensmodal: true,
         className: "toc--modal--open"
-			} %}
+			} only %}
 		</div>
 		<div class="{{prefix}}--table-of-contents--modal">
 			<h3 class="{{prefix}}--table-of-contents--headline">{{headline}}</h3>
 			{% include '@components/button/button.twig' with {
+				prefix: prefix,
         size: "large",
         type: "tertiary",
 				label: closebutton_label,
@@ -30,7 +32,7 @@
         iconPos: "center",
         icononly: true,
         className: "toc--modal--close"
-      } %}
+      } only %}
 		</div>
 		<nav class="{{prefix}}--table-of-contents">
 			<ul class="{{prefix}}--table-of-contents--list">

--- a/packages/twig/src/patterns/components/tableofcontents/tableofcontents.wingsuit.yml
+++ b/packages/twig/src/patterns/components/tableofcontents/tableofcontents.wingsuit.yml
@@ -7,26 +7,18 @@ tableofcontents:
     openbutton:
       type: object
       label: Open Button
-      description: The label and settings for the button that will show the table of contents at small breakpoints
+      description: Settings for the button that will show the table of contents at small breakpoints. Only the `size`, `type` and `label` properties will be passed to the underlying button.
       preview:
         size: "medium"
         type: "secondary"
-        label: "Open Button"
-        className: "toc--modal--open"
-        opensmodal: true
+        label: "Open"
       required: true
     closebutton:
       type: object
       label: Close Button
-      description: Label and settings for the "close" button
+      description: Settings for the button that closes the table of contents at small breakpoints. Only the `label` property will be passed to the underlying button.
       preview:
-        size: "large"
-        type: "tertiary"
-        label: "Close Button"
-        icon: close
-        iconPos: center
-        icononly: true
-        className: "toc--modal--close"
+        label: "Close"
     headline:
       type: string
       label: Headline


### PR DESCRIPTION
This fixes #604 

This was caused by problems stemming from how icons were handled in the Twig package (described in #692). The root issue was eventually resolved in #829, however the Table of Contents still wasn't rendering the close icon in its mobile view correctly. 

There were two reasons for this:

1. The underlying Button component wasn't passing the right properties for the new Icon component
2. The ToC wasn't passing the right properties to the Button component

In fact, the Table of Content component was actually letting the user pass any properties to the Open & Close buttons that they wanted. This was especially problematic given that the Buttons will only work if they have a specific classname. The user shouldn't have to figure out what that classname is or be able to set it arbitrarily.

To correct these issues, the following was done:

1. Refactor the Button so that it passes the correct props to the Icon
2. Refactor the Table of Contents so that it only passes a subset of properties to the underlying Buttons it uses, ensuring they don't break.

### Before

![image](https://github.com/international-labour-organization/designsystem/assets/12401179/f1770ee8-714c-4dfe-b990-c54e134a778f)

### After

<img width="410" alt="image" src="https://github.com/international-labour-organization/designsystem/assets/12401179/db2c4d19-7595-4bfc-acc0-a30810d699f0">

## 🎉 Bonus

This also includes two convenience scripts for preparing the Twig and React packages for development.

`pnpm react:dev:prep` and `pnpm twig:dev:prep` will each perform a clean install of their dependencies and then built the internal packages in the monorepo they rely on so you can simply run `pnpm twig:dev:docs`, for example, to start developing.