### PR TITLE
docs(react/twig) - move logo grid from brand to media category

### DIFF
--- a/packages/react/src/stories/Logo/Logo.stories.tsx
+++ b/packages/react/src/stories/Logo/Logo.stories.tsx
@@ -18,7 +18,7 @@ import {
 import { brand } from "@ilo-org/themes/tokens/brand/base.json";
 
 const LogoMeta: Meta<typeof Logo> = {
-  title: "Components/Brand/Logo",
+  title: "Components/Media/Logo",
   component: Logo,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/react/src/stories/LogoGrid/LogoGrid.stories.tsx
+++ b/packages/react/src/stories/LogoGrid/LogoGrid.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../components/LogoGrid/LogoGrid.args";
 
 const LogoMeta: Meta<typeof LogoGrid> = {
-  title: "Components/Brand/LogoGrid",
+  title: "Components/Media/LogoGrid",
   component: LogoGrid,
   tags: ["autodocs"],
   parameters: {

--- a/packages/twig/src/patterns/components/logogrid/logogrid.wingsuit.yml
+++ b/packages/twig/src/patterns/components/logogrid/logogrid.wingsuit.yml
@@ -1,5 +1,5 @@
 logogrid:
-  namespace: Components/Brand
+  namespace: Components/Media
   use: "@components/logogrid/logogrid.twig"
   label: Logo Grid
   description: The Logo Grid component renders a series of logos representing a group of organizations. It can be shown on a light or dark background.


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/955

### Notes :- 

* Currently logogrid component is under **brand** category it needs to be moved to **media**

### Screenshot after fix:- 

<img width="1019" alt="Screenshot 2024-04-22 at 01 40 31" src="https://github.com/international-labour-organization/designsystem/assets/32934169/15bdc594-bd66-43a1-b0d5-5d2aadc72019">

