### PR TITLE
ILO Theme Foundation

### DIFF
--- a/.changeset/chilly-llamas-grin.md
+++ b/.changeset/chilly-llamas-grin.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": minor
+---
+
+Add foundation file for the new theming

--- a/packages/styles/scss/_functions.scss
+++ b/packages/styles/scss/_functions.scss
@@ -57,11 +57,13 @@
 // =========================================
 
 @function spacing($size) {
-  $scaled: $size * $spacing-root;
+  $scaled: calc(#{$size} * var(--ilo-spacing-base));
+
   @if ($size % 1 != 0) {
-    $scaled: round($size) * $spacing-root;
+    $scaled: calc(#{round($size)} * var(--ilo-spacing-base));
   }
-  @return px-to-rem($scaled);
+
+  @return $scaled;
 }
 
 // =========================================

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -3,6 +3,7 @@
 //*------------------------------------*/
 @use "tokens" as *;
 @use "functions" as *;
+@use "theme/foundation" as *;
 
 // ======================================
 // Output font styles
@@ -40,15 +41,15 @@
 // ======================================
 
 @mixin breakpoint($breakpoint, $max: false) {
-  @if map-has-key($breakpoints, $breakpoint) {
+  @if map-has-key($breakpoints-foundation, $breakpoint) {
     @if not $max {
-      @media screen and (min-width: map-get($breakpoints, $breakpoint)) {
+      @media screen and (min-width: map-get($breakpoints-foundation, $breakpoint)) {
         @content;
       }
     }
 
     @if $max {
-      @media screen and (max-width: #{map-get($breakpoints, $breakpoint) - 1px}) {
+      @media screen and (max-width: #{map-get($breakpoints-foundation, $breakpoint) - 1px}) {
         @content;
       }
     }

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -3,7 +3,7 @@
 //*------------------------------------*/
 @use "tokens" as *;
 @use "functions" as *;
-@use "theme/foundation" as *;
+@use "theme/breakpoints" as *;
 
 // ======================================
 // Output font styles

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -418,7 +418,7 @@
           transform: rotate(180deg);
         }
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           top: px-to-rem(7px);
         }
       }
@@ -436,7 +436,7 @@
       letter-spacing: $type-label-small-letter-spacing;
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       @include font-styles("base");
     }
   }

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -59,7 +59,7 @@
       }
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       @include font-styles("label-medium");
       &__large {
         @include font-styles("headline-6");

--- a/packages/styles/scss/components/_cardgroup.scss
+++ b/packages/styles/scss/components/_cardgroup.scss
@@ -13,7 +13,7 @@
   }
 
   &__count {
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       &__one {
         #{$c}--inner {
           grid-template-columns: 1fr;

--- a/packages/styles/scss/components/_credit.scss
+++ b/packages/styles/scss/components/_credit.scss
@@ -29,7 +29,7 @@
     width: px-to-rem($spacing-ux-credit-height);
   }
 
-  @include breakpoint("large", true) {
+  @include breakpoint("lg", true) {
     width: 75%;
 
     &--label {
@@ -88,7 +88,7 @@
       transform: scaleX(-1);
     }
 
-    @include breakpoint("large", true) {
+    @include breakpoint("lg", true) {
       &--label {
         left: auto;
         right: 0;

--- a/packages/styles/scss/components/_datacard.scss
+++ b/packages/styles/scss/components/_datacard.scss
@@ -25,7 +25,7 @@
         row-gap: px-to-rem(26px);
       }
 
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         padding: spacing(12);
 
         &__columns {
@@ -92,7 +92,7 @@
           @include cornercut(72px, 40px);
           padding: spacing(10) spacing(6) spacing(14);
 
-          @include breakpoint("medium", true) {
+          @include breakpoint("md", true) {
             --max-width: 100%;
           }
         }

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -16,11 +16,11 @@
 
       @include globaltransition(border);
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: spacing(8) 0;
       }
 
-      @include breakpoint("medium", true) {
+      @include breakpoint("md", true) {
         --max-width: 100%;
       }
 
@@ -49,7 +49,7 @@
       #{$self}--title {
         padding: 0 0 spacing(2) 0;
         @include font-styles("headline-6");
-        @include breakpoint("large") {
+        @include breakpoint("lg") {
           #{$self}__size__wide & {
             @include font-styles("headline-5");
           }
@@ -66,19 +66,19 @@
           --max-width: #{px-to-rem(745px)};
 
           #{$self}--title {
-            @include breakpoint("large") {
+            @include breakpoint("lg") {
               @include font-styles("headline-5");
             }
           }
 
           #{$self}--image--wrapper {
-            @include breakpoint("large") {
+            @include breakpoint("lg") {
               flex: 0 0 px-to-rem(196px);
             }
           }
 
           #{$self}--picture {
-            @include breakpoint("large") {
+            @include breakpoint("lg") {
               width: px-to-rem(196px);
             }
           }
@@ -87,7 +87,7 @@
         &__narrow {
           --max-width: #{px-to-rem(343px)};
 
-          @include breakpoint("medium", true) {
+          @include breakpoint("md", true) {
             --max-width: 100%;
           }
         }

--- a/packages/styles/scss/components/_factlistcard.scss
+++ b/packages/styles/scss/components/_factlistcard.scss
@@ -15,7 +15,7 @@
 
       @include cornercut(72px, 40px);
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: spacing(12) spacing(10) spacing(14);
       }
 
@@ -25,7 +25,7 @@
 
           padding: spacing(12) spacing(10) spacing(14);
 
-          @include breakpoint("medium") {
+          @include breakpoint("md") {
             @include cornercut(87px, 48px);
           }
         }
@@ -80,7 +80,7 @@
           "copy"
         );
 
-        @include breakpoint("large") {
+        @include breakpoint("lg") {
           @include font-styles("headline-4");
           @include textmargin(
             "margin-bottom",

--- a/packages/styles/scss/components/_featurecard.scss
+++ b/packages/styles/scss/components/_featurecard.scss
@@ -104,7 +104,7 @@
         &__fluid {
           --max-width: #{px-to-rem(754px)};
 
-          @include breakpoint("medium") {
+          @include breakpoint("md") {
             #{$self}--wrap {
               flex-direction: row;
             }

--- a/packages/styles/scss/components/_fieldset.scss
+++ b/packages/styles/scss/components/_fieldset.scss
@@ -22,7 +22,7 @@
     @include textmargin("margin-bottom", $gap, "label-medium", "display", 0, 0);
 
     .ilo--tooltip--wrapper {
-      top: math.div(spacing(1), 2);
+      top: calc(#{spacing(1)} / 2);
     }
   }
 

--- a/packages/styles/scss/components/_footer.scss
+++ b/packages/styles/scss/components/_footer.scss
@@ -247,7 +247,7 @@
     }
   }
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     &--main {
       display: grid;
       grid-template-columns: minmax(0, 50%) minmax(0, 50%);
@@ -295,7 +295,7 @@
     }
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     @include footer-triangle(top-right);
 
     &--main {
@@ -392,7 +392,7 @@
       }
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       &--main {
         grid-template-areas:
           "address site-info"
@@ -402,7 +402,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       @include footer-triangle(top-left);
 
       &--main {

--- a/packages/styles/scss/components/_formcontrol.scss
+++ b/packages/styles/scss/components/_formcontrol.scss
@@ -185,6 +185,6 @@
   }
 
   .ilo--tooltip--wrapper {
-    bottom: math.div(spacing(1), 2);
+    bottom: calc(#{spacing(1)}, 2);
   }
 }

--- a/packages/styles/scss/components/_heading.scss
+++ b/packages/styles/scss/components/_heading.scss
@@ -28,7 +28,7 @@
 .ilo--h1 {
   @include font-styles("headline-2");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-1");
   }
 }
@@ -36,7 +36,7 @@
 .ilo--h2 {
   @include font-styles("headline-3");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-2");
   }
 }
@@ -44,7 +44,7 @@
 .ilo--h3 {
   @include font-styles("headline-4");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-3");
   }
 }
@@ -52,7 +52,7 @@
 .ilo--h4 {
   @include font-styles("headline-5");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-4");
   }
 }
@@ -60,7 +60,7 @@
 .ilo--h5 {
   @include font-styles("headline-6");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-5");
   }
 }
@@ -68,7 +68,7 @@
 .ilo--h6 {
   @include font-styles("headline-6");
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("headline-6");
   }
 }

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -111,7 +111,7 @@
     }
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     --card-width: 625px;
     --corner-cut-height: #{$spacing-hero-card-corner-cut-height-lg};
     --breadcrumbs-height: 48px;
@@ -375,7 +375,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       &__card-align__bottom {
         &#{$c}__card-justify__start,
         &#{$c}__card-justify__offset {

--- a/packages/styles/scss/components/_herocard.scss
+++ b/packages/styles/scss/components/_herocard.scss
@@ -9,7 +9,7 @@
   position: relative;
   padding: $spacing-hero-card-padding-y-sm $spacing-hero-card-padding-x-sm;
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     padding-block: $spacing-hero-card-padding-y-lg;
     padding-inline-end: $spacing-hero-card-padding-x-lg;
     padding-inline-start: var(--card-padding-start);
@@ -29,7 +29,7 @@
       color: map-get($color, "hero", "card", "light", "color");
       background: map-get($color, "hero", "card", "light", "background");
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         &.ilo--hero-card__background__semi-transparent {
           background: rgba(
             map-get($color, "hero", "card", "light", "background"),
@@ -43,7 +43,7 @@
       background: map-get($color, "hero", "card", "dark", "background");
       color: map-get($color, "hero", "card", "dark", "color");
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         &.ilo--hero-card__background__semi-transparent {
           background: rgba(
             map-get($color, "hero", "card", "dark", "background"),
@@ -53,7 +53,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       &__dark.ilo--hero-card__background__transparent,
       &__light.ilo--hero-card__background__transparent {
         color: map-get($color, "hero", "card", "dark", "color");
@@ -82,7 +82,7 @@
       );
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       @include cornercut(
         $spacing-hero-card-corner-cut-width-lg,
         $spacing-hero-card-corner-cut-height-lg
@@ -139,7 +139,7 @@
     @include font-styles("body-small");
     margin-bottom: px-to-rem(28px);
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       @include font-styles("base");
     }
   }
@@ -158,7 +158,7 @@
     font-family: $fonts-display;
     font-weight: 700;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       @include font-styles("headline-2");
     }
   }

--- a/packages/styles/scss/components/_image.scss
+++ b/packages/styles/scss/components/_image.scss
@@ -34,7 +34,7 @@
     left: 0;
     position: absolute;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       bottom: -#{px-to-rem(4px)};
     }
   }

--- a/packages/styles/scss/components/_list.scss
+++ b/packages/styles/scss/components/_list.scss
@@ -11,7 +11,7 @@
     font-family: $fonts-display;
     font-weight: 700;
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       @include font-styles("headline-5");
     }
   }

--- a/packages/styles/scss/components/_modal.scss
+++ b/packages/styles/scss/components/_modal.scss
@@ -71,14 +71,14 @@
     }
   }
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     &--contents {
       margin: 0 23.2%;
       width: 53.58%;
     }
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     &--contents {
       margin: 0 18.05%;
       width: 63.888%;

--- a/packages/styles/scss/components/_multilinkcard.scss
+++ b/packages/styles/scss/components/_multilinkcard.scss
@@ -24,11 +24,11 @@
         }
       }
 
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         padding: spacing(10);
       }
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: spacing(14) spacing(12);
       }
 
