### PR TITLE
fix(style) - breadcrumb links not wrapping correctly

### DIFF
--- a/.changeset/sharp-icons-eat.md
+++ b/.changeset/sharp-icons-eat.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Fix long breadcrumb links not wrapping correctly on small devices

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -51,6 +51,7 @@
 
       &--dropdown {
         font-family: $fonts-copy;
+        @include font-styles("body-xxs");
       }
     }
 

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -24,7 +24,7 @@
 						{% if not loop.first and not loop.last %}
 							<li class="{{prefix}}--breadcrumb--item">
 								<a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
-									<span class="{{prefix}}--breadcrumb--link--label--dropdown {{prefix}}--breadcrumb--link--label">{{link.label}}</span>
+									<span class="{{prefix}}--breadcrumb--link--label--dropdown">{{link.label}}</span>
 								</a>
 							</li>
 						{% endif %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/950

### Notes :- 

* Currently the text in breadcrumb links overflow in small devices

* This makes both the fixes compatible https://github.com/international-labour-organization/designsystem/pull/894 and https://github.com/international-labour-organization/designsystem/pull/815

### Screenshot :- 

<img width="979" alt="Screenshot 2024-04-17 at 17 19 05" src="https://github.com/international-labour-organization/designsystem/assets/32934169/079a00ea-b113-4169-9258-f4a19d49b448">

### Fix :- 

* Add text styles to dropdown
* Refactor classnames for labels