### PR TITLE
Fix broken hero layouts in mobile

### DIFF
--- a/.changeset/funny-teachers-remember.md
+++ b/.changeset/funny-teachers-remember.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix Hero responsive layout

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -373,10 +373,10 @@
   background: map-get($color, "tooltip", "dark", "background");
   height: $height;
   width: $width;
-
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 
   &::after {
     content: "";

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -84,6 +84,17 @@
     }
   }
 
+  &--breadcrumbs {
+    grid-area: 1 / 1 / 2 / 5;
+    z-index: 1;
+    display: flex;
+    flex-flow: row nowrap;
+
+    &--wrapper {
+      width: 100%;
+    }
+  }
+
   &--card {
     grid-area: 3 / 1 / 5 / 2;
   }
@@ -100,262 +111,254 @@
     }
   }
 
-  --card-width: 625px;
-  --corner-cut-height: #{$spacing-hero-card-corner-cut-height-lg};
-  --breadcrumbs-height: 48px;
-  --image-gap: 240px;
+  @include breakpoint("large") {
+    --card-width: 625px;
+    --corner-cut-height: #{$spacing-hero-card-corner-cut-height-lg};
+    --breadcrumbs-height: 48px;
+    --image-gap: 240px;
 
-  // Defaults to baseline
-  --row-1-lg: var(--breadcrumbs-height);
-  --row-2-lg: calc(var(--image-gap) - var(--breadcrumbs-height));
-  --row-3-lg: auto;
-  --row-4-lg: #{$spacing-hero-tooltip-height};
-  --row-5-lg: 72px;
+    // Defaults to baseline
+    --row-1-lg: var(--breadcrumbs-height);
+    --row-2-lg: calc(var(--image-gap) - var(--breadcrumbs-height));
+    --row-3-lg: auto;
+    --row-4-lg: #{$spacing-hero-tooltip-height};
+    --row-5-lg: 72px;
 
-  --col-1-lg: 0;
-  --col-2-lg: var(--card-width);
-  --col-3-lg: #{$spacing-hero-tooltip-width};
-  --col-4-lg: 1fr;
+    --col-1-lg: 0;
+    --col-2-lg: var(--card-width);
+    --col-3-lg: #{$spacing-hero-tooltip-width};
+    --col-4-lg: 1fr;
 
-  grid-template-rows:
-    var(--row-1-lg)
-    var(--row-2-lg)
-    var(--row-3-lg)
-    var(--row-4-lg);
+    grid-template-rows:
+      var(--row-1-lg)
+      var(--row-2-lg)
+      var(--row-3-lg)
+      var(--row-4-lg);
 
-  grid-template-columns:
-    var(--col-1-lg)
-    var(--col-2-lg)
-    var(--col-3-lg)
-    var(--col-4-lg);
+    grid-template-columns:
+      var(--col-1-lg)
+      var(--col-2-lg)
+      var(--col-3-lg)
+      var(--col-4-lg);
 
-  &__poster-size {
-    &__small {
-      --image-gap: 112px;
-    }
-
-    &__medium {
-      --image-gap: 176px;
-    }
-
-    &__large {
-      --image-gap: 240px;
-    }
-
-    &__xlarge {
-      --image-gap: 527px;
-    }
-  }
-
-  &__card-size {
-    &__small {
-      --card-width: 625px;
-    }
-
-    &__medium {
-      --card-width: 721px;
-    }
-
-    &__large {
-      --card-width: 856px;
-    }
-
-    &__xlarge {
-      --card-width: 920px;
-    }
-
-    &__xxlarge {
-      --card-width: 998px;
-    }
-  }
-
-  &__card-justify {
-    &__start,
-    &__offset {
-      --card-padding-start: #{$squeezy-padding-start};
-      --col-1-lg: #{$card-offset};
-    }
-
-    &__offset {
-      --added-offset: 109px;
-    }
-
-    &__center {
-      --col-1-lg: calc((100% - var(--card-width)) / 2);
-      --col-4-lg: calc(
-        ((100% - var(--card-width)) / 2) - #{$spacing-hero-tooltip-width}
-      );
-    }
-  }
-
-  &__card-align {
-    &__center {
-      --row-4-lg: calc(72px - #{$spacing-hero-tooltip-height});
-      --row-5-lg: #{$spacing-hero-tooltip-height};
-    }
-
-    &__bottom {
-      --row-3-lg: 0;
-      --row-4-lg: var(--corner-cut-height);
-      --row-5-lg: auto;
-    }
-  }
-
-  &__card-background {
-    &__transparent {
-      #{$c}--card-offset {
-        background-color: transparent !important;
-      }
-    }
-  }
-
-  &__card-theme {
-    &__dark {
-      #{$c}--card-offset {
-        background-color: map-get($color, "base", "blue", "dark");
-        position: relative;
-        box-shadow: 0.3px 0 0 0 map-get($color, "base", "blue", "dark");
+    &__poster-size {
+      &__small {
+        --image-gap: 112px;
       }
 
-      &[class*="semi-transparent"] {
+      &__medium {
+        --image-gap: 176px;
+      }
+
+      &__large {
+        --image-gap: 240px;
+      }
+
+      &__xlarge {
+        --image-gap: 527px;
+      }
+    }
+
+    &__card-size {
+      &__small {
+        --card-width: 625px;
+      }
+
+      &__medium {
+        --card-width: 721px;
+      }
+
+      &__large {
+        --card-width: 856px;
+      }
+
+      &__xlarge {
+        --card-width: 920px;
+      }
+
+      &__xxlarge {
+        --card-width: 998px;
+      }
+    }
+
+    &__card-justify {
+      &__start,
+      &__offset {
+        --card-padding-start: #{$squeezy-padding-start};
+        --col-1-lg: #{$card-offset};
+      }
+
+      &__offset {
+        --added-offset: 109px;
+      }
+
+      &__center {
+        --col-1-lg: calc((100% - var(--card-width)) / 2);
+        --col-4-lg: calc(
+          ((100% - var(--card-width)) / 2) - #{$spacing-hero-tooltip-width}
+        );
+      }
+    }
+
+    &__card-align {
+      &__center {
+        --row-4-lg: calc(72px - #{$spacing-hero-tooltip-height});
+        --row-5-lg: #{$spacing-hero-tooltip-height};
+      }
+
+      &__bottom {
+        --row-3-lg: 0;
+        --row-4-lg: var(--corner-cut-height);
+        --row-5-lg: auto;
+      }
+    }
+
+    &__card-background {
+      &__transparent {
         #{$c}--card-offset {
-          background: rgba(
-            map-get($color, "hero", "card", "dark", "background"),
-            $opacity-semi-transparent
-          );
-          box-shadow: 0.3px 0 0 0
-            rgba(
+          background-color: transparent !important;
+          box-shadow: none !important;
+        }
+      }
+    }
+
+    &__card-theme {
+      &__dark {
+        #{$c}--card-offset {
+          background-color: map-get($color, "base", "blue", "dark");
+          position: relative;
+          box-shadow: 0.3px 0 0 0 map-get($color, "base", "blue", "dark");
+        }
+
+        &[class*="semi-transparent"] {
+          #{$c}--card-offset {
+            background: rgba(
               map-get($color, "hero", "card", "dark", "background"),
               $opacity-semi-transparent
             );
+            box-shadow: 0.3px 0 0 0
+              rgba(
+                map-get($color, "hero", "card", "dark", "background"),
+                $opacity-semi-transparent
+              );
+          }
         }
       }
-    }
 
-    &__light {
-      #{$c}--card-offset {
-        background: map-get($color, "hero", "card", "light", "background");
-        box-shadow: 0.3px 0 0 0
-          map-get($color, "hero", "card", "light", "background");
-      }
-
-      &[class*="semi-transparent"] {
+      &__light {
         #{$c}--card-offset {
-          background: rgba(
-            map-get($color, "hero", "card", "light", "background"),
-            $opacity-semi-transparent
-          );
+          background: map-get($color, "hero", "card", "light", "background");
           box-shadow: 0.3px 0 0 0
-            rgba(
+            map-get($color, "hero", "card", "light", "background");
+        }
+
+        &[class*="semi-transparent"] {
+          #{$c}--card-offset {
+            background: rgba(
               map-get($color, "hero", "card", "light", "background"),
               $opacity-semi-transparent
             );
+            box-shadow: 0.3px 0 0 0
+              rgba(
+                map-get($color, "hero", "card", "light", "background"),
+                $opacity-semi-transparent
+              );
+          }
         }
       }
     }
-  }
 
-  &--breadcrumbs {
-    grid-area: 1 / 1 / 2 / 5;
-    z-index: 1;
-    display: flex;
-    flex-flow: row nowrap;
-
-    &--wrapper {
-      width: 100%;
-    }
-  }
-
-  &--background {
-    grid-area: 1 / 1 / 5 / 5;
-
-    #{$c}__card-align__center & {
-      grid-area: 1 / 1 / 6 / 5;
-    }
-
-    #{$c}__card-align__bottom & {
+    &--background {
       grid-area: 1 / 1 / 5 / 5;
-    }
-  }
 
