### PR TITLE
Fix(themes): add fallbacks for Japanese fonts

### DIFF
--- a/.changeset/nervous-lies-return.md
+++ b/.changeset/nervous-lies-return.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/themes": patch
+---
+
+Add Hiragino Sans and Yu Gothic as fallbacks for Noto Sans CJK JP (Japanese)

--- a/packages/themes/tokens/fonts/base.json
+++ b/packages/themes/tokens/fonts/base.json
@@ -1,10 +1,10 @@
 {
   "fonts": {
     "display": {
-      "value": "Overpass, Noto Sans, Noto Sans CJK JP, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
+      "value": "Overpass, Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
     },
     "copy": {
-      "value": "Noto Sans, Noto Sans CJK JP, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
+      "value": "Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
     }
   }
 }


### PR DESCRIPTION
Add Hiragino Sans and Yu Gothic as fallbacks for Noto Sans CJK JP (Japanese)

Fixes #818 