### PR TITLE
fix(twig) - Tabs attributes do not match their roles

### DIFF
--- a/.changeset/nervous-weeks-cross.md
+++ b/.changeset/nervous-weeks-cross.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Fix lighthouse accessibility audit error of tabs attributes not matching their roles

--- a/packages/twig/src/patterns/components/tabs/tabs.twig
+++ b/packages/twig/src/patterns/components/tabs/tabs.twig
@@ -1,6 +1,3 @@
-{#
-  TABS COMPONENT
-#}
 {% set uid = "now"|date('Uv') %}
 {% set tabids = [] %}
 {% for item in items %}
@@ -9,8 +6,8 @@
 <div class="{{prefix}}--tabs" data-prefix="{{prefix}}" id="tabs--{{uid}}" data-loadcomponent="Tabs">
     <ul class="{{prefix}}--tabs--selection" aria-controls="tabs--{{uid}}" role="tablist" style="--tabscount: {{items|length}};">
       {% for item in items %}
-        <li class="{{prefix}}--tabs--selection--item" role="tab">
-          <a href="#tab--{{tabids[loop.index - 1]}}" class="{{prefix}}--tabs--selection--button{% if item.icon is defined %} icon{% endif %}" aria-controls="tab--{{tabids[loop.index - 1]}}" tabindex="0" aria-selected="{% if loop.index == 1 %}true{% else %}false{% endif %}" title="{{item.label}}">
+        <li class="{{prefix}}--tabs--selection--item" role="presentation"> {# changed role to presentation for list item #}
+          <a href="#tab--{{tabids[loop.index - 1]}}" class="{{prefix}}--tabs--selection--button{% if item.icon is defined %} icon{% endif %}" aria-controls="tab--{{tabids[loop.index - 1]}}" role="tab" tabindex="0" {% if loop.index == 1 %}aria-selected="true"{% else %}aria-selected="false"{% endif %} title="{{item.label}}">
             <span class="{{prefix}}--tabs--selection--label">{{item.label}}</span>
             {% if item.icon is defined %}
               {% include '@components/icon/icon.twig' with {icon: item.icon} %}
@@ -21,7 +18,7 @@
     </ul>
     <div class="{{prefix}}--tabs--content">
       {% for item in items %}
-        <div id="tab--{{tabids[loop.index - 1]}}" role="tabpanel" aria-expanded="{% if loop.index == 1 %}true{% else %}false{% endif %}">
+        <div id="tab--{{tabids[loop.index - 1]}}" role="tabpanel" aria-labelledby="tab--{{tabids[loop.index - 1]}}" {% if loop.index == 1 %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %}>
           {% include '@components/' ~ item.component ~ '/' ~ item.component ~ '.twig' with item.componentdata %}
         </div>
       {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/845

### Notes :- 

* Currently the lighthouse accessibility check is throwing an error that mentions [aria-*] attributes do not match their roles in tabs

### Fix :- 

* Assign proper roles and aria attributes for the tabs component

