### PR TITLE
Fix/styles: tabs on one line

### DIFF
--- a/.changeset/tidy-houses-worry.md
+++ b/.changeset/tidy-houses-worry.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Better solution for keeping tab labels on one line

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -115,14 +115,14 @@
       }
 
       &--label {
-        display: -webkit-box;
-        -webkit-line-clamp: 1;
-        -webkit-box-orient: vertical;
         overflow: hidden;
         padding-top: spacing(1);
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       &--item {
+        overflow: hidden;
         display: block;
         width: 100%;
 


### PR DESCRIPTION
This does the same thing as #939 but with better supported css. It seems like the previous solution used some `-webkit` properties that are not well supported.