### PR TITLE
Twig Dynamic Imports

### DIFF
--- a/packages/maestro/src/plugin/twig.d.ts
+++ b/packages/maestro/src/plugin/twig.d.ts
@@ -2,6 +2,7 @@ type PluginParams = {
   namespaces: Record<string, string>;
   functions?: Record<string, unknown>;
   globalContext?: Record<string, unknown>;
+  dynamics?: string[];
 };
 function twig(args: PluginParams): PluginOption;
 

--- a/packages/maestro/src/vite.ts
+++ b/packages/maestro/src/vite.ts
@@ -6,6 +6,7 @@ import twig from "./plugin/twig";
 type Options = {
   namespaces: Record<string, string>;
   globals?: Record<string, unknown>;
+  dynamics?: string[];
 };
 
 function UIPatterns(options: Options) {
@@ -14,6 +15,7 @@ function UIPatterns(options: Options) {
     twig({
       namespaces: options.namespaces,
       globalContext: options.globals,
+      dynamics: options.dynamics,
       functions: {
         boolval: (instance: typeof Twig) =>
           //@ts-expect-error typedefintions are wrong


### PR DESCRIPTION
## Dynamic Imports

As mentioned in #1111, Mastro was unable to process the component that had imports like this 
```twig
{% include '@components/' ~ component ~ '/' ~ component ~ '.twig' with modaldata %}
```

The problem was that `vite-plugin-twig-drupal,` which is used under Maestro's hood, does not implement parsing the dynamic imports.

This PR allows Maestro to support imports like this.

## API

During the Maestro's integration, we have a new option named `dynamics`. This is a string array that should contain all component names that are using a dynamic import. 

```ts
export default defineConfig({
  plugins: UIPatterns({
    namespaces: {
      components: join(__dirname, "..", "src/components"),
    },
    globals: {
      prefix: "ilo",
    },
    dynamics: ["modal", "tabs"],
  }),
});
```

This helps the maestro prevent `cross-dynamic` imports. For example, if we have to support dynamic imports, we need to prepopulate the components that may be imported during development but exclude those that also have dynamic imports.

### Demo

https://github.com/user-attachments/assets/75a1e570-1e90-4136-bb29-b86ae98c5000