-  &--card-offset {
-    grid-area: 3 / 1 / 6 / 2;
-    z-index: 0;
-    position: relative;
+      #{$c}__card-align__center & {
+        grid-area: 1 / 1 / 6 / 5;
+      }
 
-    #{$c}__card-justify__offset &,
-    #{$c}__card-justify__center & {
-      background: transparent !important;
+      #{$c}__card-align__bottom & {
+        grid-area: 1 / 1 / 5 / 5;
+      }
     }
 
-    #{$c}__card-align__center & {
-      grid-area: 3 / 1 / 4 / 2;
+    &--card-offset {
+      grid-area: 3 / 1 / 6 / 2;
+      z-index: 0;
+      position: relative;
+
+      #{$c}__card-justify__offset &,
+      #{$c}__card-justify__center & {
+        background: transparent !important;
+      }
+
+      #{$c}__card-align__center & {
+        grid-area: 3 / 1 / 4 / 2;
+      }
+
+      #{$c}__card-align__bottom & {
+        grid-area: 4 / 1 / 6 / 2;
+      }
     }
 
-    #{$c}__card-align__bottom & {
-      grid-area: 4 / 1 / 6 / 2;
-    }
-  }
+    &--card {
+      grid-area: 3 / 2 / 6 / 3;
 
-  &--card {
-    grid-area: 3 / 2 / 6 / 3;
+      #{$c}__card-align__center & {
+        grid-area: 3 / 2 / 4 / 3;
+      }
 
-    #{$c}__card-align__center & {
-      grid-area: 3 / 2 / 4 / 3;
-    }
-
-    #{$c}__card-align__bottom & {
-      grid-area: 4 / 2 / 6 / 3;
-    }
-  }
-
-  &--caption {
-    grid-area: 4 / 3 / 5 / 4;
-    position: relative;
-
-    #{$c}__card-align__center & {
-      grid-area: 5 / 1 / 6 / 3;
+      #{$c}__card-align__bottom & {
+        grid-area: 4 / 2 / 6 / 3;
+      }
     }
 
