### PR TITLE
fix(style) - refactor link styles in breadcrumb

### DIFF
--- a/.changeset/modern-mugs-lay.md
+++ b/.changeset/modern-mugs-lay.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Add styling to links in breadcrumb

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -24,7 +24,7 @@
 						{% if not loop.first and not loop.last %}
 							<li class="{{prefix}}--breadcrumb--item">
 								<a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
-									<span class="{{prefix}}--breadcrumb--link--label--dropdown">{{link.label}}</span>
+									<span class="{{prefix}}--breadcrumb--link--label--dropdown {{prefix}}--breadcrumb--link--label">{{link.label}}</span>
 								</a>
 							</li>
 						{% endif %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/878

### Notes :- 

* Currently in large devices the breadcrumb items in the middle have a different font style.

### Fix :- 

* Add styling to all the link labels in the breadcrumb


### Before 

![image](https://github.com/international-labour-organization/designsystem/assets/12401179/b0bfeaf3-b78c-4ba0-a207-831d4386f692)

### After

<img width="1696" alt="Screenshot 2024-03-27 at 11 26 35" src="https://github.com/international-labour-organization/designsystem/assets/32934169/5e1e44f4-33d1-4bc5-9f4b-3db6389f9ace">


