### PR TITLE
ci(github): fixed the cypress binary missing error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            cypress-${{ runner.os }}-cypress-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-cypress-
       
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,20 +41,14 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v4
-        name: Setup pnpm cache
+        name: Cache pnpm store and cypress binary
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-cache-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Cache Cypress binary
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
+            ${{ runner.os }}-cache-
       
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Fixes #1052 

The error seems to have been caused by mismatching caching strategies between the pnpm dependencies and cypress. This results in cases where there is a cache hit for pnpm dependencies but a cache miss for the cypress binary. Since there was a cache hit for the dependencies, pnpm will not bother downloading the cypress binary - hence the error message.

This PR changes the caching strategy for the cypress binary to match the caching strategy for the pnpm dependencies so that the situation above does not occur.