### PR TITLE
Explicit auto exports

### DIFF
--- a/.changeset/six-bikes-decide.md
+++ b/.changeset/six-bikes-decide.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+commonjs module resolution

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,6 @@
   "license": "Apache-2.0",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
-  "type": "module",
   "types": "lib/types/react/src/index.d.ts",
   "jest": {
     "moduleNameMapper": {

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -27,10 +27,12 @@ const config = {
     {
       dir: "lib/esm",
       format: "esm",
+      exports: "auto",
     },
     {
       dir: "lib/cjs",
       format: "cjs",
+      exports: "auto",
     },
   ],
 };


### PR DESCRIPTION
# Description 

We need to start from the beginning to understand the root of the problem. React package is exported in two types

### Part 1
- CJS: aka `commonjs`  aka nodes in initial module system
```js
module.exports  // "default" export

exports.something // "named" exports
```
- ESM: [ECMA Specification](https://tc39.es/ecma262/#sec-modules), what are modules for Javascript as a language aka *The Correct Way*

```js
export default  // default export

export { something } // named export
 
```
Here is our rollup config
```js
// rollup.config
const config = {
  ...,
  output: [
    {
      dir: "lib/esm",
      format: "esm",
    },
    {
      dir: "lib/cjs",
      format: "cjs",
    },
  ],
}
```

### Part 2
We know our target bundle types, but here is a catch we are writing the ESM in our codebase but rollup has to target both
ESM and CJS. Just imagine the compilation step, rollup is trying to be consistent during the exports so it places the default export under the "default" named object in `CJS` and that's what is throwing the warning. So this PR explicitly tells Rollup that this behavior is known to us.

End we end up with logs like this 

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/7bae6ce1-d573-4a1a-9f88-a646363aebeb)

Will chunk["default"] fail our bundle? No, right now every component has its index file which is named export for commonjs and package json has a path set up for it

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/522c1495-bd97-48bd-b994-130af85d8128)
![image](https://github.com/international-labour-organization/designsystem/assets/36326203/c36f731d-a0d7-431f-9c6e-c8fd0fe73399)

so if you want to import the Video component with common JS you will have to import it like this 

```js
const { Video } = require("@ilo-org/react/components/Video");
```

### Part 3 
If you try to import components with commonjs right now you will get the error like this 

![image](https://github.com/international-labour-organization/designsystem/assets/36326203/c1c23ba2-930c-4bdf-88f9-5be1359fcc55)

Our package json had a [`module` type](https://nodejs.org/api/packages.html#type), which for nodes means that it should be treated as an ESM module, so this PR eliminates it too


### Future 
IMHO after 1.0 we should fully move named exports
