### PR TITLE
fix(react) - add paramater layout to storybook

### DIFF
--- a/.changeset/seven-ducks-rescue.md
+++ b/.changeset/seven-ducks-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+Add paramater layout to storybook and remove padding reset

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -8,10 +8,6 @@
     width: 100%;
   }
 
-  body.sb-main-padded.sb-show-main {
-    padding: 0;
-  }
-
   .story-decorator-wrapper {
     display: table;
     text-align: center;

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -1,31 +1,5 @@
 <style>
-  html,
-  body,
-  .story-decorator,
-  .story-decorator-wrapper,
   .story-decorator {
-    height: 100%;
-    width: 100%;
-  }
-
-  .story-decorator-wrapper {
-    display: table;
-    text-align: center;
-    max-width: 958px;
-  }
-
-  .story-decorator-wrapper.full-width-wrapper {
-    display: block;
-    text-align: initial;
-    max-width: 100%;
-  }
-
-  .story-decorator {
-    display: table-cell;
     padding-top: 2rem;
-  }
-
-  .story-decorator * {
-    text-align: initial;
   }
 </style>

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -32,6 +32,7 @@ export const parameters = {
     canvas: { title: "Code", hidden: false },
   },
   viewMode: "docs",
+  layout: "padded",
   docs: {
     theme: theme,
     source: {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/357

### Notes :- 

* Currently there is no padding set in stories and padding is set to 0

### Fix :- 

* Add parameter layout padded
* Remove padding reset to 0

### Screenshots :- 

### Before

<img width="789" alt="Screenshot 2024-03-16 at 18 12 08" src="https://github.com/international-labour-organization/designsystem/assets/32934169/225983be-ffc5-4a94-b2da-383105c66c2c">

### After

<img width="682" alt="Screenshot 2024-03-16 at 18 12 34" src="https://github.com/international-labour-organization/designsystem/assets/32934169/1296f31d-0b84-4d8a-a0f5-597c3eff9f99">

