### PR TITLE
fix(style) - Refactor incorrect heading styles in richtext

### DIFF
--- a/.changeset/poor-spiders-juggle.md
+++ b/.changeset/poor-spiders-juggle.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix incorrect heading styles in richtext

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -95,7 +95,7 @@
       "body-small",
       "copy"
     );
-    @include font-styles("rich-text-heading-1");
+    @include font-styles("rich-text-heading-1-md");
   }
 
   h2 {
@@ -107,7 +107,7 @@
       "body-small",
       "copy"
     );
-    @include font-styles("rich-text-heading-2");
+    @include font-styles("rich-text-heading-2-md");
   }
 
   h3 {
@@ -119,7 +119,7 @@
       "body-small",
       "copy"
     );
-    @include font-styles("rich-text-heading-3");
+    @include font-styles("rich-text-heading-3-md");
   }
 
   h4 {
@@ -131,7 +131,7 @@
       "body-small",
       "copy"
     );
-    @include font-styles("rich-text-heading-4");
+    @include font-styles("rich-text-heading-4-md");
   }
 
   h5 {
@@ -143,7 +143,7 @@
       "body-small",
       "copy"
     );
-    @include font-styles("rich-text-heading-5");
+    @include font-styles("rich-text-heading-5-md");
   }
 
   ul,
@@ -249,7 +249,7 @@
         "body-large",
         "copy"
       );
-      @include font-styles("rich-text-heading-1-md");
+      @include font-styles("rich-text-heading-1");
     }
 
     h2 {
@@ -261,7 +261,7 @@
         "body-large",
         "copy"
       );
-      @include font-styles("rich-text-heading-2-md");
+      @include font-styles("rich-text-heading-2");
     }
 
     h3 {
@@ -273,7 +273,7 @@
         "body-large",
         "copy"
       );
-      @include font-styles("rich-text-heading-3-md");
+      @include font-styles("rich-text-heading-3");
     }
 
     h4 {
@@ -285,7 +285,7 @@
         "body-large",
         "copy"
       );
-      @include font-styles("rich-text-heading-4-md");
+      @include font-styles("rich-text-heading-4");
     }
 
     h5 {
@@ -297,7 +297,7 @@
         "body-large",
         "copy"
       );
-      @include font-styles("rich-text-heading-5-md");
+      @include font-styles("rich-text-heading-5");
     }
 
     p {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/381

### Notes :- 

* Currently the heading styles are swapped for mobile and desktop

### Fix

* Add proper heading styling for mobile and desktop

### Screenshot :- 

<img width="989" alt="Screenshot 2024-02-09 at 00 52 38" src="https://github.com/international-labour-organization/designsystem/assets/32934169/b99328f5-3350-49fd-a1e1-0019d9bb6f4d">



