### PR TITLE
fix(maestro): add monorepo build scripts

### DIFF
--- a/packages/maestro/package.json
+++ b/packages/maestro/package.json
@@ -24,6 +24,8 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc && vite build",
+    "build:lib": "pnpm build",
+    "build:docs": "pnpm build",
     "lint": "eslint --ext .ts lib"
   },
   "dependencies": {


### PR DESCRIPTION
This adds aliases for the `build:lib` and `build:docs` scripts that get run by turborepo on all packages when we run those two commands. Without this you have to build maestro separately, which isn't ideal, it should get build with everything else in both scenarios: building the library and building the Storybook projects.