### PR TITLE
Twig/React/Styles: Refactor Breadcrumb

### DIFF
--- a/.changeset/new-wasps-smash.md
+++ b/.changeset/new-wasps-smash.md
@@ -1,6 +1,6 @@
 ---
-"@ilo-org/twig": minor
+"@ilo-org/twig": patch
 "@ilo-org/styles": patch
 ---
 
-Refactors the Breadcrumb Twig template and styles to simplify the implementation and address some accessibility issues. This also removes the `home` field from the Breadcrumb template and instead renders the first item in the list of `links` as the Home button.
+Refactors the Breadcrumb Twig template. The `home` field will soon be deprecated, it will still work, but users should switch to passing in all of the links to the `links` field. The first `link` will be rendered as a house icon. This also fixes several accessibility issues with the Breadcrumb, including adding a `buttonlabel` prop for the context ellipsis that appears when the Breadcrumbs are collapsed.

--- a/.changeset/new-wasps-smash.md
+++ b/.changeset/new-wasps-smash.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/twig": minor
+"@ilo-org/styles": patch
+---
+
+Refactors the Breadcrumb Twig template and styles to simplify the implementation and address some accessibility issues. This also removes the `home` field from the Breadcrumb template and instead renders the first item in the list of `links` as the Home button.

--- a/.changeset/silly-pumas-smoke.md
+++ b/.changeset/silly-pumas-smoke.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": minor
+"@ilo-org/twig": minor
+---
+
+Change Context Menu from an unordered to an ordered list

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -339,18 +339,33 @@
 @mixin cornercut(
   $width: $spacing-padding-8,
   $height: $spacing-padding-5,
-  $dir: "right"
+  $dir: "right",
+  $side: "top"
 ) {
-  clip-path: polygon(
-    0 0,
-    calc(100% - $width) 0,
-    100% $height,
-    100% 100%,
-    0 100%
-  );
+  @if ($side == "top") {
+    @if ($dir == "right") {
+      clip-path: polygon(
+        0 0,
+        calc(100% - $width) 0,
+        100% $height,
+        100% 100%,
+        0 100%
+      );
+    }
 
-  @if ($dir == "left") {
-    clip-path: polygon($width 0, 100% 0, 100% 100%, 0 100%, 0 $height);
+    @if ($dir == "left") {
+      clip-path: polygon($width 0, 100% 0, 100% 100%, 0 100%, 0 $height);
+    }
+  }
+
+  @if ($side == "bottom") {
+    @if ($dir == "right") {
+      clip-path: polygon(0 0, 100% 0, calc(100% - $width) $height, 0 100%);
+    }
+
+    @if ($dir == "left") {
+      clip-path: polygon(0 0, 100% 0, 100% $height, $width 100%);
+    }
   }
 }
 

--- a/packages/styles/scss/components/_breadcrumb.scss
+++ b/packages/styles/scss/components/_breadcrumb.scss
@@ -2,68 +2,94 @@
 @use "../functions" as *;
 @use "../animations" as *;
 @import "../mixins";
+@import "../config";
 
-.ilo--breadcrumb {
+.#{$prefix}--breadcrumb {
+  $breadcrumb: &;
+
   position: relative;
+  display: inline-block;
   z-index: 10;
 
-  &--items {
-    align-items: center;
-    background-color: $color-base-neutrals-white;
+  &--inner {
     display: inline-flex;
-    justify-content: flex-start;
-    padding-block: spacing(4);
-    padding-inline-end: 0;
+    // Local variable set in the Hero for alignment
     padding-inline-start: var(--breadcrumb-padding);
-    position: relative;
-    &.context--menu {
-      padding: 0;
+    padding-inline-end: spacing(12);
+    padding-block: spacing(4);
+    background-color: $color-base-neutrals-white;
+    @include cornercut(spacing(12), 100%, "right", "bottom");
+
+    [dir="rtl"] & {
+      @include cornercut(spacing(12), 100%, "left", "bottom");
     }
   }
 
-  &--link {
+  &--items,
+  &--context {
     align-items: center;
-    background-position: right;
-    background-repeat: no-repeat;
-    color: map-get($color, "link", "text", "default");
     display: inline-flex;
-    height: px-to-rem(16px);
-    padding-block: 0;
-    padding-inline-start: spacing(4);
-    padding-inline-end: spacing(6);
-    text-decoration: none;
-    text-decoration-thickness: px-to-rem($borders-base);
+    justify-content: flex-start;
+    list-style: none;
+  }
+
+  &--item,
+  &--context__collapse {
+    background-repeat: no-repeat;
     @include dataurlicon("breadcrumbdivider", $color-link-text-default);
+    background-position: left;
+    padding-inline: spacing(6) spacing(4);
 
     [dir="rtl"] & {
-      background-position: left;
+      background-position: right;
+      background-repeat: no-repeat;
       @include dataurlicon("breadcrumbdividerrtl", $color-link-text-default);
     }
+  }
 
-    &--label {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 40ch;
-      font-family: $fonts-copy;
-      font-weight: 400;
-      @include font-styles("body-xxs");
+  &--context {
+    $context: &;
+    position: relative;
 
-      &--dropdown {
-        font-family: $fonts-copy;
-        @include font-styles("body-xxs");
+    &--button {
+      display: none;
+      padding: 0;
+      margin: 0;
+      border: none;
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: 16px 4px;
+      position: relative;
+      width: px-to-rem(42px);
+      height: px-to-rem(16px);
+      @include dataurlicon("elipsis", $color-link-text-default);
+
+      &:hover {
+        cursor: pointer;
+        @include dataurlicon("elipsis", $color-base-blue-medium);
       }
     }
 
-    &:hover,
-    &:focus {
-      color: map-get($color, "link", "text", "hover");
-      text-decoration: underline;
-      text-decoration-thickness: px-to-rem($borders-base);
-      @include dataurlicon("breadcrumbdivider", $color-link-text-hover);
+    &--menu {
+      display: none;
+      position: fixed;
+      width: px-to-rem(120px);
+      z-index: 10;
 
-      [dir="rtl"] & {
-        @include dataurlicon("breadcrumbdividerrtl", $color-link-text-hover);
+      &__visible {
+        display: inline-block;
+      }
+    }
+
+    &__collapse {
+      padding-inline: spacing(3) spacing(1);
+
+      #{$breadcrumb}--items {
+        display: none;
+      }
+
+      #{$context}--button {
+        display: inline-block;
       }
     }
   }
@@ -71,19 +97,32 @@
   &--item {
     align-items: center;
     display: flex;
-    height: px-to-rem(16px);
 
-    &.home {
+    &__first {
       align-items: center;
       display: flex;
       position: relative;
+      // Make sure arrow doesn't appear before house even in RTL
+      background: none !important;
+      // Make sure the outline is visible when focused
+      padding-inline-start: 2px;
 
-      .ilo--breadcrumb--link {
-        &--label {
-          @include isVisuallyHidden();
+      &:hover,
+      &:focus {
+        #{$breadcrumb}--link {
+          &:after {
+            @include dataurlicon("home", $color-link-text-hover);
+          }
         }
+      }
 
-        &:before {
+      #{$breadcrumb}--link {
+        background: none;
+        width: px-to-rem(16px);
+        height: px-to-rem(16px);
+        position: relative;
+
+        &:after {
           background-position: center center;
           background-repeat: no-repeat;
           content: "";
@@ -95,207 +134,34 @@
           width: px-to-rem(16px);
           @include dataurlicon("home", $color-link-text-default);
         }
-
-        [dir="rtl"] & {
-          &:before {
-            left: initial;
-            right: 0;
-          }
-        }
       }
+    }
+  }
+
+  &--link {
+    display: inline-flex;
+    align-items: center;
+    color: $color-link-text-default;
+    height: px-to-rem(16px);
+    padding-block: 0;
+    text-decoration: none;
+
+    &--label {
+      white-space: nowrap;
+      overflow-x: clip;
+      text-overflow: ellipsis;
+      max-width: 30ch;
+      font-family: $fonts-copy;
+      font-weight: 400;
+      @include font-styles("body-xxs");
 
       &:hover,
       &:focus {
-        .ilo--breadcrumb--link {
-          &:before {
-            @include dataurlicon("home", $color-link-text-hover);
-          }
-        }
+        color: $color-link-text-hover;
+        text-decoration: underline;
+        text-underline-offset: px-to-rem(4px);
+        text-decoration-thickness: px-to-rem(2px);
       }
     }
-
-    &.final {
-      .ilo--breadcrumb--link {
-        background-image: none;
-      }
-    }
-  }
-
-  .ilo--breadcrumb--item--context {
-    align-items: flex-start;
-    display: flex;
-    height: px-to-rem(16px);
-  }
-
-  &.contextmenu {
-    .ilo--breadcrumb--item--context {
-      background-position: center center;
-      background-repeat: no-repeat;
-      background-size: 16px 4px;
-      position: relative;
-      width: px-to-rem(42px);
-      @include dataurlicon("elipsis", $color-link-text-default);
-
-      &:hover {
-        cursor: pointer;
-        @include dataurlicon("elipsis", $color-base-blue-medium);
-      }
-
-      &:after {
-        background-position: center center;
-        background-repeat: no-repeat;
-        content: "";
-        display: block;
-        height: px-to-rem(16px);
-        right: -7px;
-        position: absolute;
-        top: 0;
-        width: px-to-rem(16px);
-        @include dataurlicon("breadcrumbdivider", $color-link-text-default);
-
-        [dir="rtl"] & {
-          right: auto;
-          left: -7px;
-          @include dataurlicon(
-            "breadcrumbdividerrtl",
-            $color-link-text-default
-          );
-        }
-      }
-
-      .context--menu {
-        border-radius: px-to-rem(2px);
-        background-color: $color-ux-background-highlight;
-        display: inline-block;
-        left: px-to-rem(-40px);
-        opacity: 0;
-        position: absolute;
-        top: calc(100% + 24px);
-        width: px-to-rem(120px);
-        z-index: 10;
-        @include globaltransition("opacity");
-
-        &.open {
-          opacity: 1;
-          @include globaltransition("opacity");
-        }
-
-        &:before {
-          background-position: top center;
-          background-repeat: no-repeat;
-          background-size: contain;
-          @include dataurlicon(
-            "halfsquaretriangle",
-            $color-ux-background-highlight
-          );
-          content: "";
-          height: px-to-rem(12px);
-          position: absolute;
-          left: 50%;
-          top: -#{px-to-rem(6px)};
-          transform: translateX(-50%) rotate(135deg);
-          width: px-to-rem(12px);
-        }
-
-        &:hover {
-          cursor: pointer;
-        }
-
-        .ilo--breadcrumb--item {
-          display: inline-block;
-          height: auto;
-          padding: 0 spacing(2);
-          position: relative;
-          width: 100%;
-
-          &:last-of-type a {
-            border-bottom: none;
-          }
-
-          &:hover,
-          &:focus {
-            background-color: $color-base-blue-light;
-            text-decoration: none;
-
-            .ilo--breadcrumb--link {
-              text-decoration: underline;
-              text-decoration-thickness: px-to-rem($borders-base);
-            }
-          }
-
-          &.endsection {
-            border-bottom: px-to-rem($borders-base) solid
-              $color-base-neutrals-white;
-
-            .ilo--context-menu--link {
-              border-bottom: none;
-            }
-          }
-        }
-
-        .ilo--breadcrumb--link {
-          background: none;
-          border-bottom: px-to-rem($borders-base) solid
-            $color-base-neutrals-white;
-          color: map-get($color, "link", "text", "default");
-          display: inline-block;
-          font-family: $fonts-copy;
-          font-weight: map-get($type, "weights", "section");
-          height: auto;
-          padding: spacing(4) 0;
-          text-decoration: none;
-          width: 100%;
-          @include font-styles("body-xxs");
-
-          &:visited {
-            color: map-get($color, "link", "text", "default");
-          }
-
-          &:active {
-            color: map-get($color, "link", "text", "active");
-            outline: none;
-          }
-
-          &:hover,
-          &:focus {
-            color: map-get($color, "link", "text", "hover");
-            outline: none;
-            text-decoration: underline;
-            text-decoration-thickness: px-to-rem($borders-base);
-          }
-        }
-      }
-    }
-  }
-
-  &--items {
-    &:after {
-      background: linear-gradient(to bottom right, white 50%, transparent 50%);
-      content: "";
-      display: inline-block;
-      height: 47px;
-      position: absolute;
-      right: -47px;
-      top: 0;
-      width: 47px;
-
-      [dir="rtl"] & {
-        right: auto;
-        left: -47px;
-        transform: scaleX(-1);
-      }
-    }
-
-    &.context--menu {
-      &:after {
-        content: none;
-      }
-    }
-  }
-
-  // @TODO: This shouldn't be here, we should handle this through Storybook configuation
-  &.storybook {
-    background-color: $brand-ilo-grey-ui;
-    height: 100vh;
   }
 }

--- a/packages/styles/scss/components/_contextmenu.scss
+++ b/packages/styles/scss/components/_contextmenu.scss
@@ -8,6 +8,7 @@
   display: inline-block;
   position: relative;
   width: auto;
+  list-style: none;
 
   &:before {
     background-position: top center;

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.js
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.js
@@ -45,12 +45,35 @@ export default class Breadcrumb {
    * @chainable
    */
   cacheDomReferences() {
-    this.breadcrumbs = this.element.querySelector(".ilo--breadcrumb--items");
-    this.breadcrumbwidth = this.breadcrumbs.offsetWidth;
-    this.ContextButton = this.element.querySelector(
-      `.${this.prefix}--breadcrumb--item--context`
+    // Store references to classnames
+    this.breadcrumbsId = `${this.prefix}--breadcrumb--container`;
+    this.contextAreaClass = `${this.prefix}--breadcrumb--context`;
+    this.contextMenuItemsClass = `${this.prefix}--context-menu`;
+    this.contextCollapseClass = `${this.contextAreaClass}__collapse`;
+    this.contextButtonClass = `${this.contextAreaClass}--button`;
+    this.contextMenuClass = `${this.contextAreaClass}--menu`;
+    this.contextMenuVisibleClass = `${this.contextMenuClass}__visible`;
+
+    // Store reference to DOM elements
+    this.breadcrumbs = this.element.querySelector(`#${this.breadcrumbsId}`);
+    this.contextArea = this.element.querySelector(`.${this.contextAreaClass}`);
+    this.contextMenu = this.element.querySelector(`.${this.contextMenuClass}`);
+    this.contextButton = this.element.querySelector(
+      `.${this.contextButtonClass}`
     );
-    this.ContextMenu = this.element.querySelector(`.context--menu`);
+    this.breadcrumbsLastLink = this.element.querySelector(
+      `#${this.breadcrumbsId} > li:last-child a`
+    );
+    this.contextMenuItems = this.element.querySelector(
+      `.${this.contextMenuItemsClass}`
+    );
+    this.contextMenuItemFirstLink =
+      this.contextMenuItems.querySelector("li:first-child a");
+    this.contextMenuItemLastLink =
+      this.contextMenuItems.querySelector("li:last-child a");
+
+    // Store a reference to the breadcrumbs width so we know when to uncollapse them
+    this.breadcrumbsWidth = this.breadcrumbs.offsetWidth;
 
     return this;
   }
@@ -64,42 +87,37 @@ export default class Breadcrumb {
   setupHandlers() {
     this.onResize = this.onResize.bind(this);
     this.onClick = this.onClick.bind(this);
+    this.contexMenuIsOpen = this.contexMenuIsOpen.bind(this);
+    this.openContextMenu = this.openContextMenu.bind(this);
+    this.closeContextMenu = this.closeContextMenu.bind(this);
+    this.focusBreadcrumbsLastLink = this.focusBreadcrumbsLastLink.bind(this);
+    this.focusContextMenuItemFirstLink =
+      this.focusContextMenuItemFirstLink.bind(this);
+    this.onKeydown = this.onKeydown.bind(this);
 
     return this;
   }
 
   /**
-   * Creates event listeners to enable interaction with view
+   * Adds event listeners to enable interaction with view
    *
    * @return {Object} Breadcrumb A reference to the instance of the class
    * @chainable
    */
   enable() {
+    // Handle resizing events
     window.addEventListener(EVENTS.RESIZE, (e) => this.onResize(e));
-    if (this.ContextButton) {
-      this.ContextButton.addEventListener(EVENTS.CLICK, () => this.onClick());
-    }
 
-    return this;
-  }
+    if (this.contextButton) {
+      // When the context button gets clicked
+      this.contextButton.addEventListener(EVENTS.CLICK, (e) => this.onClick(e));
 
-  /**
-   * onResize interaction with the accordion button
-   *
-   * @return {Object} Breadcrumb A reference to the instance of the class
-   * @chainable
-   */
-  onResize() {
-    if (this.ContextMenu) {
-      if (this.breadcrumbwidth > this.element.offsetWidth / 2) {
-        this.element.classList.add("contextmenu");
-        this.ContextMenu.classList.remove("open");
-      } else {
-        this.element.classList.remove("contextmenu");
-        this.ContextMenu.classList.remove("open");
-      }
+      // We only need the keydown handler to manage tab navigation when the
+      // context menu is visible
+      this.element.addEventListener("keydown", (e) => this.onKeydown(e));
+
+      return this;
     }
-    return this;
   }
 
   /**
@@ -108,15 +126,151 @@ export default class Breadcrumb {
    * @return {Object} Breadcrumb A reference to the instance of the class
    * @chainable
    */
-  onClick() {
-    if (this.ContextMenu) {
-      if (this.ContextMenu.classList.contains("open")) {
-        this.ContextMenu.classList.remove("open");
+  onClick(e) {
+    e.stopPropagation();
+    if (this.contexMenuIsOpen()) {
+      this.closeContextMenu();
+    } else {
+      this.openContextMenu();
+      // Add an event listener to close the context menu if the user clicks outside of it
+      window.addEventListener("click", this.closeContextMenu, { once: true });
+    }
+    return this;
+  }
+
+  /**
+   * onResize interaction
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  onResize() {
+    if (this.contextArea && this.breadcrumbsWidth) {
+      if (this.breadcrumbsWidth >= window.innerWidth / 1.5) {
+        this.contextArea.classList.add(this.contextCollapseClass);
       } else {
-        this.ContextMenu.classList.add("open");
+        this.contextArea.classList.remove(this.contextCollapseClass);
+        this.closeContextMenu();
+      }
+    }
+    return this;
+  }
+
+  /**
+   * onKeydown interaction for tab navigation
+   *
+   * @param {*} e keydown event
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  onKeydown(e) {
+    // Back navigation using the shift key
+    if (e.shiftKey) {
+      if (e.key.toLowerCase() === "tab") {
+        // If the first context menu item is selected, tabbing back
+        // should select the context button
+        if (document.activeElement === this.contextMenuItemFirstLink) {
+          e.preventDefault();
+          this.contextButton.focus();
+        }
+      }
+      return this;
+    }
+
+    // When using tab navigation
+    if (e.key.toLowerCase() === "tab") {
+      // If the context menu is open...
+      const contexMenuIsOpen = this.contexMenuIsOpen();
+      // If the context button is focused then the next focusable item
+      // should be the first item in the context menu
+      if (contexMenuIsOpen) {
+        if (document.activeElement === this.contextButton) {
+          e.preventDefault();
+          this.focusContextMenuItemFirstLink();
+        }
+
+        // If the last context menu item is focused then the next focusable
+        // item should be the last breadcrumb item
+        if (document.activeElement === this.contextMenuItemLastLink) {
+          e.preventDefault();
+          this.focusBreadcrumbsLastLink();
+          this.closeContextMenu();
+        }
       }
     }
 
+    return this;
+  }
+
+  /**
+   * Position the context menu directly beneath the button
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  positionContextMenu() {
+    const buttonRect = this.contextButton.getBoundingClientRect();
+    const buttonCenterX = buttonRect.left + buttonRect.width / 2;
+    const contextMenuWidth = this.contextMenu.offsetWidth;
+    const navStart = buttonCenterX - contextMenuWidth / 2;
+    const navTop = buttonRect.bottom + 16;
+    this.contextMenu.style.left = navStart + "px";
+    this.contextMenu.style.top = navTop + "px";
+    return this;
+  }
+
+  /**
+   * Open the Context menu
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  openContextMenu() {
+    this.contextMenu.classList.add(this.contextMenuVisibleClass);
+    this.contextButton.setAttribute("aria-expanded", "true");
+    this.positionContextMenu();
+    return this;
+  }
+
+  /**
+   * Close the Context menu
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  closeContextMenu() {
+    this.contextMenu.classList.remove(this.contextMenuVisibleClass);
+    this.contextButton.setAttribute("aria-expanded", "false");
+  }
+
+  /**
+   * Check to see whether the Context menu is open
+   *
+   * @returns boolean
+   */
+  contexMenuIsOpen() {
+    return this.contextMenu.classList.contains(this.contextMenuVisibleClass);
+  }
+
+  /**
+   * Focuses first link in the Context Menu
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  focusContextMenuItemFirstLink() {
+    this.contextMenuItemFirstLink.focus();
+    return this;
+  }
+
+  /**
+   * Focuses last item of the Breadcrumbs
+   *
+   * @return {Object} Breadcrumb A reference to the instance of the class
+   * @chainable
+   */
+  focusBreadcrumbsLastLink() {
+    this.breadcrumbsLastLink.focus();
     return this;
   }
 }

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -33,7 +33,7 @@
 							</li>
 						{% endfor %}
 					</ol>
-					<button aria-label="{{buttonlabel|default('Toggle links')}}" aria-expanded="false" controls="{{prefix}}--breadcrumb--menu" class="{{prefix}}--breadcrumb--context--button"></button>
+					<button aria-label="{{buttonlabel|default('More links')}}" aria-expanded="false" controls="{{prefix}}--breadcrumb--menu" class="{{prefix}}--breadcrumb--context--button"></button>
 				</li>
 			{% endif %}
 			{# Render the last one outside the context area #}

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.twig
@@ -1,43 +1,55 @@
-{#
-  BREADCRUMB COMPONENT
-#}
+{# breadcrumb.twig #}
+
+{# If a home field is passed, it will be used as the first link #}
+{# THE `HOME` FIELD WILL BE DEPRECATED IN FUTURE VERSIONS AND SHOULD NOT BE USED #}
+{% if home %}
+	{% set firstlink = home %}
+	{% set contextLinks = links|slice(0, items|length - 1) %}
+{% endif %}
+
+{% if not home %}
+	{% set firstlink = links|first %}
+	{% set contextLinks = links|slice(1, items|length - 1) %}
+{% endif %}
+
 {% set lastlink = links|last %}
-{% set firstlink = links|first %}
-<nav class="{{prefix}}--breadcrumb{% if className %} {{className}}{% endif %}" data-prefix="{{prefix}}" data-loadcomponent="Breadcrumb">
-	<ol class="{{prefix}}--breadcrumb--items">
-		<li class="{{prefix}}--breadcrumb--item home">
-			<a class="{{prefix}}--breadcrumb--link" href="{{home.url}}">
-				<span class="{{prefix}}--breadcrumb--link--label">{{home.label}}</span>
-			</a>
-		</li>
-		{% if links|length >= 2 %}
-			<li class="{{prefix}}--breadcrumb--item first">
-				<a class="{{prefix}}--breadcrumb--link" href="{{firstlink.url}}">
-					<span class="{{prefix}}--breadcrumb--link--label">{{firstlink.label}}</span>
-				</a>
+
+<nav class="{{prefix}}--breadcrumb {% if className %}{{className}}{% endif %}" data-prefix="{{prefix}}" data-loadcomponent="Breadcrumb">
+	<div class="{{prefix}}--breadcrumb--inner">
+		<ol class="{{prefix}}--breadcrumb--items" id="{{prefix}}--breadcrumb--container">
+			{# Render the first link on its own as a custom icon #}
+			<li class="{{prefix}}--breadcrumb--item {{prefix}}--breadcrumb--item__first">
+				<a aria-label="{{firstlink.label}}" class="{{prefix}}--breadcrumb--link" href="{{firstlink.url}}}"></a>
 			</li>
-		{% endif %}
-		{% if links|length >= 3%}
-			<li class="{{prefix}}--breadcrumb--item--context">
-				<ul class="{{prefix}}--breadcrumb--items context--menu">
-					{% for link in links %}
-						{% if not loop.first and not loop.last %}
+			{# Render all but the first and last items in the context area #}
+			{% if contextLinks|length > 0 %}
+				<li class="{{prefix}}--breadcrumb--context">
+					<ol class="{{prefix}}--breadcrumb--items">
+						{% for link in contextLinks %}
 							<li class="{{prefix}}--breadcrumb--item">
 								<a href="{{link.url}}" class="{{prefix}}--breadcrumb--link">
-									<span class="{{prefix}}--breadcrumb--link--label--dropdown">{{link.label}}</span>
+									<span class="{{prefix}}--breadcrumb--link--label">{{link.label}}</span>
 								</a>
 							</li>
-						{% endif %}
-					{% endfor %}
-				</ul>
-			</li>
-		{% endif %}
-		{% if links|length >= 1%}
-			<li class="{{prefix}}--breadcrumb--item final">
-				<a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
-					<span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
-				</a>
-			</li>
-		{% endif %}
-	</ol>
+						{% endfor %}
+					</ol>
+					<button aria-label="{{buttonlabel|default('Toggle links')}}" aria-expanded="false" controls="{{prefix}}--breadcrumb--menu" class="{{prefix}}--breadcrumb--context--button"></button>
+				</li>
+			{% endif %}
+			{# Render the last one outside the context area #}
+			{% if links|length > 1 %}
+				<li class="{{prefix}}--breadcrumb--item">
+					<a class="{{prefix}}--breadcrumb--link" href="{{lastlink.url}}">
+						<span class="{{prefix}}--breadcrumb--link--label">{{lastlink.label}}</span>
+					</a>
+				</li>
+			{% endif %}
+		</ol>
+	</div>
+	<div class="{{prefix}}--breadcrumb--context--menu" id="{{prefix}}--breadcrumb--menu">
+		{% include '@components/contextmenu/contextmenu.twig' with {
+			links: contextLinks,
+			prefix: prefix
+		} only %}
+	</div>
 </nav>

--- a/packages/twig/src/patterns/components/breadcrumb/breadcrumb.wingsuit.yml
+++ b/packages/twig/src/patterns/components/breadcrumb/breadcrumb.wingsuit.yml
@@ -4,14 +4,13 @@ breadcrumb:
   label: Breadcrumb
   description: A component for displaying links in a "breadcrumb" ux
   fields:
-    home:
-      type: object
-      label: Home
-      description: url and label for link to site home page
-      required: true
-      preview:
-        label: "Home"
-        url: "/"
+    buttonlabel:
+      type: string
+      label: buttonlabel
+      description: The `aria-label` value for the button that toggles the context menu when the Breadcrumbs are collapsed
+      required: false
+      default: "Toggle links"
+      preview: "Toggle links"
     links:
       type: object
       label: Home

--- a/packages/twig/src/patterns/components/contextmenu/contextmenu.twig
+++ b/packages/twig/src/patterns/components/contextmenu/contextmenu.twig
@@ -1,12 +1,12 @@
 {#
   CONTEXT MENU COMPONENT
 #}
-<ul class="{{prefix}}--context-menu">
-  {% for link in links %}
-  <li class="{{prefix}}--context-menu--item{% if link.endsection == 'true' %} endsection{% endif %}">
-    <a href="{{link.url}}" class="{{prefix}}--context-menu--link">
-      <span class="{{prefix}}--context-menu--label">{{link.label}}</span>
-    </a>
-  </li>
-  {% endfor %}
-</ul>
+<ol class="{{prefix}}--context-menu">
+	{% for link in links %}
+		<li class="{{prefix}}--context-menu--item{% if link.endsection == 'true' %} endsection{% endif %}">
+			<a href="{{link.url}}" class="{{prefix}}--context-menu--link">
+				<span class="{{prefix}}--context-menu--label">{{link.label}}</span>
+			</a>
+		</li>
+	{% endfor %}
+</ol>


### PR DESCRIPTION
I set out to fix #972 while at the same time contributing to #971 and cleaning up the CSS. I ended up doing a complete refactor of the both the Twig and SCSS component. It also solves an accessibility issue wherein that were supposed to be hidden in the context menu were still clickable and accessible via tab navigation

I'll finish this up tomorrow and implement in React as well. In the meantime, comments welcome.