@@ -37,7 +37,7 @@
         margin-bottom: spacing(8);
         color: $brand-ilo-black;
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           @include font-styles("headline-4");
         }
       }
@@ -47,7 +47,7 @@
         margin-bottom: spacing(8);
         color: $brand-ilo-black;
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           @include font-styles("base");
         }
       }
@@ -75,14 +75,14 @@
           }
 
           #{$self}--title {
-            @include breakpoint("medium") {
+            @include breakpoint("md") {
               @include font-styles("headline-5");
               margin-bottom: spacing(6);
             }
           }
 
           #{$self}--intro {
-            @include breakpoint("medium") {
+            @include breakpoint("md") {
               @include font-styles("body-small");
               margin-bottom: spacing(6);
             }
@@ -99,7 +99,7 @@
             margin-bottom: spacing(3);
           }
 
-          @include breakpoint("medium") {
+          @include breakpoint("md") {
             padding: spacing(14) spacing(12);
 
             &#{$self}__align__right {

--- a/packages/styles/scss/components/_navigation.scss
+++ b/packages/styles/scss/components/_navigation.scss
@@ -17,7 +17,7 @@
     width: 100%;
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     overflow: visible;
   }
 
@@ -50,7 +50,7 @@
       background-size: 32px;
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: none;
     }
 
