### PR TITLE
Fix(styles/themes): Chinese fonts not rendering correctly

### DIFF
--- a/.changeset/old-chairs-return.md
+++ b/.changeset/old-chairs-return.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/styles": patch
+"@ilo-org/themes": patch
+---
+
+Fixes a bug where Japanese characters were getting rendered instead of Chinese characters for some users.

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -6,11 +6,10 @@
     * Typography
     */
   --ilo-scale: 1; // default scale for the design system
-  --ilo-font-family: Overpass, Noto Sans, Noto Sans CJK JP, Yu Gothic,
-    Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑,
-    sans-serif;
-  --ilo-font-copy: Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans,
-    TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif;
+  --ilo-font-family: Overpass, Noto Sans, PingFang SC, Microsoft YaHei, 微软雅黑,
+    Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, sans-serif;
+  --ilo-font-copy: Noto Sans, PingFang SC, Microsoft YaHei, 微软雅黑,
+    Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, sans-serif;
   --ilo-font-family-headings: var(--ilo-font-family);
   --ilo-font-family-monospace: monospace;
   --ilo-line-height: 1.46;

--- a/packages/themes/tokens/fonts/base.json
+++ b/packages/themes/tokens/fonts/base.json
@@ -1,10 +1,10 @@
 {
   "fonts": {
     "display": {
-      "value": "Overpass, Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
+      "value": "Overpass, Noto Sans, PingFang SC, Microsoft YaHei, 微软雅黑, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, sans-serif"
     },
     "copy": {
-      "value": "Noto Sans, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, PingFang SC, Microsoft YaHei, 微软雅黑, sans-serif"
+      "value": "Noto Sans, PingFang SC, Microsoft YaHei, 微软雅黑, Noto Sans CJK JP, Yu Gothic, Hiragino Sans, TakaoPGothic, sans-serif"
     }
   }
 }


### PR DESCRIPTION
Fixes #986 

The problem was that in the `font-family` declarations, we were asking for Japanese system fonts before Chinese system fonts. Because Japanese system fonts include a subset of Chinese characters, those glyphs were getting rendered instead of the Chinese glyphs for the same character. Asking for the Chinese system fonts first systems to fix this without breaking Japanese font rendering.

I've only tested this on a Windows machine with Chrome (which is where we were having the problem, so it needs to be confirmed by Japanese and Chinese users on other devices). cc @inesdgomes 

## How to test

1. [Go to this website](https://pinkylam.me/generator/chinese-lorem-ipsum)
2. Copy all of the text that appears
3. [Go to the Twig deploy preview of this PR](https://deploy-preview-1089--ilo-ui-twig.netlify.app/?path=/docs/components-content-rich-text--rich-text)
4. Select `Canvas` in the top left 
5. Paste the Chinese text the content window of the controls menu at the bottom

![Screenshot 2024-06-28 at 14 39 23](https://github.com/international-labour-organization/designsystem/assets/12401179/fb366d7f-9a5e-4fc5-a59a-7d6f2535356d)

## Before & After Screenshots

### Chinese RichText Before

<img width="578" alt="RichText-Chinese-Before" src="https://github.com/international-labour-organization/designsystem/assets/12401179/8c3b5604-d0d1-48c4-a121-7aa72ba984fa">

### Chinese RichText After

<img width="566" alt="RichText-Chinese-After" src="https://github.com/international-labour-organization/designsystem/assets/12401179/88a645e0-9b99-4a13-9cf5-0ba0ef536971">

## Chinese Card Before

<img width="570" alt="Cards-Chinese-Before" src="https://github.com/international-labour-organization/designsystem/assets/12401179/913fcf2d-b2fc-42d3-b52d-0f8a500145c6">

## Chinese Card After

<img width="580" alt="Cards-Chinese-After" src="https://github.com/international-labour-organization/designsystem/assets/12401179/54bfdbb1-fc56-456f-bfa4-42f154260e64">

### Japanese RichText Before

<img width="552" alt="RichText-Japanese-Before" src="https://github.com/international-labour-organization/designsystem/assets/12401179/36092b56-ff2c-4bb3-8fc7-f683163bf7c7">

### Japanese RichText After

<img width="565" alt="RichText-Japanese-After" src="https://github.com/international-labour-organization/designsystem/assets/12401179/e9a2078e-ff44-4275-b317-fe92ee930e6f">

### Japanese Card Before

<img width="604" alt="Card-Japanese-Before" src="https://github.com/international-labour-organization/designsystem/assets/12401179/8d5be9ce-2534-4f48-80ce-3df5358a6553">

### Japanese Card After 

<img width="648" alt="Card-Japanese-After" src="https://github.com/international-labour-organization/designsystem/assets/12401179/cc4ccf7a-1328-412e-bc1d-6fb481b5bdcb">
