### PR TITLE
fix(style) - refactor padding inside accordion panel

### DIFF
--- a/.changeset/hot-avocados-appear.md
+++ b/.changeset/hot-avocados-appear.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix accordion text moving inside panel when it is expanding by having constant padding when it is both closed and open

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -91,6 +91,7 @@
     .ilo--accordion--innerpanel {
       padding-bottom: spacing(9);
       padding-top: spacing(2);
+      padding-inline-end: spacing(8);
     }
 
     &--open {
@@ -100,7 +101,6 @@
       &#{$panel}__scroll {
         max-height: $scroll-max-height;
         overflow-y: auto;
-        padding-right: spacing(8);
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/981

### Notes :- 

* Currently when the accordion opens up the padding inside changes which breaks the sentence.

### Fix :-

* Add consistent padding inside the panel

### Fix in bb8 :- 

https://github.com/international-labour-organization/designsystem/assets/32934169/f5930369-dc85-4918-a5f3-939f37ec53da



