### PR TITLE
feat(react/twig): add icon size option to social media

### DIFF
--- a/.changeset/honest-birds-juggle.md
+++ b/.changeset/honest-birds-juggle.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Add new option to change size of icon in the social media component

--- a/packages/react/src/components/SocialMedia/SocialMedia.args.ts
+++ b/packages/react/src/components/SocialMedia/SocialMedia.args.ts
@@ -4,6 +4,7 @@ export const defaultArgs: SocialMediaProps = {
   headline: "Follow us on social media",
   theme: "light",
   justify: "start",
+  iconSize: "normal",
   icons: [
     {
       icon: "facebook",

--- a/packages/react/src/components/SocialMedia/SocialMedia.props.ts
+++ b/packages/react/src/components/SocialMedia/SocialMedia.props.ts
@@ -42,4 +42,9 @@ export interface SocialMediaProps {
    * Specify the icons to display.
    */
   icons: SocialMediaIcons[];
+
+  /**
+   * The size of the social media icons
+   */
+  iconSize: "normal" | "large";
 }

--- a/packages/react/src/components/SocialMedia/SocialMedia.tsx
+++ b/packages/react/src/components/SocialMedia/SocialMedia.tsx
@@ -8,6 +8,7 @@ const SocialMedia: React.FC<SocialMediaProps> = ({
   justify = "start",
   headline,
   icons,
+  iconSize = "normal",
 }) => {
   const { prefix } = useGlobalSettings();
 
@@ -22,6 +23,7 @@ const SocialMedia: React.FC<SocialMediaProps> = ({
   const listClass = `${baseClass}--list`;
   const listItemClass = `${listClass}--item`;
   const iconClass = `${listItemClass}--icon`;
+  const iconSizeClass = `${listItemClass}--icon__${iconSize}`;
 
   return (
     <div className={classes}>
@@ -31,7 +33,11 @@ const SocialMedia: React.FC<SocialMediaProps> = ({
           <li className={listItemClass}>
             <a
               title={item.label}
-              className={classnames(iconClass, `${iconClass}__${item.icon}`)}
+              className={classnames(
+                iconClass,
+                iconSizeClass,
+                `${iconClass}__${item.icon}`
+              )}
               href={item.url}
             >
               {item.label}

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -67,6 +67,12 @@
         width: px-to-rem($icon-size + 8px);
         transition: all 0.1s ease-in-out;
 
+        &__large {
+          background-size: auto px-to-rem(24px);
+          height: px-to-rem(36px);
+          width: px-to-rem(36px);
+        }
+
         &:hover {
           background-color: map-get(
             $color,

--- a/packages/twig/src/patterns/components/socialmedia/socialmedia.twig
+++ b/packages/twig/src/patterns/components/socialmedia/socialmedia.twig
@@ -8,7 +8,7 @@
     <ul class="{{ prefix }}--social-media--list">
         {% for item in icons %}
             <li class="{{ prefix }}--social-media--list--item">
-                <a class="{{ prefix }}--social-media--list--item--icon {{ prefix }}--social-media--list--item--icon__{{ item.icon }}" href={{ item.url }} title={{ item.label|capitalize }} target="_blank">
+                <a class="{{ prefix }}--social-media--list--item--icon {{ prefix }}--social-media--list--item--icon__{{ iconSize|default("normal") }} {{ prefix }}--social-media--list--item--icon__{{ item.icon }}" href={{ item.url }} title={{ item.label|capitalize }} target="_blank">
                     {{item.label|capitalize}}
                 </a>
             </li>

--- a/packages/twig/src/patterns/components/socialmedia/socialmedia.wingsuit.yml
+++ b/packages/twig/src/patterns/components/socialmedia/socialmedia.wingsuit.yml
@@ -22,6 +22,15 @@ socialmedia:
         center: center
       preview: start
       defaultValue: start
+    iconSize:
+      type: select
+      label: Icon size
+      description: The size of the social media icons
+      options:
+        normal: normal
+        large: large
+      preview: normal
+      defaultValue: normal
   fields:
     headline:
       type: string


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/956

### Notes :- 

* Add a new icon size option to change the size of social media icons

### Screenshots :- 

Normal 

<img width="308" alt="Screenshot 2024-05-16 at 02 45 54" src="https://github.com/international-labour-organization/designsystem/assets/32934169/d42f66ea-e28e-48b5-8f39-48e0a685312c">

Large

<img width="371" alt="Screenshot 2024-05-16 at 02 46 43" src="https://github.com/international-labour-organization/designsystem/assets/32934169/93bfda31-7ae7-4139-9fce-9756b16f5ba6">



