### PR TITLE
fix(style) - improve accordion expanded status

### DIFF
--- a/.changeset/itchy-spies-sparkle.md
+++ b/.changeset/itchy-spies-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Improve accordion expanded interactions by refactoring active and hover states

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -44,14 +44,14 @@
 
     &:hover,
     &:focus {
-      background-color: $color-ux-background-hover;
       border-top-color: $color-ux-borders-hover;
       color: $color-ux-labels-hover;
       fill: $color-ux-labels-hover;
       cursor: pointer;
 
       &[aria-expanded="true"] {
-        @include dataurlicon("minus", $color-ux-labels-hover);
+        color: $brand-ilo-dark-blue;
+        @include dataurlicon("minus", $brand-ilo-dark-blue);
       }
 
       &[aria-expanded="false"] {
@@ -69,7 +69,9 @@
     }
 
     &[aria-expanded="true"] {
-      @include dataurlicon("minus", $color-ux-labels-actionable);
+      background-color: $color-base-blue-light;
+      color: $brand-ilo-blue;
+      @include dataurlicon("minus", $brand-ilo-blue);
     }
 
     &[aria-expanded="false"] {


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/843

### Notes :- 

* Refactor styles of accordion expanded status

- [x] 'Closed Hover' state: light blue background was removed
- [x] 'Open Default' state: light blue background was added; text and icon should now be ILO blue
- [x] 'Open Hover' state: text and icon should now be dark blue

Demo :- 

https://github.com/international-labour-organization/designsystem/assets/32934169/c71976b6-d142-48c0-8d12-dff5f8497e6c



