### PR TITLE
fix(style) - add appropriate spacing to accordion text

### DIFF
--- a/.changeset/few-lions-join.md
+++ b/.changeset/few-lions-join.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix accordion button text overlapping plus/minus icon

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -16,7 +16,7 @@
     width: 100%;
     margin: 0;
     padding: spacing(4) 0;
-    padding-inline-end: spacing(4);
+    padding-inline-end: spacing(11);
 
     background-color: $color-ux-background-default;
     background-position: calc(100% - px-to-rem(6px)) center;
@@ -38,7 +38,7 @@
     &--large {
       @include font-styles("headline-6");
       padding: spacing(5) 0;
-      padding-inline-end: spacing(4);
+      padding-inline-end: spacing(11);
     }
 
     &:hover,
@@ -64,7 +64,7 @@
       &--large {
         @include font-styles("headline-6");
         padding: spacing(5) 0;
-        padding-inline-end: spacing(4);
+        padding-inline-end: spacing(11);
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/936

### Notes :- 

* Currently in large screens the accordion overflows with the plus icon. 
* Based on investigation the spacing used is also not in sync with the design. 
* The design uses 44px spacing from the end

### Screenshot :- 

Large screen (Large Accordion) :- 

<img width="1009" alt="Screenshot 2024-04-12 at 01 43 38" src="https://github.com/international-labour-organization/designsystem/assets/32934169/57d1b948-e2f1-4875-a69e-227e4cd03f5d">

Small screen (Large Accordion) :-

<img width="1003" alt="Screenshot 2024-04-12 at 01 43 49" src="https://github.com/international-labour-organization/designsystem/assets/32934169/a6e20c0c-b73e-4b4f-9254-cf2dc9795a02">

Large screen (Small Accordion) :- 

<img width="200" alt="Screenshot 2024-04-12 at 01 43 49" src="https://github.com/international-labour-organization/designsystem/assets/32934169/8b296573-3b05-4fff-afff-1924712b4efb">

Small screen (Small Accordion) :-

<img width="200" alt="Screenshot 2024-04-12 at 01 43 49" src="https://github.com/international-labour-organization/designsystem/assets/32934169/60eee646-9b95-4d69-afd7-e53b00750a6d">

### Fix :- 

* Sync with design and add appropriate spacing for padding-inline-end 