### PR TITLE
fix(style) - Add spacing to iframe in richtext 

### DIFF
--- a/.changeset/wild-moose-explode.md
+++ b/.changeset/wild-moose-explode.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Add appropriate padding to iframes in richtext

--- a/.changeset/wild-moose-explode.md
+++ b/.changeset/wild-moose-explode.md
@@ -2,4 +2,4 @@
 "@ilo-org/styles": patch
 ---
 
-Add appropriate padding to iframes in richtext
+Add appropriate margin to iframes in richtext

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -22,7 +22,6 @@
   p + figure,
   p + img,
   p + blockquote,
-  p + iframe,
   ul + img,
   ol + img,
   dl + img,
@@ -41,12 +40,8 @@
     );
   }
 
-  article {
-    margin-bottom: spacing(14);
-  }
-
   iframe {
-    margin-bottom: spacing(14);
+    margin-block: spacing(8) spacing(14);
   }
 
   figure {
@@ -292,7 +287,6 @@
     p + figure,
     p + img,
     p + blockquote,
-    p + iframe,
     ul + img,
     ol + img,
     dl + img,
@@ -313,6 +307,10 @@
 
     hr {
       margin-bottom: spacing(19);
+    }
+
+    iframe {
+      margin-block: calc(spacing(9) + px-to-rem(2)) spacing(14);
     }
 
     figure {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/773

### Notes :- 

* Add spacing to iframe in richtext

### Steps :-

* Revert all changes done before
* Add appropriate spacing to iframe

### Screenshot :- 

<img width="971" alt="Screenshot 2024-05-22 at 01 09 45" src="https://github.com/international-labour-organization/designsystem/assets/32934169/54a1a7b2-7fb3-4a84-96bb-9abb96198feb">


