### PR TITLE
fix(twig) - use new icon component in tabs

### DIFF
--- a/.changeset/chilly-pants-glow.md
+++ b/.changeset/chilly-pants-glow.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Fix icons not showing in tabs by using the new twig icon component

--- a/.changeset/tidy-ties-work.md
+++ b/.changeset/tidy-ties-work.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+In tabs, make sure long label doesn't cover up icon

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -71,6 +71,7 @@
         font-family: $fonts-display;
         font-weight: 600;
         display: flex;
+        gap: spacing(1);
         height: px-to-rem(60px);
         justify-content: flex-start;
         padding-left: spacing(2);
@@ -88,13 +89,13 @@
         &.icon {
           .ilo--icon {
             height: px-to-rem(16px);
-            margin-right: px-to-rem(5px);
             order: 1;
             width: px-to-rem(16px);
           }
 
           .ilo--tabs--selection--label {
             order: 2;
+            flex: 1 1;
           }
         }
 

--- a/packages/twig/src/patterns/components/tabs/tabs.twig
+++ b/packages/twig/src/patterns/components/tabs/tabs.twig
@@ -10,7 +10,10 @@
           <a href="#tab--{{tabids[loop.index - 1]}}" class="{{prefix}}--tabs--selection--button{% if item.icon is defined %} icon{% endif %}" aria-controls="tab--{{tabids[loop.index - 1]}}" role="tab" tabindex="0" {% if loop.index == 1 %}aria-selected="true"{% else %}aria-selected="false"{% endif %} title="{{item.label}}">
             <span class="{{prefix}}--tabs--selection--label">{{item.label}}</span>
             {% if item.icon is defined %}
-              {% include '@components/icon/icon.twig' with {icon: item.icon} %}
+              {% include '@components/icon/icon.twig' with {
+               name: item.icon,
+               size: '24'
+              } %}
             {% endif %}
           </a>
         </li>

--- a/packages/twig/src/patterns/components/tabs/tabs.wingsuit.yml
+++ b/packages/twig/src/patterns/components/tabs/tabs.wingsuit.yml
@@ -7,9 +7,10 @@ tabs:
     items:
       type: object
       label: Items
-      description: The items and labels for each tab
+      description: The items and labels for each tab. Each item takes a `label` property which gives the tag a name, a `component` property which specifies the kind of component the tab should render, and the `componentdata` which contains the data that will be passed to that component. You can also include an optional `icon` component with the name of the icon to render next to the label.
       preview:
         - label: "Tab Label With A Really Really Lenghty Title Even Though We Do Not Recommend Such A Lengthy Title"
+          icon: "info"
           component: "image"
           componentdata:
             alt: "My alt text"
@@ -33,137 +34,5 @@ tabs:
     default:
       label: Default
       description: the default settings for the Tabs
-    withicon:
-      label: With Icon
-      description: Tabs with Icons
-      fields:
-        items:
-          - label: "Tab One"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab One Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab One tImage"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab One Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab One Image"
-            icon: error
-          - label: "Tab Two"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Two Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Two Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Two Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Two Image"
-            icon: error
-          - label: "Tab Three"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Three Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Three Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Three Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Three Image"
-            icon: error
-    fiveitems:
-      label: Five Items
-      description: Tab component with five items
-      fields:
-        items:
-          - label: "Tab One"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab One Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab One tImage"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab One Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab One Image"
-          - label: "Tab Two"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Two Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Two Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Two Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Two Image"
-          - label: "Tab Three"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Three Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Three Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Three Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Three Image"
-          - label: "Tab Four Has A Really Lenghthy Title Which Might Get Truncated"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Four Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Four Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Four Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Four Image"
-          - label: "Tab Five"
-            component: "image"
-            componentdata:
-              alt: "My alt text"
-              caption: "my image caption"
-              credit: "Photo: copyright 2022 Person S. Name"
-              url:
-                - breakpoint: 0
-                  src: "https://place-hold.it/400x300?text=Tab Five Image"
-                - breakpoint: 800
-                  src: "https://place-hold.it/800x600?text=Tab Five Image"
-                - breakpoint: 1200
-                  src: "https://place-hold.it/1200x900?text=Tab Five Image"
-                - breakpoint: 1440
-                  src: "https://place-hold.it/1600x1200?text=Tab Five Image"
+
   visibility: storybook


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/953

### Notes :- 

* Currently tabs are not showing icons in twig

### Screenshot after fix:- 

<img width="982" alt="Screenshot 2024-04-18 at 01 38 06" src="https://github.com/international-labour-organization/designsystem/assets/32934169/0dd76372-d96b-448a-9f08-29bd9afb02eb">

### Fix :- 

* Added new icon component passing icon name
*  Used sizing given by design