### PR TITLE
fix(twig/react) - Pagination in RTL

### DIFF
--- a/.changeset/perfect-rules-rescue.md
+++ b/.changeset/perfect-rules-rescue.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Fix design bug in pagination for rtl

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -84,7 +84,8 @@ const Pagination: FC<PaginationProps> = ({
       </div>
 
       <p className={`${baseClass}--page`}>
-        <span>{currentPage + 1}</span> {pageCountPreposition}{" "}
+        <span>{currentPage + 1}</span>
+        <span>{pageCountPreposition}</span>
         <span>{totalPages}</span>
       </p>
 

--- a/packages/styles/scss/components/_pagination.scss
+++ b/packages/styles/scss/components/_pagination.scss
@@ -19,7 +19,6 @@
     height: px-to-rem(40px);
     overflow: hidden;
     position: relative;
-    text-align: left;
     text-indent: -999%;
     width: px-to-rem(40px);
     @include font-styles("label-medium");
@@ -224,11 +223,18 @@
   }
 
   &--page {
+    display: flex;
+    gap: spacing(1);
     @include font-styles("nav-md-sm");
     margin-inline-end: spacing(2);
     font-family: $fonts-copy;
     font-weight: 400;
     line-height: 45px;
+
+    [dir="rtl"] & {
+      margin-inline-end: 0;
+      margin-inline-start: spacing(2);
+    }
   }
 
   &--previous-set,

--- a/packages/twig/src/patterns/components/pagination/pagination.twig
+++ b/packages/twig/src/patterns/components/pagination/pagination.twig
@@ -24,7 +24,8 @@
     {% set currentPageZeroIndex = currentPage * 1 %}
     {% set currentPageIndex = currentPageZeroIndex + 1 %}
 
-    <span>{{currentPageIndex}}</span> {{pageCountPreposition}}
+    <span>{{currentPageIndex}}</span> 
+    <span>{{pageCountPreposition}}</span>
     <span>{{totalPages}}</span>
   </p>
 


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/868

### Notes :- 

* Currently the pagination breaks when we switch to RTL mode. 

### Fix :- 

* Add proper spacing between page count
* Fix RTL text of page count and mirror spacing

### Screenshots :- 

### Before
<img width="354" alt="Screenshot 2024-03-12 at 16 10 12" src="https://github.com/international-labour-organization/designsystem/assets/32934169/f1cd1a69-e4e3-4edb-8c47-e850b68f2ecf">

### After

#### LTR
<img width="346" alt="Screenshot 2024-03-16 at 17 37 07" src="https://github.com/international-labour-organization/designsystem/assets/32934169/2aa4017e-59f2-4156-91c7-ef07ceffd0e8">

#### RTL
<img width="354" alt="Screenshot 2024-03-16 at 17 22 56" src="https://github.com/international-labour-organization/designsystem/assets/32934169/e8331cd9-6073-4762-b7c1-8c8ba1fee6d2">