@@ -78,7 +78,7 @@
         background-size: 32px;
       }
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         display: none;
       }
     }
@@ -88,7 +88,7 @@
     display: block;
     height: spacing(14);
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       height: spacing(18);
     }
 
@@ -97,7 +97,7 @@
       padding: spacing(4) 0;
       width: auto;
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: 0 0 spacing(6);
       }
     }
@@ -113,7 +113,7 @@
       justify-content: space-between;
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       background: $brand-ilo-blue;
     }
   }
@@ -178,17 +178,17 @@
           }
         }
 
-        @include breakpoint("large") {
+        @include breakpoint("lg") {
           display: flex;
         }
       }
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: 0;
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       background: $brand-ilo-blue;
       display: flex;
       justify-content: flex-end;
@@ -205,7 +205,7 @@
       visibility: hidden;
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: flex;
       justify-content: space-between;
       padding: 0 spacing(5);
@@ -235,12 +235,12 @@
     }
 
     .ilo--header--local & {
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         display: none;
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       background: $brand-ilo-dark-blue;
       overflow: visible;
       position: static;
@@ -258,7 +258,7 @@
     padding: spacing(4) 0;
     text-align: right;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: block;
     }
 
@@ -274,7 +274,7 @@
 .ilo--nav {
   width: 100%;
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     width: auto;
   }
 
