### PR TITLE
Fix/Fonts: Arabic font weights

### DIFF
--- a/.changeset/mighty-dancers-study.md
+++ b/.changeset/mighty-dancers-study.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/fonts": patch
+---
+
+Set correct font weight for Arabic bold fonts

--- a/packages/fonts/font-css/fonts-ar.css
+++ b/packages/fonts/font-css/fonts-ar.css
@@ -48,7 +48,7 @@
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.woff2") format("woff2"),
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.woff") format("woff"),
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.ttf") format("truetype");
-  font-weight: normal;
+  font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
@@ -63,7 +63,7 @@
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.woff2") format("woff2"),
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.woff") format("woff"),
     url("../assets/Noto_Sans_Arabic/NotoSansArabic-Bold.ttf") format("truetype");
-  font-weight: normal;
+  font-weight: 700;
   font-style: italic;
   font-display: swap;
 }


### PR DESCRIPTION
Arabic font face declarations were set incorrectly so that bond fonts were being applied even when the font-weight was set to normal. This fixes that by setting the appropriate font-weight value to the bold fonts.

https://www-preview.ilo.org/ar/alraq

<img width="1403" alt="Screenshot 2024-04-17 at 16 59 37" src="https://github.com/international-labour-organization/designsystem/assets/12401179/534d9811-e3c2-4a33-9c41-d3039b502b76">
