### PR TITLE
feat(styles): Content tabs titles always in one line

### DIFF
--- a/.changeset/twelve-ducks-look.md
+++ b/.changeset/twelve-ducks-look.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Showing tabs titles always in one line.

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -115,10 +115,10 @@
       }
 
       &--label {
-        max-width: 50ch;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
         padding-top: spacing(1);
       }
 


### PR DESCRIPTION
https://zoocha.atlassian.net/browse/ILO-253

This is to amend this requirement:
Text always shows in one line. Text truncates according to screen size.

![Screenshot 2024-04-11 at 12 46 44](https://github.com/international-labour-organization/designsystem/assets/28706287/7d8f3966-83cb-49e0-8371-ae6c8fcb6998)
