### PR TITLE
Safe Event Listeners

### DIFF
--- a/.changeset/stupid-clocks-pull.md
+++ b/.changeset/stupid-clocks-pull.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+added defensive checks for the modal and navigation components

--- a/packages/twig/src/patterns/components/modal/modal.js
+++ b/packages/twig/src/patterns/components/modal/modal.js
@@ -76,6 +76,8 @@ export default class Modal {
    * @chainable
    */
   enable() {
+    if (!this.OpenButton || !this.CloseButton) return this;
+
     this.OpenButton.addEventListener(EVENTS.CLICK, () =>
       this.OpenButtonHandler()
     );

--- a/packages/twig/src/patterns/components/navigation/navigation.js
+++ b/packages/twig/src/patterns/components/navigation/navigation.js
@@ -213,24 +213,27 @@ export default class Navigation {
       });
     }
 
-    // Click events in the searchBox should not bubble up to the body
-    this.searchBox.addEventListener(
-      EVENTS.CLICK,
-      (ev) => {
-        ev.stopPropagation();
-      },
-      false
-    );
+    if (this.searchBox) {
+      // Click events in the searchBox should not bubble up to the body
+      this.searchBox.addEventListener(
+        EVENTS.CLICK,
+        (ev) => {
+          ev.stopPropagation();
+        },
+        false
+      );
+    }
 
-    // Click events in the subNav should not bubble up to the body
-    this.subNav.addEventListener(
-      EVENTS.CLICK,
-      (ev) => {
-        ev.stopPropagation();
-      },
-      false
-    );
-
+    if (this.subNav) {
+      // Click events in the subNav should not bubble up to the body
+      this.subNav.addEventListener(
+        EVENTS.CLICK,
+        (ev) => {
+          ev.stopPropagation();
+        },
+        false
+      );
+    }
     window.addEventListener(EVENTS.RESIZE, (e) => {
       if (window.innerWidth >= 1024) {
         this.onResize(e);


### PR DESCRIPTION
## Description 

This PR addresses the unsafe event listeners in the modal and navigation components. Those might be issues of `ilo_base_theme`, as mentioned in #931 comment, but, in case of incorrect props or removed dom elements, those event listeners now have a safety net


https://github.com/international-labour-organization/designsystem/assets/36326203/d0a39f31-800f-4aa7-bf63-f8f8ccc10e7d

