### PR TITLE
Deprecated build directory for styles 

### DIFF
--- a/.changeset/shy-frogs-drop.md
+++ b/.changeset/shy-frogs-drop.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": minor
+---
+
+removed legacy build dir

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -11,13 +11,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:legacy": "sass scss:build/css --load-path=./node_modules && postcss build/css/index.css --base/css build/css --dir build/minified && postcss build/css/monorepo.css --base/css build/css --dir build/minified",
-    "build:next": "gulp",
-    "build": "pnpm build:legacy && pnpm build:next",
+    "build": "gulp",
     "build:lib": "pnpm build",
     "build:docs": "pnpm build",
-    "gulp": "gulp",
-    "minify": "postcss build/css/index.css --base/css build/css --dir build/minified && postcss build/css/monorepo.css --base/css build/css --dir build/minified",
     "format": "prettier --check . --ignore-path ../../.prettierignore",
     "format:fix": "prettier --write . --ignore-path ../../.prettierignore",
     "lint": "eslint --ext .js,.ts,.tsx",
@@ -26,7 +22,6 @@
   "author": "@justintemps, @johnpauldavis, @avrilpearl, @ghlost",
   "license": "Apache-2.0",
   "files": [
-    "build",
     "scss",
     "css"
   ],
@@ -36,7 +31,6 @@
     "@ilo-org/themes": "workspace:*"
   },
   "devDependencies": {
-    "cssnano": "^5.1.13",
     "del": "^7.0.0",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.3.0",
@@ -45,8 +39,6 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
-    "postcss": "^8.4.31",
-    "postcss-cli": "^10.0.0",
     "sass": "^1.62.1"
   }
 }

--- a/packages/styles/postcss.config.js
+++ b/packages/styles/postcss.config.js
@@ -1,7 +1,1 @@
-module.exports = {
-  plugins: [
-    require("cssnano")({
-      preset: "default",
-    }),
-  ],
-};
+module.exports = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,9 +467,6 @@ importers:
         specifier: workspace:*
         version: link:../themes
     devDependencies:
-      cssnano:
-        specifier: ^5.1.13
-        version: 5.1.13(postcss@8.4.31)
       del:
         specifier: ^7.0.0
         version: 7.0.0
@@ -494,12 +491,6 @@ importers:
       gulp-sourcemaps:
         specifier: ^3.0.0
         version: 3.0.0
-      postcss:
-        specifier: ^8.4.31
-        version: 8.4.31
-      postcss-cli:
-        specifier: ^10.0.0
-        version: 10.0.0(postcss@8.4.31)
       sass:
         specifier: ^1.62.1
         version: 1.62.1
@@ -17735,11 +17726,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /dependency-graph@0.11.0:
-    resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
-    engines: {node: '>= 0.6.0'}
-    dev: true
-
   /deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
@@ -20901,11 +20887,6 @@ packages:
   /get-stdin@8.0.0:
     resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
     engines: {node: '>=10'}
-    dev: true
-
-  /get-stdin@9.0.0:
-    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
-    engines: {node: '>=12'}
     dev: true
 
   /get-stream@2.3.1:
@@ -30509,30 +30490,6 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-cli@10.0.0(postcss@8.4.31):
-    resolution: {integrity: sha512-Wjy/00wBBEgQqnSToznxLWDnATznokFGXsHtF/3G8glRZpz5KYlfHcBW/VMJmWAeF2x49zjgy4izjM3/Wx1dKA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      chokidar: 3.6.0
-      dependency-graph: 0.11.0
-      fs-extra: 10.1.0
-      get-stdin: 9.0.0
-      globby: 13.2.2
-      picocolors: 1.0.0
-      postcss: 8.4.31
-      postcss-load-config: 4.0.2(postcss@8.4.31)
-      postcss-reporter: 7.1.0(postcss@8.4.31)
-      pretty-hrtime: 1.0.3
-      read-cache: 1.0.0
-      slash: 4.0.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - ts-node
-    dev: true
-
   /postcss-color-functional-notation@4.2.4(postcss@7.0.39):
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
@@ -32085,17 +32042,6 @@ packages:
       lodash: 4.17.21
       log-symbols: 2.2.0
       postcss: 7.0.39
-    dev: true
-
-  /postcss-reporter@7.1.0(postcss@8.4.31):
-    resolution: {integrity: sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      picocolors: 1.0.0
-      postcss: 8.4.31
-      thenby: 1.3.4
     dev: true
 
   /postcss-resolve-nested-selector@0.1.1:
@@ -37431,10 +37377,6 @@ packages:
   /textextensions@5.16.0:
     resolution: {integrity: sha512-7D/r3s6uPZyU//MCYrX6I14nzauDwJ5CxazouuRGNuvSCihW87ufN6VLoROLCrHg6FblLuJrT6N2BVaPVzqElw==}
     engines: {node: '>=0.8'}
-    dev: true
-
-  /thenby@1.3.4:
-    resolution: {integrity: sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==}
     dev: true
 
   /thenify-all@1.6.0:


### PR DESCRIPTION
## Description

This PR removes legacy build tooling for the `@ilo-org/styles` package and makes `build:next` default 

- removed extra packages: `postcss`, `postcss-cli`, `cssnano` those packages are contained inside the gulps implementation
- `postcss` config is not removed, because `gulp-postcss` needs it, but the bare config is enough because `cssnano` is handled by gulpfile 
-  extra unused commands were removed

### Drupal

ILO Drupal website has no dependency on legacy implementation. The styles are mentioned inside `library` and `theme` and both of them are using `css` dir

> ilo.libraries.yml
```yml
global:
  css:
    base:
      dist/css/00-base/base.css: {}
      node_modules/@ilo-org/styles/css/global.css: {}
      node_modules/@ilo-org/styles/css/components/container.css: {}
```

> ilo.theme
```php
function ilo_library_info_build() {
  // Define libraries based on the components.
  $extensions = ['css'];
  $directory = 'themes/custom/ilo/node_modules/@ilo-org/styles/css/components';
  $css = 'node_modules/@ilo-org/styles/css/components';
```
So styles aren't affected at all 

https://github.com/international-labour-organization/designsystem/assets/36326203/8986c839-2bcc-4e96-a2a3-6bbdf85e92c9



