### PR TITLE
test(twig) - add initial tests for user interface/ transitions

### DIFF
--- a/packages/twig/cypress/e2e/transitions/loading.cy.js
+++ b/packages/twig/cypress/e2e/transitions/loading.cy.js
@@ -1,0 +1,14 @@
+//WIP
+describe("loading", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/loading");
+    cy.getPreview("loading").first().as("loadingSection");
+  });
+
+  it("renders the loading component correctly", () => {
+    cy.get(".ilo--loading").should("exist");
+    /*
+      Will require variant url to add more testing
+    */
+  });
+});

--- a/packages/twig/cypress/e2e/user-interface/button.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/button.cy.js
@@ -1,0 +1,20 @@
+describe("button", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/button");
+    cy.getPreview("button").first().as("buttonSection");
+  });
+
+  it("renders the button component correctly", () => {
+    cy.get("@buttonSection").within(() => {
+      cy.contains("Button");
+
+      cy.get("span").should("exist");
+      cy.get("svg").should("exist");
+
+      cy.get("span").should("have.text", "Button");
+      cy.get("svg")
+        .should("have.attr", "data-size", "24")
+        .should("have.attr", "data-name", "add");
+    });
+  });
+});

--- a/packages/twig/cypress/e2e/user-interface/icon.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/icon.cy.js
@@ -1,0 +1,16 @@
+describe("icon", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/icon");
+    cy.getPreview("icon").first().as("iconSection");
+  });
+
+  it("renders the icon component correctly", () => {
+    cy.get("@iconSection").within(() => {
+      cy.get("svg")
+        .should("exist")
+        .should("have.attr", "fill", "#000000")
+        .should("have.attr", "width", "24")
+        .should("have.attr", "height", "24");
+    });
+  });
+});

--- a/packages/twig/cypress/e2e/user-interface/read-me.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/read-me.cy.js
@@ -1,0 +1,22 @@
+describe("readmore", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/readmore");
+    cy.getPreview("readmore").first().as("readMoreSection");
+  });
+
+  it("renders the readmore component correctly", () => {
+    cy.get("@readMoreSection").within(() => {
+      cy.contains("Underlying the ILO’s work");
+      cy.contains("Read More");
+    });
+  });
+
+  it("check if the read more button works as expected", () => {
+    cy.get(".ilo--read-more--open").should("not.exist");
+    cy.contains("Close").should("not.exist");
+
+    cy.get("button").should("exist").click();
+    cy.contains("Close").should("exist");
+    cy.get(".ilo--read-more--open").should("exist");
+  });
+});

--- a/packages/twig/cypress/e2e/user-interface/tabs.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/tabs.cy.js
@@ -1,0 +1,48 @@
+describe("tabs", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/tabs");
+    cy.getPreview("tabs").first().as("tabsSection");
+  });
+
+  it("renders the tabs component correctly", () => {
+    cy.get("@tabsSection").within(() => {
+      cy.contains("Tab Label With A Really");
+      cy.contains("Tab Label 2");
+      cy.contains("Women construction workers in Nepal");
+
+      cy.get("picture").within(() => {
+        cy.get("source").should("have.length", 3);
+        cy.get("source")
+          .should("have.attr", "srcset")
+          .and("include", "/images/large.jpg");
+        cy.get("img")
+          .should("have.attr", "src")
+          .and("include", "/images/small.jpg");
+      });
+    });
+  });
+
+  it("checks if tab switch works as expected", () => {
+    cy.get("@tabsSection").within(() => {
+      // Check if first tab is selected
+
+      cy.get(".ilo--tabs--selection--button")
+        .first()
+        .should("have.attr", "aria-selected", "true");
+
+      // Fetch second tab and click it
+
+      cy.get(".ilo--tabs--selection--button")
+        .should("exist")
+        .eq(1)
+        .should("have.attr", "aria-selected", "false")
+        .click();
+
+      // Check if second tab is selected after click
+
+      cy.get(".ilo--tabs--selection--button")
+        .eq(1)
+        .should("have.attr", "aria-selected", "true");
+    });
+  });
+});

--- a/packages/twig/cypress/e2e/user-interface/tags.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/tags.cy.js
@@ -1,0 +1,16 @@
+describe("tags", () => {
+  beforeEach(() => {
+    cy.visit("/patterns/tags");
+    cy.getPreview("tags").first().as("tagsSection");
+  });
+
+  it("renders the tags component correctly", () => {
+    cy.get("@tagsSection").within(() => {
+      cy.contains("content 1");
+      cy.contains("content 2");
+      cy.contains("content 3");
+
+      cy.get(".ilo--tags").should("exist").children("li");
+    });
+  });
+});


### PR DESCRIPTION
### Notes :- 

Initial implementation of user interface :- 

[#455](https://github.com/international-labour-organization/designsystem/issues/455)

* Create tests for user interface rendering
* Create test for transitions

### Components :- 

- [x] Loading
- [x] Button
- [x] Icon
- [x] Read me
- [x] Tabs
- [x] Tags



