### PR TITLE
docs(react) - Make LTR default in storybook

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -76,6 +76,6 @@ export const decorators: Decorator[] = [
 export const globalTypes = {
   rtlDirection: {
     description: "HTML dir attribute",
-    defaultValue: "ltr",
+    defaultValue: false,
   },
 };


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/898

### Notes :- 

* Currently when the react storybook loads up it defaults the direction selected to RTL

### Fix :- 

* Set default value to false to default to LTR

