### PR TITLE
fix(style) - reduce sharpness of language switcher button

### DIFF
--- a/.changeset/breezy-dryers-sit.md
+++ b/.changeset/breezy-dryers-sit.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Reduce the sharpness of the edge of the language switcher button as it becomes too sharp during the hover effect

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -595,7 +595,7 @@
 
   &::before {
     background: $brand-ilo-dark-blue;
-    clip-path: polygon(0 0, 100% 0, 100% 100%);
+    clip-path: polygon(0 0, 100% 0, 97% 100%);
     content: "";
     display: block;
     height: 100%;
@@ -605,7 +605,7 @@
     width: 32px;
 
     [dir="rtl"] & {
-      clip-path: polygon(0 0, 0 100%, 100% 0);
+      clip-path: polygon(0 0, 0 100%, 97% 0);
       left: auto;
       right: -31px;
     }


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/929

### Notes :- 

* The corner of the language switcher button looks a bit unaligned with the cut. 

### Fixes :-

* Refactor clipcut to make button edge less sharp