@@ -291,7 +291,7 @@
   &--set {
     width: 100%;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: flex;
       width: auto;
     }
@@ -302,7 +302,7 @@
     font-family: $fonts-display;
     font-weight: 500;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: flex;
       align-items: center;
 
@@ -326,7 +326,7 @@
       text-decoration: none;
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       background: $brand-ilo-dark-blue;
       color: $brand-ilo-white;
       display: inline-block;
@@ -386,7 +386,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       @include dataurlicon("add", $brand-ilo-white);
       @include font-styles("nav-bold-b-sm");
 
@@ -440,12 +440,12 @@
     justify-content: space-between;
 
     [dir="rtl"] {
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: 0 max((100% - 1260px) / 2, 20px) 0 0;
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       padding: 0 32px 0 max((100% - 1260px) / 2, 20px);
     }
 
@@ -466,7 +466,7 @@
     &--set {
       display: none;
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         display: flex;
         justify-content: space-between;
       }
@@ -578,7 +578,7 @@
     }
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     display: none;
   }
 }
@@ -694,7 +694,7 @@
     transform: translateX(0);
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     height: auto;
     left: 0;
     padding: spacing(8) 0;
@@ -717,7 +717,7 @@
   }
 
   &--inner {
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: flex;
       justify-content: space-between;
     }
@@ -728,7 +728,7 @@
     grid-template-columns: 1fr;
     width: 100%;
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       grid-auto-flow: column;
       grid-template-columns: repeat(5, 1fr);
       grid-template-rows: repeat(5, 1fr);
@@ -756,7 +756,7 @@
 }
 
 .ilo--mobile--subnav {
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     display: none;
   }
 
@@ -829,7 +829,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: none;
     }
   }
@@ -862,7 +862,7 @@
     transform: translateX(0);
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     filter: drop-shadow(0px 0.8px 1.6px rgba(30, 45, 190, 0.038))
       drop-shadow(0px 4px 8px rgba(30, 45, 190, 0.054))
       drop-shadow(0px 10px 20px rgba(30, 45, 190, 0.08));
@@ -904,7 +904,7 @@
 .ilo--search {
   display: none;
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     display: flex;
   }
 

--- a/packages/styles/scss/components/_notification.scss
+++ b/packages/styles/scss/components/_notification.scss
@@ -16,7 +16,7 @@
     max-width: 340px;
     width: 100%;
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       max-width: 490px;
     }
 
@@ -32,7 +32,7 @@
       padding: spacing(6);
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       max-width: 100%;
 
       .ilo--notification--content {
@@ -62,7 +62,7 @@
       width: px-to-rem(40px);
       top: 0;
 
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         .ilo--notification--inline & {
           background-position: center;
         }
@@ -96,7 +96,7 @@
 
     margin-bottom: spacing(3);
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--notification--inline & {
         margin-bottom: 0;
       }
@@ -107,14 +107,14 @@
     font-weight: 400;
     @include font-styles("body-xs");
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--notification--inline & {
         margin-left: spacing(6);
       }
     }
 
     &:not(:last-child) {
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         .ilo--notification--inline & {
           flex-grow: 1;
         }
@@ -128,7 +128,7 @@
     font-weight: 400;
     @include font-styles("body-xs");
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--notification--inline & {
         margin-left: spacing(4);
       }
@@ -138,7 +138,7 @@
       margin-bottom: spacing(5);
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--notification--inline & {
         margin-bottom: 0;
       }
@@ -146,7 +146,7 @@
   }
 
   &--cta {
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--notification--inline & {
         margin-left: spacing(6);
       }

--- a/packages/styles/scss/components/_promocard.scss
+++ b/packages/styles/scss/components/_promocard.scss
@@ -13,7 +13,7 @@
       &__narrow {
         --max-width: #{px-to-rem(343px)};
 
-        @include breakpoint("medium", true) {
+        @include breakpoint("md", true) {
           --max-width: 100%;
         }
       }
@@ -39,11 +39,11 @@
       padding: spacing(10) spacing(6);
       width: 100%;
 
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         padding: spacing(12);
       }
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: spacing(16) spacing(18);
       }
 
