### PR TITLE
fix(style) - make cardgroup grid more responsive

### DIFF
--- a/.changeset/good-seals-add.md
+++ b/.changeset/good-seals-add.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix cards in cardgroups having unequal width based on content

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -22,19 +22,19 @@
 
       &__two {
         #{$c}--inner {
-          grid-template-columns: repeat(2, 1fr);
+          grid-template-columns: repeat(2, minmax(0, 1fr));
         }
       }
 
       &__three {
         #{$c}--inner {
-          grid-template-columns: repeat(3, 1fr);
+          grid-template-columns: repeat(3, minmax(0, 1fr));
         }
       }
 
       &__four {
         #{$c}--inner {
-          grid-template-columns: repeat(4, 1fr);
+          grid-template-columns: repeat(4, minmax(0, 1fr));
         }
       }
     }
@@ -55,6 +55,7 @@
     height: 100%;
     width: 100%;
     max-width: 100%;
+    overflow-wrap: break-word;
   }
 
   &--button-wrap {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/949

### Notes :- 

* Currently cards in card groups do not have the same width and they change bsaed on the content

### Screenshot :- 

Before  :- 

<img width="927" alt="Screenshot 2024-04-17 at 16 43 56" src="https://github.com/international-labour-organization/designsystem/assets/32934169/e02d797f-500c-4c5c-837d-4b976815b529">


After :- 

<img width="925" alt="Screenshot 2024-04-17 at 16 45 14" src="https://github.com/international-labour-organization/designsystem/assets/32934169/1bbf6187-1629-4433-a5e9-a250cdd2caa0">

