### PR TITLE
fix(style) - housekeeping for button css

### DIFF
--- a/.changeset/chilled-melons-whisper.md
+++ b/.changeset/chilled-melons-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Fix icon position to properly align with button label

--- a/.changeset/chilly-pants-juggle.md
+++ b/.changeset/chilly-pants-juggle.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+CSS housekeeping for button component

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -29,10 +29,11 @@ const Button: FC<ButtonProps> = ({
 
   const ButtonClasses = classNames(className, {
     [baseClass]: true,
-    [`${baseClass}--${size}`]: size,
-    [`${baseClass}--${type}`]: type,
-    [`icon icon__position--${icoPos}`]: icon && !icononly,
-    [`icon icon--only`]: icon && icononly,
+    [`${baseClass}__${size}`]: size,
+    [`${baseClass}__${type}`]: type,
+    [`${baseClass}--icon ${baseClass}--icon--position__${icoPos}`]:
+      icon && !icononly,
+    [`${baseClass}--icon ${baseClass}--icon--only`]: icon && icononly,
   });
 
   /**

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -2,23 +2,35 @@
 @use "../functions" as *;
 @import "../animations";
 @import "../mixins";
+@import "../config";
 
-.ilo--button {
+.#{$prefix}--button {
+  --ilo-button-label-weight: 700;
+  --ilo-button-labels-actionable-color: var(--ilo-color-blue-dark);
+  --ilo-button-labels-active-color: var(--ilo-color-blue-light);
+  --ilo-button-labels-alert-color: var(--ilo-color-white);
+  --ilo-button-labels-hover-color: var(--ilo-color-blue);
+
+  // This provides a reference to the outerclass within nested declarations
+  $button: &;
   display: inline-block;
   font-family: var(--ilo-fonts-display);
-  font-weight: map-get($type, "weights", "label");
+  font-weight: var(--ilo-button-label-weight);
   padding: 0;
-  @include borderradius("button");
+  border-radius: var(--ilo-border-md);
+  @include globaltransition("color, background-color, border-color");
 
   .link__label,
   .button__label {
     display: inline-block;
+    position: relative;
+    top: px-to-rem(2px);
   }
 
-  &.icon {
+  &--icon {
     position: relative;
 
-    .ilo--icon {
+    .#{$prefix}--icon {
       height: 100%;
       max-height: px-to-rem(32px);
       max-width: px-to-rem(32px);
@@ -26,25 +38,25 @@
       width: 100%;
     }
 
-    &.icon__position--left {
+    &--position__left {
       .link__label,
       .button__label {
-        padding-left: spacing(12);
+        padding-inline-start: spacing(6);
       }
 
-      .ilo--icon {
+      .#{$prefix}--icon {
         left: px-to-rem(13px);
         top: px-to-rem(7px);
       }
     }
 
-    &.icon__position--right {
+    &--position__right {
       .link__label,
       .button__label {
-        padding-right: spacing(12);
+        padding-inline-end: spacing(6);
       }
 
-      .ilo--icon {
+      .#{$prefix}--icon {
         right: px-to-rem(13px);
         top: px-to-rem(7px);
       }
@@ -57,269 +69,204 @@
     }
   }
 
-  &--large {
-    .link__label,
-    .button__label {
-      padding: spacing(3) spacing(6);
-      @include font-styles("button-large");
-    }
+  &__large {
+    padding: spacing(3) spacing(6);
+    @include font-styles("button-large");
 
-    &.icon--only {
+    &.#{$prefix}--button--icon--only {
       height: px-to-rem(45px);
       width: px-to-rem(45px);
+      padding: unset;
 
-      .ilo--icon {
+      .#{$prefix}--icon {
         left: px-to-rem(4.5px);
         top: px-to-rem(4.5px);
       }
     }
   }
 
-  &--medium {
-    .link__label,
-    .button__label {
-      padding: spacing(2) spacing(5);
-      @include font-styles("button-medium");
+  &__medium {
+    padding: spacing(2) spacing(5);
+    @include font-styles("button-medium");
+
+    .#{$prefix}--icon {
+      max-height: px-to-rem(30px);
+      max-width: px-to-rem(30px);
+      position: absolute;
     }
 
-    &.icon {
-      .ilo--icon {
-        max-height: px-to-rem(30px);
-        max-width: px-to-rem(30px);
-        position: absolute;
+    &.#{$prefix}--button--icon--position__left {
+      .link__label,
+      .button__label {
+        padding-inline-start: spacing(6);
       }
 
-      &.icon__position--left {
-        .link__label,
-        .button__label {
-          padding-left: spacing(11);
-        }
-
-        .ilo--icon {
-          left: px-to-rem(10px);
-          top: px-to-rem(3px);
-        }
-      }
-
-      &.icon__position--right {
-        .link__label,
-        .button__label {
-          padding-right: spacing(11);
-        }
-
-        .ilo--icon {
-          right: px-to-rem(10px);
-          top: px-to-rem(3px);
-        }
+      .#{$prefix}--icon {
+        left: px-to-rem(10px);
+        top: px-to-rem(3px);
       }
     }
 
-    &.icon--only {
+    &.#{$prefix}--button--icon--position__right {
+      .link__label,
+      .button__label {
+        padding-inline-end: spacing(6);
+      }
+
+      .#{$prefix}--icon {
+        right: px-to-rem(10px);
+        top: px-to-rem(3px);
+      }
+    }
+
+    &.#{$prefix}--button--icon--only {
       height: px-to-rem(36px);
       width: px-to-rem(36px);
+      padding: unset;
 
-      .ilo--icon {
+      .#{$prefix}--icon {
         left: px-to-rem(2px);
         top: px-to-rem(2px);
       }
     }
   }
 
-  &--small {
-    .link__label,
-    .button__label {
-      padding: spacing(1) spacing(4);
-      @include font-styles("button-small");
+  &__small {
+    padding: spacing(1) spacing(4);
+    @include font-styles("button-small");
+
+    .#{$prefix}--icon {
+      max-height: px-to-rem(28px);
+      max-width: px-to-rem(28px);
+      position: absolute;
     }
 
-    &.icon {
-      .ilo--icon {
-        max-height: px-to-rem(28px);
-        max-width: px-to-rem(28px);
-        position: absolute;
+    &.#{$prefix}--button--icon--position__left {
+      .link__label,
+      .button__label {
+        padding-inline-start: spacing(5);
       }
 
-      &.icon__position--left {
-        .link__label,
-        .button__label {
-          padding-left: spacing(9);
-        }
-
-        .ilo--icon {
-          left: px-to-rem(6px);
-          top: px-to-rem(1px);
-        }
-      }
-
-      &.icon__position--right {
-        .link__label,
-        .button__label {
-          padding-right: spacing(9);
-        }
-
-        .ilo--icon {
-          right: px-to-rem(6px);
-          top: px-to-rem(1px);
-        }
+      .#{$prefix}--icon {
+        left: px-to-rem(6px);
+        top: 0;
       }
     }
 
-    &.icon--only {
+    &.#{$prefix}--button--icon--position__right {
+      .link__label,
+      .button__label {
+        padding-inline-end: spacing(9);
+      }
+
+      .#{$prefix}--icon {
+        right: 6;
+        top: 0;
+      }
+    }
+
+    &.#{$prefix}--button--icon--only {
       height: px-to-rem(26px);
       width: px-to-rem(26px);
+      padding: unset;
 
-      .ilo--icon {
+      .#{$prefix}--icon {
         left: px-to-rem(0.5px);
         top: px-to-rem(0.5px);
       }
     }
   }
 
-  &--primary {
-    background-color: map-get($color, "ux", "background", "attention");
-    border: map-get($borders, "base")
-      map-get($color, "ux", "borders", "attention") solid;
-    color: map-get($color, "ux", "labels", "actionable");
+  &__primary {
+    background-color: var(--ilo-color-yellow);
+    border: var(--ilo-border-base) var(--ilo-color-yellow) solid;
+    color: var(--ilo-button-labels-actionable-color);
+  }
+
+  &__secondary {
+    background-color: var(--ilo-color-background-default);
+    border: var(--ilo-border-base) var(--ilo-color-borders-default) solid;
+    color: var(--ilo-button-labels-actionable-color);
+
+    &:hover {
+      background-color: var(--ilo-color-background-hover);
+      border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
+    }
+
+    &:active {
+      background-color: var(--ilo-color-background-active);
+      border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
+      box-shadow: none;
+      color: var(--ilo-button-labels-active-color);
+    }
+  }
+
+  &__tertiary {
+    background-color: var(--ilo-color-background-highlight);
+    border: var(--ilo-border-base) var(--ilo-color-background-highlight) solid;
+    color: var(--ilo-button-labels-actionable-color);
+  }
+
+  &__alert {
+    background-color: var(--ilo-color-red-dark);
+    border: var(--ilo-border-base) var(--ilo-color-red-dark) solid;
+    color: var(--ilo-button-labels-alert-color);
+
+    &:hover {
+      background-color: var(--ilo-color-background-hover);
+      border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
+      color: var(--ilo-button-labels-hover-color);
+    }
+
+    &:focus {
+      background-color: var(--ilo-color-background-focus);
+      border: var(--ilo-border-base) var(--ilo-color-borders-focus) solid;
+      color: var(--ilo-button-labels-focus-color);
+      outline: none;
+    }
+
+    &:active {
+      background-color: var(--ilo-color-background-active);
+      border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
+      box-shadow: none;
+      color: var(--ilo-button-labels-active-color);
+    }
   }
 
   &:focus {
-    background-color: map-get($color, "ux", "background", "focus");
-    border: map-get($borders, "base") map-get($color, "ux", "borders", "focus")
-      solid;
-    box-shadow: 4px 4px 0 1px map-get($color, "ux", "borders", "focus") inset,
-      -4px -4px 0 1px map-get($color, "ux", "borders", "focus") inset;
-    color: map-get($color, "ux", "labels", "focus");
+    background-color: var(--ilo-color-background-focus);
+    border: var(--ilo-border-base) var(--ilo-color-borders-focus) solid;
+    box-shadow: 4px 4px 0 1px var(--ilo-color-borders-focus) inset,
+      -4px -4px 0 1px var(--ilo-color-borders-focus) inset;
+    color: var(--ilo-button-labels-focus-color);
     outline: none;
     @include globaltransition("color, background-color, border-color");
 
-    &.ilo--button--small {
-      box-shadow: 3px 3px 0 1px map-get($color, "ux", "borders", "focus") inset,
-        -3px -3px 0 1px map-get($color, "ux", "borders", "focus") inset;
+    &.#{$prefix}--small {
+      box-shadow: 3px 3px 0 1px var(--ilo-color-borders-focus) inset,
+        -3px -3px 0 1px var(--ilo-color-borders-focus) inset;
     }
   }
 
   &:hover {
-    background-color: map-get($color, "ux", "background", "hover");
-    border: map-get($borders, "base") map-get($color, "ux", "borders", "hover")
-      solid;
+    background-color: var(--ilo-color-background-hover);
+    border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
     box-shadow: none;
-    color: map-get($color, "ux", "labels", "hover");
+    color: var(--ilo-button-labels-hover-color);
     cursor: pointer;
     @include globaltransition("color, background-color, border-color");
-
-    &.ilo--button--small {
-      box-shadow: none;
-    }
   }
 
   &:active {
-    background-color: map-get($color, "ux", "background", "active");
-    border: map-get($borders, "base") map-get($color, "ux", "borders", "active")
-      solid;
+    background-color: var(--ilo-color-background-active);
+    border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
     box-shadow: none;
-    color: map-get($color, "ux", "labels", "active");
+    color: var(--ilo-button-labels-active-color);
     @include globaltransition("color, background-color, border-color");
-
-    &.ilo--button--small {
-      box-shadow: none;
-    }
   }
 
   &:disabled {
-    opacity: map-get($opacity, "disabled");
+    opacity: $opacity-disabled;
     pointer-events: none;
-  }
-
-  &--secondary {
-    background-color: map-get($color, "ux", "background", "default");
-    border: map-get($borders, "small")
-      map-get($color, "ux", "borders", "default") solid;
-    color: map-get($color, "ux", "labels", "actionable");
-    @include globaltransition("color, background-color, border-color");
-
-    &:hover {
-      background-color: map-get($color, "ux", "background", "hover");
-      border: map-get($borders, "small")
-        map-get($color, "ux", "borders", "hover") solid;
-      @include globaltransition("color, background-color, border-color");
-    }
-
-    &:active {
-      background-color: map-get($color, "ux", "background", "active");
-      border: map-get($borders, "base")
-        map-get($color, "ux", "borders", "active") solid;
-      box-shadow: none;
-      color: map-get($color, "ux", "labels", "active");
-      @include globaltransition("color, background-color, border-color");
-
-      &.ilo--button--small {
-        box-shadow: none;
-      }
-    }
-  }
-
-  &--tertiary {
-    background-color: map-get($color, "ux", "background", "highlight");
-    border: map-get($borders, "base")
-      map-get($color, "ux", "background", "highlight") solid;
-    color: map-get($color, "ux", "labels", "actionable");
-    @include globaltransition("color, background-color, border-color");
-  }
-
-  &--alert {
-    background-color: map-get($color, "ux", "background", "alert");
-    border: map-get($borders, "small") map-get($color, "ux", "borders", "alert")
-      solid;
-    color: map-get($color, "ux", "labels", "alert");
-    @include globaltransition("color, background-color, border-color");
-
-    &:hover {
-      background-color: map-get($color, "ux", "background", "hover");
-      border: map-get($borders, "small")
-        map-get($color, "ux", "borders", "hover") solid;
-      color: map-get($color, "ux", "labels", "hover");
-      @include globaltransition("color, background-color, border-color");
-    }
-
-    &:focus {
-      background-color: map-get($color, "ux", "background", "focus");
-      border: map-get($borders, "base")
-        map-get($color, "ux", "borders", "focus") solid;
-      color: map-get($color, "ux", "labels", "focus");
-      outline: none;
-      @include globaltransition("color, background-color, border-color");
-    }
-
-    &:active {
-      background-color: map-get($color, "ux", "background", "active");
-      border: map-get($borders, "base")
-        map-get($color, "ux", "borders", "active") solid;
-      box-shadow: none;
-      color: map-get($color, "ux", "labels", "active");
-      @include globaltransition("color, background-color, border-color");
-
-      &.ilo--button--small {
-        box-shadow: none;
-      }
-    }
-  }
-}
-
-[id*="story--components-button"] div {
-  .ilo--button {
-    margin-right: 10px;
-    margin-bottom: 10px;
-
-    &--large.icon--only {
-      transform: translateY(-6px);
-    }
-
-    &--medium.icon--only {
-      transform: translateY(-5px);
-    }
-
-    &--small.icon--only {
-      transform: translateY(-5px);
-    }
   }
 }

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -179,23 +179,23 @@
 
   &__primary {
     background-color: var(--ilo-color-yellow);
-    border: var(--ilo-border-base) var(--ilo-color-yellow) solid;
+    border: var(--ilo-border-md) var(--ilo-color-yellow) solid;
     color: var(--ilo-button-labels-actionable-color);
   }
 
   &__secondary {
     background-color: var(--ilo-color-background-default);
-    border: var(--ilo-border-base) var(--ilo-color-borders-default) solid;
+    border: var(--ilo-border-md) var(--ilo-color-borders-default) solid;
     color: var(--ilo-button-labels-actionable-color);
 
     &:hover {
       background-color: var(--ilo-color-background-hover);
-      border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
+      border: var(--ilo-border-md) var(--ilo-color-borders-hover) solid;
     }
 
     &:active {
       background-color: var(--ilo-color-background-active);
-      border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
+      border: var(--ilo-border-md) var(--ilo-color-borders-active) solid;
       box-shadow: none;
       color: var(--ilo-button-labels-active-color);
     }
@@ -203,31 +203,31 @@
 
   &__tertiary {
     background-color: var(--ilo-color-background-highlight);
-    border: var(--ilo-border-base) var(--ilo-color-background-highlight) solid;
+    border: var(--ilo-border-md) var(--ilo-color-background-highlight) solid;
     color: var(--ilo-button-labels-actionable-color);
   }
 
   &__alert {
     background-color: var(--ilo-color-red-dark);
-    border: var(--ilo-border-base) var(--ilo-color-red-dark) solid;
+    border: var(--ilo-border-md) var(--ilo-color-red-dark) solid;
     color: var(--ilo-button-labels-alert-color);
 
     &:hover {
       background-color: var(--ilo-color-background-hover);
-      border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
+      border: var(--ilo-border-md) var(--ilo-color-borders-hover) solid;
       color: var(--ilo-button-labels-hover-color);
     }
 
     &:focus {
       background-color: var(--ilo-color-background-focus);
-      border: var(--ilo-border-base) var(--ilo-color-borders-focus) solid;
+      border: var(--ilo-border-md) var(--ilo-color-borders-focus) solid;
       color: var(--ilo-button-labels-focus-color);
       outline: none;
     }
 
     &:active {
       background-color: var(--ilo-color-background-active);
-      border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
+      border: var(--ilo-border-md) var(--ilo-color-borders-active) solid;
       box-shadow: none;
       color: var(--ilo-button-labels-active-color);
     }
@@ -235,7 +235,7 @@
 
   &:focus {
     background-color: var(--ilo-color-background-focus);
-    border: var(--ilo-border-base) var(--ilo-color-borders-focus) solid;
+    border: var(--ilo-border-md) var(--ilo-color-borders-focus) solid;
     box-shadow: 4px 4px 0 1px var(--ilo-color-borders-focus) inset,
       -4px -4px 0 1px var(--ilo-color-borders-focus) inset;
     color: var(--ilo-button-labels-focus-color);
@@ -250,7 +250,7 @@
 
   &:hover {
     background-color: var(--ilo-color-background-hover);
-    border: var(--ilo-border-base) var(--ilo-color-borders-hover) solid;
+    border: var(--ilo-border-md) var(--ilo-color-borders-hover) solid;
     box-shadow: none;
     color: var(--ilo-button-labels-hover-color);
     cursor: pointer;
@@ -259,7 +259,7 @@
 
   &:active {
     background-color: var(--ilo-color-background-active);
-    border: var(--ilo-border-base) var(--ilo-color-borders-active) solid;
+    border: var(--ilo-border-md) var(--ilo-color-borders-active) solid;
     box-shadow: none;
     color: var(--ilo-button-labels-active-color);
     @include globaltransition("color, background-color, border-color");

--- a/packages/styles/scss/components/_icon.scss
+++ b/packages/styles/scss/components/_icon.scss
@@ -1,6 +1,0 @@
-.ilo--icon {
-  &:not([data-js-processed="true"]) {
-    height: 24px;
-    width: 24px;
-  }
-}

--- a/packages/styles/scss/components/index.scss
+++ b/packages/styles/scss/components/index.scss
@@ -54,4 +54,3 @@
 @use "tooltip";
 @use "video";
 @use "socialmedia";
-@use "icon";

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -105,6 +105,4 @@
   --ilo-border-sm: calc(#{px-to-rem(1.5)} * var(--ilo-scale));
   --ilo-border-md: calc(#{px-to-rem(2)} * var(--ilo-scale));
   --ilo-border-lg: calc(#{px-to-rem(4)} * var(--ilo-scale));
-
-  --ilo-border-base: var(--ilo-border-md);
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -42,7 +42,7 @@
   --ilo-color-gray-charcoal: rgba(45, 45, 45, 1);
   --ilo-color-gray-accessible: rgba(109, 109, 109, 1);
   --ilo-color-gray-light: rgba(237, 240, 242, 1);
-  --ilo-color-gray-ui: rgba(184, 196, 204, 1);
+  --ilo-color-gray-base: rgba(184, 196, 204, 1);
 
   --ilo-color-red: rgba(250, 60, 75, 1);
   --ilo-color-red-light: rgba(254, 216, 219, 1);
@@ -65,6 +65,16 @@
   --ilo-color-notification-type-info: var(--ilo-color-blue);
   --ilo-color-notification-type-success: var(--ilo-color-green);
   --ilo-color-notification-type-warning: var(--ilo-color-yellow);
+  --ilo-color-background-default: var(--ilo-color-white);
+  --ilo-color-background-active: var(--ilo-color-blue);
+  --ilo-color-background-highlight: var(--ilo-color-gray-light);
+  --ilo-color-background-hover: var(--ilo-color-blue-lighter);
+  --ilo-color-background-focus: var(--ilo-color-white);
+
+  --ilo-color-borders-default: var(--ilo-color-gray-base);
+  --ilo-color-borders-hover: var(--ilo-color-blue);
+  --ilo-color-borders-active: var(--ilo-color-blue);
+  --ilo-color-borders-focus: var(--ilo-color-yellow);
 
   /**
     * Sizing
@@ -95,4 +105,6 @@
   --ilo-border-sm: calc(#{px-to-rem(1.5)} * var(--ilo-scale));
   --ilo-border-md: calc(#{px-to-rem(2)} * var(--ilo-scale));
   --ilo-border-lg: calc(#{px-to-rem(4)} * var(--ilo-scale));
+
+  --ilo-border-base: var(--ilo-border-md);
 }

--- a/packages/twig/src/patterns/components/button/button.twig
+++ b/packages/twig/src/patterns/components/button/button.twig
@@ -2,7 +2,7 @@
   BUTTON COMPONENT
 #}
 {% if url %}
-	<a class="{{prefix}}--button ilo--button--{{size}} {{prefix}}--button--{{type}}{% if icon %} icon icon__position--{{iconPosition}}{% endif %}{% if icononly|boolval %} icon--only{% endif %}{% if className %} {{className}}{% endif %}" href="{{url}}" {% if target %} target="{{target}}" rel="noopener noreferrer"{% endif %}{{ disabled|boolval ? ' disabled' }}>
+	<a class="{{prefix}}--button ilo--button__{{size}} {{prefix}}--button__{{type}}{% if icon %} {{prefix}}--button--icon {{prefix}}--button--icon--position__{{iconPosition}}{% endif %}{% if icononly|boolval %} {{prefix}}--button--icon--only{% endif %}{% if className %} {{className}}{% endif %}" href="{{url}}" {% if target is defined and target != 'false' %} target="{{target}}" rel="noopener noreferrer" {% endif %} {{ disabled|boolval ? ' disabled' }}>
 		<span class="link__label">{{label}}</span>
 		{% block button_icon %}
 			{% if icon %}
@@ -16,7 +16,7 @@
 		{% endblock %}
 	</a>
 {% else %}
-	<button class="{{prefix}}--button ilo--button--{{size}} {{prefix}}--button--{{type}}{% if icon %} icon icon__position--{{iconPosition}}{% endif %}{% if icononly|boolval %} icon--only{% endif %}{% if className %} {{className}}{% endif %}" {% if kind %} type="{{kind}}" {% endif %} {% if opensmodal|boolval %} aria-haspopup="dialog" {% endif %}{{ disabled|boolval ? ' disabled' }}{% if name %} name="{{name}}" {% endif %}>
+	<button class="{{prefix}}--button ilo--button__{{size}} {{prefix}}--button__{{type}}{% if icon %} {{prefix}}--button--icon {{prefix}}--button--icon--position__{{iconPosition}}{% endif %}{% if icononly|boolval %} {{prefix}}--button--icon--only{% endif %}{% if className %} {{className}}{% endif %}" {% if kind %} type="{{kind}}" {% endif %} {% if opensmodal %} aria-haspopup="dialog" {% endif %} {{ disabled|boolval ? ' disabled' }}>
 		<span class="button__label">{{label}}</span>
 		{{ block("button_icon") }}
 	</button>

--- a/packages/twig/src/patterns/components/icon/icon.twig
+++ b/packages/twig/src/patterns/components/icon/icon.twig
@@ -1,4 +1,4 @@
 {#
   ICON COMPONENT
 #}
-<svg class="{{prefix}}--icon" data-name="{{name}}" data-size="{{size}}" data-color="{{color}}" data-loadcomponent="Icon"></svg>
+<svg width="24" height="24" class="{{prefix}}--icon" data-name="{{name}}" data-size="{{size}}" data-color="{{color}}" data-loadcomponent="Icon"></svg>


### PR DESCRIPTION
This PR provides refactoring/housekeeping of the **button** component.

- [x] Replace explicit instances of `ilo` with the `$prefix` variable to enable theming later on
- [x] Make sure classnames conform to modified BEM convention (`block--element__modifier`)
- [x] Remove local variables that should instead use standard ones from the theme
- [x] Explain any local variables that have to be used for special cases
- [x] Remove unneeded rules
- [x] Replace `map-get` invocations with the name of the css variable exported by the themes package
- [x] Use LTR/RTL agnostic css (Example `padding-inline-start` instead of `padding-left`)
- [x] Where necessary, break up the CSS for very big components into logical sub-components, that could potentially be exported from the Design System by themselves

Related to #971 

**Design bugs fixed :-** 

**Align the small button icon and label**

Before :- 
<img width="150" alt="Screenshot 2024-05-06 at 16 57 33" src="https://github.com/international-labour-organization/designsystem/assets/32934169/9ead1e93-c927-4074-ae2c-b30722cd5185">

After :- 
<img width="180" alt="Screenshot 2024-05-06 at 17 00 28" src="https://github.com/international-labour-organization/designsystem/assets/32934169/9cebf572-f99d-470d-9710-e58fbf80d7ed">

**Fix icon only component in twig**

Before :- 
<img width="83" alt="Screenshot 2024-05-06 at 17 02 44" src="https://github.com/international-labour-organization/designsystem/assets/32934169/dabec334-c9e7-4c00-90c3-7a4786e6ddb8">

After :- 
<img width="64" alt="Screenshot 2024-05-06 at 17 02 54" src="https://github.com/international-labour-organization/designsystem/assets/32934169/9ccda18d-ed65-48dc-86ca-53d53ba54cd9">