@@ -92,7 +92,7 @@
             @include font-styles("headline-4");
             margin-bottom: spacing(2);
 
-            @include breakpoint("medium") {
+            @include breakpoint("md") {
               @include font-styles("headline-2");
             }
           }
@@ -111,7 +111,7 @@
       #{$self}--title {
         @include font-styles("headline-4");
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           @include font-styles("headline-2");
         }
       }
@@ -120,7 +120,7 @@
         @include font-styles("body-small");
         margin-bottom: spacing(8);
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           @include font-styles("base");
         }
       }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -207,7 +207,7 @@
   // Repeat list styles from the list component
   @include invincible-list;
 
-  @include breakpoint("medium") {
+  @include breakpoint("md") {
     @include font-styles("base");
 
     h1,
@@ -384,7 +384,7 @@
         transform: scaleX(-1);
       }
 
-      @include breakpoint("medium") {
+      @include breakpoint("md") {
         padding: spacing(15) spacing(12) spacing(12) 0;
 
         blockquote {

--- a/packages/styles/scss/components/_statcard.scss
+++ b/packages/styles/scss/components/_statcard.scss
@@ -10,7 +10,7 @@
     &__stat {
       --max-width: #{px-to-rem(343px)};
 
-      @include breakpoint("medium", true) {
+      @include breakpoint("md", true) {
         --max-width: 100%;
       }
 

--- a/packages/styles/scss/components/_tableofcontents.scss
+++ b/packages/styles/scss/components/_tableofcontents.scss
@@ -46,7 +46,7 @@
       width: 100vw;
       z-index: 10001;
 
-      @include breakpoint("large") {
+      @include breakpoint("lg") {
         padding: 0;
       }
     }
@@ -63,7 +63,7 @@
     }
   }
 
-  @include breakpoint("large") {
+  @include breakpoint("lg") {
     display: block;
 
     & > * {
@@ -94,7 +94,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       display: none;
 
       &.show {

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -149,7 +149,7 @@
       }
     }
 
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       .ilo--tabs--content {
         padding: spacing(10) spacing(16) spacing(16) spacing(16);
       }
@@ -171,7 +171,7 @@
       }
     }
 
-    @include breakpoint("large") {
+    @include breakpoint("lg") {
       .ilo--tabs--selection {
         &--item {
           width: min(calc(var(--tabscount) / 1 * 100%), 100%);

--- a/packages/styles/scss/components/_textcard.scss
+++ b/packages/styles/scss/components/_textcard.scss
@@ -40,7 +40,7 @@
         }
       }
 
-      @include breakpoint("medium", true) {
+      @include breakpoint("md", true) {
         --max-width: 100%;
       }
 
@@ -57,7 +57,7 @@
 
           padding: spacing(10) spacing(6) spacing(8);
 
-          @include breakpoint("medium", true) {
+          @include breakpoint("md", true) {
             --max-width: 100%;
           }
 
@@ -101,7 +101,7 @@
           "copy"
         );
 
-        @include breakpoint("medium") {
+        @include breakpoint("md") {
           @include font-styles("headline-5");
           @include textmargin(
             "margin-bottom",

--- a/packages/styles/scss/components/_tooltip.scss
+++ b/packages/styles/scss/components/_tooltip.scss
@@ -27,7 +27,7 @@
   max-width: px-to-rem(180px);
 
   &--long {
-    @include breakpoint("medium") {
+    @include breakpoint("md") {
       max-width: px-to-rem(400px);
     }
   }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -115,7 +115,7 @@
           color: $color-ux-video-controls-default-icon;
         }
 
-        @include breakpoint("large") {
+        @include breakpoint("lg") {
           width: px-to-rem(80px);
           flex-direction: column;
           height: px-to-rem(124px);

--- a/packages/styles/scss/global.scss
+++ b/packages/styles/scss/global.scss
@@ -4,8 +4,8 @@
 // Load the css resets
 @use "reset";
 
-//Import type styles
-@use "typography";
-
 //Theme Foundation
 @use "theme";
+
+//Import type styles
+@use "typography";

--- a/packages/styles/scss/global.scss
+++ b/packages/styles/scss/global.scss
@@ -6,3 +6,6 @@
 
 //Import type styles
 @use "typography";
+
+//Theme Foundation
+@use "theme";

--- a/packages/styles/scss/monorepo.scss
+++ b/packages/styles/scss/monorepo.scss
@@ -6,11 +6,11 @@
 // Load the css resets
 @use "reset";
 
+//Theme Foundation
+@use "theme";
+
 //Import type styles
 @use "typographymonorepo";
 
 // Import our custom components css
 @use "components";
-
-//Theme Foundation
-@use "theme";

--- a/packages/styles/scss/monorepo.scss
+++ b/packages/styles/scss/monorepo.scss
@@ -11,3 +11,6 @@
 
 // Import our custom components css
 @use "components";
+
+//Theme Foundation
+@use "theme";

--- a/packages/styles/scss/theme/_breakpoints.scss
+++ b/packages/styles/scss/theme/_breakpoints.scss
@@ -1,0 +1,11 @@
+/**
+  * Breakpoints are defined in scss because they can't be referenced as a css variables
+  */
+$breakpoints-foundation: (
+  xs: 320px,
+  sm: 414px,
+  md: 610px,
+  lg: 1024px,
+  xl: 1168px,
+  xxl: 1140px,
+);

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,3 +1,5 @@
+@use "../functions" as *;
+
 :root {
   /**
     * Typography
@@ -56,12 +58,12 @@
   --ilo-breakpoint-lg: 1024px;
   --ilo-breakpoint-xl: 1168px;
   --ilo-breakpoint-xxl: 1440px;
-  --ilo-border-radius: calc(px-to-rem(2) * var(--ilo-scale));
+  --ilo-border-radius: calc(#{px-to-rem(2)} * var(--ilo-scale));
 
   /**
     * Spacing
     */
-  --ilo-spacing-base: calc(px-to-rem(4) * var(--ilo-scale));
+  --ilo-spacing-base: calc(#{px-to-rem(4)} * var(--ilo-scale));
 
   /**
     * transition
@@ -72,8 +74,8 @@
   /**
     * Border
     */
-  --ilo-border-xs: calc(px-to-rem(1) * var(--ilo-scale));
-  --ilo-border-sm: calc(px-to-rem(1.5) * var(--ilo-scale));
-  --ilo-border-md: calc(px-to-rem(2) * var(--ilo-scale));
-  --ilo-border-lg: calc(px-to-rem(4) * var(--ilo-scale));
+  --ilo-border-xs: calc(#{px-to-rem(1)} * var(--ilo-scale));
+  --ilo-border-sm: calc(#{px-to-rem(1.5)} * var(--ilo-scale));
+  --ilo-border-md: calc(#{px-to-rem(2)} * var(--ilo-scale));
+  --ilo-border-lg: calc(#{px-to-rem(4)} * var(--ilo-scale));
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,5 +1,16 @@
 :root {
-  --ilo-prefix: "ilo";
+  /**
+    * Typography
+    */
+  --ilo-scale: 1; // default scale for the design system
+  --ilo-font-family: Overpass, Noto Sans, Noto Sans CJK JP, Yu Gothic,
+    Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑,
+    sans-serif;
+  --ilo-font-copy: Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans,
+    TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif;
+  --ilo-font-family-headings: var(--ilo-font-family);
+  --ilo-font-family-monospace: monospace;
+  --ilo-line-height: 1.46;
 
   /**
     * Colors
@@ -46,4 +57,9 @@
   --ilo-breakpoint-xl: 1168px;
   --ilo-breakpoint-xxl: 1440px;
   --ilo-border-radius: calc(px-to-rem(2) * var(--ilo-scale));
+
+  /**
+    * Spacing
+    */
+  --ilo-spacing-base: calc(px-to-rem(4) * var(--ilo-scale));
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,0 +1,36 @@
+:root {
+  /**
+    * Colors
+    */
+  --ilo-color-white: rgba(255, 255, 255, 1);
+
+  --ilo-color-blue: rgba(30, 45, 190, 1);
+  --ilo-color-blue-lighter: rgba(235, 245, 253, 1);
+  --ilo-color-blue-light: rgba(190, 220, 250, 1);
+  --ilo-color-blue-dark: rgba(35, 0, 80, 1);
+  --ilo-color-blue-medium: rgba(210, 213, 242, 1);
+  --ilo-color-blue-ramp: rgba(30, 45, 190, 0.4);
+  --ilo-color-blue-dark-ramp: rgba(35, 0, 80, 0.5);
+
+  --ilo-color-gray-charcoal: rgba(45, 45, 45, 1);
+  --ilo-color-gray-accessible: rgba(109, 109, 109, 1);
+  --ilo-color-gray-light: rgba(237, 240, 242, 1);
+  --ilo-color-gray-ui: rgba(184, 196, 204, 1);
+
+  --ilo-color-red: rgba(250, 60, 75, 1);
+  --ilo-color-red-light: rgba(254, 216, 219, 1);
+  --ilo-color-red-dark: rgba(200, 48, 60, 1);
+  --ilo-color-red-ramp: rgba(250, 60, 75, 0.2);
+
+  --ilo-color-yellow: rgba(255, 205, 45, 1);
+  --ilo-color-yellow-light: rgba(255, 245, 200, 1);
+  --ilo-color-yellow-ramp: rgba(255, 205, 45, 0.2);
+
+  --ilo-color-green: rgba(140, 225, 100, 1);
+  --ilo-color-green-light: rgba(232, 249, 224, 1);
+  --ilo-color-green-ramp: rgba(140, 225, 100, 0.2);
+
+  --ilo-color-turquoise: rgba(5, 210, 210, 1);
+
+  --ilo-color-purple: rgba(150, 10, 85, 1);
+}

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -62,4 +62,18 @@
     * Spacing
     */
   --ilo-spacing-base: calc(px-to-rem(4) * var(--ilo-scale));
+
+  /**
+    * transition
+    */
+  --ilo-transition-duration: 150ms;
+  --ilo-transition-timing-function: ease-out;
+
+  /**
+    * Border
+    */
+  --ilo-border-xs: calc(px-to-rem(1) * var(--ilo-scale));
+  --ilo-border-sm: calc(px-to-rem(1.5) * var(--ilo-scale));
+  --ilo-border-md: calc(px-to-rem(2) * var(--ilo-scale));
+  --ilo-border-lg: calc(px-to-rem(4) * var(--ilo-scale));
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,4 +1,6 @@
 :root {
+  --ilo-prefix: "ilo";
+
   /**
     * Colors
     */

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -78,7 +78,7 @@ $breakpoints-foundation: (
   --ilo-spacing-base: calc(#{px-to-rem(4)} * var(--ilo-scale));
 
   /**
-    * transition
+    * Transition
     */
   --ilo-transition-duration: 150ms;
   --ilo-transition-timing-function: ease-out;

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -33,4 +33,15 @@
   --ilo-color-turquoise: rgba(5, 210, 210, 1);
 
   --ilo-color-purple: rgba(150, 10, 85, 1);
+
+  /**
+    * Sizing
+    */
+  --ilo-breakpoint-xs: 320px;
+  --ilo-breakpoint-sm: 414px;
+  --ilo-breakpoint-md: 610px;
+  --ilo-breakpoint-lg: 1024px;
+  --ilo-breakpoint-xl: 1168px;
+  --ilo-breakpoint-xxl: 1440px;
+  --ilo-border-radius: calc(px-to-rem(2) * var(--ilo-scale));
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,5 +1,17 @@
 @use "../functions" as *;
 
+/**
+  * Breakpoints are defined in scss because they can't be referenced as a css variables
+  */
+$breakpoints-foundation: (
+  xs: 320px,
+  small: 414px,
+  md: 610px,
+  lg: 1024px,
+  xl: 1168px,
+  xxl: 1140px,
+);
+
 :root {
   /**
     * Typography
@@ -52,12 +64,12 @@
   /**
     * Sizing
     */
-  --ilo-breakpoint-xs: 320px;
-  --ilo-breakpoint-sm: 414px;
-  --ilo-breakpoint-md: 610px;
-  --ilo-breakpoint-lg: 1024px;
-  --ilo-breakpoint-xl: 1168px;
-  --ilo-breakpoint-xxl: 1440px;
+  --ilo-breakpoint-xs: #{map-get($breakpoints-foundation, "xs")};
+  --ilo-breakpoint-sm: #{map-get($breakpoints-foundation, "sm")};
+  --ilo-breakpoint-md: #{map-get($breakpoints-foundation, "md")};
+  --ilo-breakpoint-lg: #{map-get($breakpoints-foundation, "lg")};
+  --ilo-breakpoint-xl: #{map-get($breakpoints-foundation, "xl")};
+  --ilo-breakpoint-xxl: #{map-get($breakpoints-foundation, "xxl")};
   --ilo-border-radius: calc(#{px-to-rem(2)} * var(--ilo-scale));
 
   /**

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -1,16 +1,5 @@
 @use "../functions" as *;
-
-/**
-  * Breakpoints are defined in scss because they can't be referenced as a css variables
-  */
-$breakpoints-foundation: (
-  xs: 320px,
-  small: 414px,
-  md: 610px,
-  lg: 1024px,
-  xl: 1168px,
-  xxl: 1140px,
-);
+@use "./breakpoints" as *;
 
 :root {
   /**

--- a/packages/styles/scss/theme/index.scss
+++ b/packages/styles/scss/theme/index.scss
@@ -1,0 +1,1 @@
+@use "./foundation";

--- a/packages/styles/scss/theme/index.scss
+++ b/packages/styles/scss/theme/index.scss
@@ -1,1 +1,1 @@
-@use "./foundation";
+@use "foundation";

--- a/packages/twig/cypress/e2e/feedback/tooltip.cy.js
+++ b/packages/twig/cypress/e2e/feedback/tooltip.cy.js
@@ -4,10 +4,13 @@ describe("tooltip", () => {
     cy.getPreview("tooltip").first().as("tooltipSection");
   });
 
-  it("renders the tooltip correctly and check if popover works on hover", () => {
+  it("renders the tooltip correctly and checks if popover works on hover", () => {
     cy.get("@tooltipSection").within(() => {
       cy.get(".ilo--tooltip").should("not.be.visible");
-      cy.get(".ilo--tooltip--wrapper").should("exist").trigger("mouseover");
+      cy.get(".ilo--tooltip--wrapper__icon")
+        .should("exist")
+        .invoke("show")
+        .trigger("mouseover", { force: true });
       cy.contains("Tooltip text");
       cy.get(".ilo--tooltip").should("be.visible");
     });

--- a/packages/twig/cypress/e2e/feedback/tooltip.cy.js
+++ b/packages/twig/cypress/e2e/feedback/tooltip.cy.js
@@ -7,7 +7,7 @@ describe("tooltip", () => {
   it("renders the tooltip correctly and checks if popover works on hover", () => {
     cy.get("@tooltipSection").within(() => {
       cy.get(".ilo--tooltip").should("not.be.visible");
-      cy.get(".ilo--tooltip--wrapper__icon")
+      cy.get(".ilo--tooltip--wrapper")
         .should("exist")
         .invoke("show")
         .trigger("mouseover", { force: true });


### PR DESCRIPTION
## Foundation 

The PR introduces the foundation file mentioned in #999. The foundation file has 2 primary sources, the first one is the **Figma** foundation file, and the second one is the old token system or actual source code. There is also a third-ish one I named it **Mixed**, part from source code and part from Figma components

Foundation file 
✅ - Implemented
🚧 - Partially
⛔ - Not Implemented

| Scope | Status | Soure | 
|--------|--------|------|
| Colors | ✅ | Figma | 
| Typography | 🚧 |  Mixed | 
| Sizing | ✅ |  Figma | 
| Spacing | ✅ | Figma | 
| Breakpoints | ✅ | Source Code | 
| Transitions | ✅ |  Source Code | 
| Borders | ✅ |  Source Code | 

### Typography
 
Typograph is marked as not implemented because we need a Figma update for #896, but it has a main port of the current token system


### Mixins

Two widely used mixins were refactored
-  `spacing` mixin now is fully powered by a new foundation
-  `breakpoint` mixin was a bit problematic because referencing CSS variables as a media query value isn't possible without `js` interaction so I have used SCSS variables to define the breakpoints(for mixing usage) and also composed `CSS` variables from those, `SCSS`version of variables aren't directly referenced by any property it's only used for breakpoint mixin. 

### Found Figma Problems
We have 2 green colors, so I made the second one, `green-light`
<img width="649" alt="image" src="https://github.com/international-labour-organization/designsystem/assets/36326203/22ba89c0-7e81-4c52-bc60-d939bde73625">


### Prefixes

All foundation variables are prefixed as proposed in #999. Prefixes are static for now, but they can be implemented with concatenation if we really want to make it "dynamic".  I still suggest to keep it static for now because it's better for visual feedback, referencing and general readability, after we agree about "composability" of the designsystem we can always do plain old find and replace for `--ilo` 
