### PR TITLE
fix(style) - Increase line height on hyperlink to prevent thickness inconsistency

### DIFF
--- a/.changeset/nice-ducks-design.md
+++ b/.changeset/nice-ducks-design.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix hyperlink underline showing thickness inconsistency on hover

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -244,7 +244,7 @@
   color: map-get($color, "link", "text", "default");
   font-size: inherit;
   font-weight: inherit;
-  line-height: inherit;
+  line-height: 1.7;
   text-decoration: underline;
   text-underline-offset: px-to-rem(6px);
   text-decoration-thickness: px-to-rem(1.5px);


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/935

### Notes :- 

* Currently hyperlinks show an inconsistent underline on hover.

### Screenshot :- 

Before  :- 

<img width="853" alt="Screenshot 2024-04-10 at 15 45 13" src="https://github.com/international-labour-organization/designsystem/assets/22772102/16790f0b-efee-4150-8492-76930de3a561">

After :- 

<img width="967" alt="Screenshot 2024-04-13 at 18 59 41" src="https://github.com/international-labour-organization/designsystem/assets/32934169/68b5a585-c236-4e29-ab8e-6cf45c4bf099">


### Fix :- 

* Increase line height to have more spacing