### PR TITLE
feat(twig-styles): accordion title always in one line

### DIFF
--- a/.changeset/weak-ants-perform.md
+++ b/.changeset/weak-ants-perform.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Truncate the accordion title to show always in one line using css.

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -79,6 +79,13 @@
     [dir="rtl"] & {
       background-position: calc(0% + px-to-rem(6px)) center;
     }
+
+    p {
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
   }
 
   &--panel {

--- a/packages/twig/src/patterns/components/accordion/accordion-item.twig
+++ b/packages/twig/src/patterns/components/accordion/accordion-item.twig
@@ -11,7 +11,7 @@
 <li class="{{prefix}}--accordion--item" id="{{ accordion_id }}">
 	<div class="ilo--h3">
 		<button class="{{prefix}}--accordion--button {{prefix}}--accordion--button--{{ size|default('small') }}" aria-expanded="{{ defaultExpanded }}" aria-controls="{{ panel_id }}" id="{{ button_id }}">
-			{{label}}
+			<p>{{label}}</p>
 		</button>
 	</div>
 	<div class="{{prefix}}--accordion--panel {{ expanded_class }} {{ scroll_class }}" id="{{ panel_id }}" aria-labelledby="{{ button_id }}" role="region" aria-hidden={{defaultExpanded ? 'false' : 'true'}}>


### PR DESCRIPTION
https://zoocha.atlassian.net/browse/ILO-253

This is to amend this requirement: 
`Text always shows in one line. Text truncates according to screen size.` using css and adding the <p> to the button label.


![Screenshot 2024-04-10 at 16 06 49](https://github.com/international-labour-organization/designsystem/assets/28706287/d604c378-1e4d-4809-afc4-feb5c629957c)
