### PR TITLE
GH-904: fixed the substitution of the prefix

### DIFF
--- a/.changeset/young-elephants-sin.md
+++ b/.changeset/young-elephants-sin.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": minor
+---
+
+Fixed the substitution of the prefix

--- a/packages/twig/README.md
+++ b/packages/twig/README.md
@@ -64,16 +64,10 @@ To build storybook
 pnpm build:storybook
 ```
 
-To build and start storybook
+To build the package for distribution
 
 ```bash
-pnpm build
-```
-
-To build Twigs to be used in a CMS like Drupal (this will output Twigs and necessary JavaScript to a `/dist` folder.)
-
-```bash
-pnpm output
+pnpm build:lib
 ```
 
 This package imports the `prefix` from the `themes` package; to manually import it, run

--- a/packages/twig/copytemplates.js
+++ b/packages/twig/copytemplates.js
@@ -1,57 +1,27 @@
 // This copies twig templates and yml wingsuit files from where Storybook needs them to a more convenient folder for use in a CMS
-const fs = require("fs");
-const path = require("path");
+const fs = require("fs-extra");
+const { globSync } = require("glob");
 const theme = require("@ilo-org/themes/tokens/theme/base.json");
-let buffer = new Buffer.from(`prefix: ${theme.themeprefix.value}`);
-const srcpath = `./src/patterns/components`;
 
-const checkFolder = async (dir) => {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
-  }
-};
-
-const traverseDirectory = (directory) => {
-  let files = fs.readdirSync(directory).filter((file) => {
-    return file !== ".DS_Store";
+const twigFiles = globSync("src/patterns/components/**/*.twig");
+twigFiles.forEach((file) => {
+  const componentName = file.match(/([^\/]+)\.twig$/)[1];
+  fs.readFile(file, "utf8", function (err, filedata) {
+    const formatted = filedata.replace(/{{prefix}}/g, theme.themeprefix.value);
+    fs.ensureDirSync(`dist/components/${componentName}`);
+    fs.writeFileSync(
+      `dist/components/${componentName}/${componentName}.twig`,
+      formatted,
+      "utf8"
+    );
   });
-  for (const f in files) {
-    const file = files[f];
-    const absolute = path.join(directory, file);
-    const ext = path.extname(file).toLowerCase();
-    if (fs.statSync(absolute).isDirectory()) {
-      traverseDirectory(absolute);
-    } else {
-      if (ext === ".twig" || ext === ".yml") {
-        let filepath = directory
-          .replace(`src/`, `dist/`)
-          .replace("patterns/", "")
-          .replace(`/${file}`, "");
-        checkFolder(filepath);
-        fs.readFile(absolute, "utf8", function (err, filedata) {
-          let formatted = filedata.replace(/{{prefix}}/g, buffer);
-          fs.writeFile(
-            `${path
-              .dirname(absolute)
-              .replace(`src/`, `dist/`)
-              .replace("patterns/", "")}/${file}`,
-            formatted,
-            "utf8",
-            function (err) {
-              if (err) return console.log(".writeFile", err);
-            }
-          );
-          if (err) return console.log("readFile", err);
-        });
-      }
-    }
-  }
-};
+});
 
-const copyTemplates = async () => {
-  await checkFolder(`./dist/`);
-  await checkFolder(`./dist/components/`);
-  traverseDirectory(srcpath);
-};
-
-copyTemplates();
+const wingsuitFiles = globSync("src/patterns/components/**/*.yml");
+wingsuitFiles.forEach((file) => {
+  const componentName = file.match(/([^\/]+)\.wingsuit.yml$/)[1];
+  fs.copySync(
+    file,
+    `dist/components/${componentName}/${componentName}.wingsuit.yml`
+  );
+});


### PR DESCRIPTION
Fixes #904 

The prefix in the twig templates was not being substituted correctly as the twig package was built. This PR fixes that and also cleans up the script that copies the files and the README.