### PR TITLE
Fix/Twig: Package Structure

### DIFF
--- a/.changeset/honest-trees-accept.md
+++ b/.changeset/honest-trees-accept.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": minor
+---
+
+fixed dist folder not being published to npm

--- a/.changeset/lemon-dryers-attend.md
+++ b/.changeset/lemon-dryers-attend.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Make sure subcomponents are exported from the same directory as components

--- a/packages/twig/copytemplates.js
+++ b/packages/twig/copytemplates.js
@@ -1,19 +1,36 @@
 // This copies twig templates and yml wingsuit files from where Storybook needs them to a more convenient folder for use in a CMS
 const fs = require("fs-extra");
+const path = require("path");
 const { globSync } = require("glob");
 const theme = require("@ilo-org/themes/tokens/theme/base.json");
 
-const twigFiles = globSync("src/patterns/components/**/*.twig");
-twigFiles.forEach((file) => {
-  const componentName = file.match(/([^\/]+)\.twig$/)[1];
-  fs.readFile(file, "utf8", function (err, filedata) {
-    const formatted = filedata.replace(/{{prefix}}/g, theme.themeprefix.value);
-    fs.ensureDirSync(`dist/components/${componentName}`);
-    fs.writeFileSync(
-      `dist/components/${componentName}/${componentName}.twig`,
-      formatted,
-      "utf8"
-    );
+// Get a list of the component directories in patterns
+const componentDirs = globSync("src/patterns/components/*/");
+
+componentDirs.forEach((dir) => {
+  // Get the name of the component from the dir
+  const componentName = path.basename(dir);
+
+  // Get a list of the twig files inside the dir
+  const twigFiles = globSync(`${dir}/**/*.twig`);
+
+  // For each Twig File
+  twigFiles.forEach((file) => {
+    //Get the name of the Twig file
+    const twigFile = path.basename(file);
+    fs.readFile(file, "utf8", function (err, filedata) {
+      // Substitute the prefix
+      const formatted = filedata
+        .replace(/{{prefix}}/g, theme.themeprefix.value)
+        .replace(/prefix/g, `'${theme.themeprefix.value}'`);
+      // Then write it to the component directory in the dist folder
+      fs.ensureDirSync(`dist/components/${componentName}`);
+      fs.writeFileSync(
+        `dist/components/${componentName}/${twigFile}`,
+        formatted,
+        "utf8"
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Make sure subcomponents are exported from the same directory as components in the build folder.