-    #{$c}__card-align__bottom & {
-      grid-area: 4 / 1 / 5 / 2;
-    }
+    &--caption {
+      grid-area: 4 / 3 / 5 / 4;
+      position: relative;
 
-    #{$c}__card-align__center &,
-    #{$c}__card-align__bottom & {
+      #{$c}__card-align__center & {
+        grid-area: 5 / 1 / 6 / 3;
+      }
+
+      #{$c}__card-align__bottom & {
+        grid-area: 4 / 1 / 5 / 2;
+      }
+
+      #{$c}__card-align__center &,
+      #{$c}__card-align__bottom & {
+        &--wrapper {
+          position: absolute;
+          left: 0;
+          bottom: 0;
+        }
+      }
+
+      #{$c}__card-align__bottom#{$c}__card-justify__start & {
+        grid-area: 1 / 1 / 3 / 3;
+      }
+
+      #{$c}__card-align__bottom#{$c}__card-justify__offset & {
+        grid-area: 1 / 2 / 3 / 3;
+      }
+
+      #{$c}__card-align__bottom#{$c}__card-justify__start &,
+      #{$c}__card-align__bottom#{$c}__card-justify__offset & {
+        #{$c}--caption--wrapper {
+          @include caption-icon-wrapper(
+            "right",
+            $spacing-hero-tooltip-width,
+            $spacing-hero-tooltip-height
+          );
+
+          position: absolute;
+          left: 0;
+          right: initial;
+          bottom: 0;
+        }
+      }
+
       &--wrapper {
-        position: absolute;
-        left: 0;
-        bottom: 0;
+        left: 2px;
       }
-    }
-
-    #{$c}__card-align__bottom#{$c}__card-justify__start & {
-      grid-area: 1 / 1 / 3 / 3;
-    }
-
-    #{$c}__card-align__bottom#{$c}__card-justify__offset & {
-      grid-area: 1 / 2 / 3 / 3;
-    }
-
-    #{$c}__card-align__bottom#{$c}__card-justify__start &,
-    #{$c}__card-align__bottom#{$c}__card-justify__offset & {
-      #{$c}--caption--wrapper {
-        @include caption-icon-wrapper(
-          "right",
-          $spacing-hero-tooltip-width,
-          $spacing-hero-tooltip-height
-        );
-
-        position: absolute;
-        left: 0;
-        right: initial;
-        bottom: 0;
-      }
-    }
-
-    &--wrapper {
-      left: 2px;
     }
   }
 
@@ -372,20 +375,22 @@
       }
     }
 
-    &__card-align__bottom {
-      &#{$c}__card-justify__start,
-      &#{$c}__card-justify__offset {
-        #{$c}--caption--wrapper {
-          @include caption-icon-wrapper(
-            "left",
-            $spacing-hero-tooltip-width,
-            $spacing-hero-tooltip-height
-          );
+    @include breakpoint("large") {
+      &__card-align__bottom {
+        &#{$c}__card-justify__start,
+        &#{$c}__card-justify__offset {
+          #{$c}--caption--wrapper {
+            @include caption-icon-wrapper(
+              "left",
+              $spacing-hero-tooltip-width,
+              $spacing-hero-tooltip-height
+            );
 
-          position: absolute;
-          left: initial;
-          right: 0;
-          bottom: 0;
+            position: absolute;
+            left: initial;
+            right: 0;
+            bottom: 0;
+          }
         }
       }
     }


### PR DESCRIPTION
#820 introduced a regression that broke responsive layouts in the Hero component. 

## Before

![image](https://github.com/international-labour-organization/designsystem/assets/12401179/6b59baf6-05f4-4e32-b10b-765f703bb2d2)

This reverts back to the former version of the Hero component and adds a fix for the issue it was intended to solve, making sure the breadcrumb appears correctly in mobile.

## After

<img width="537" alt="image" src="https://github.com/international-labour-organization/designsystem/assets/12401179/be77fbca-92f2-45a6-9360-8793b2eab3c1">