### PR TITLE
fix(style) - table of contents padding on hover

### DIFF
--- a/.changeset/healthy-badgers-sneeze.md
+++ b/.changeset/healthy-badgers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix table of contents padding on hover

--- a/packages/styles/scss/components/_tableofcontents.scss
+++ b/packages/styles/scss/components/_tableofcontents.scss
@@ -153,6 +153,7 @@
       margin: 0;
       outline: none;
       padding: spacing(4) spacing(4) spacing(4);
+      padding-inline-end: spacing(12);
       width: 100%;
       @include dataurlicon("stemarrow", $color-ux-labels-hover);
       @include globaltransition("background-color, border, color");
@@ -168,6 +169,7 @@
       margin: -2px 0 0 0;
       outline: none;
       padding: spacing(4) spacing(4) spacing(4);
+      padding-inline-end: spacing(12);
       width: 100%;
       @include dataurlicon(
         "stemarrow",


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/847

### Notes :- 

* Currently when table of content is hovered on in small screens the padding changes

### Fix :- 

* Have the padding-inline-end for hover state as well

