### PR TITLE
build(twig): restored package.json fields

### DIFF
--- a/packages/twig-new/.eslintrc.cjs
+++ b/packages/twig-new/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: ["@ilo-org/eslint-config"],
+  globals: {
+    Drupal: true,
+    cy: true,
+  },
+  ignorePatterns: ["dist/"],
+};

--- a/packages/twig-new/.gitignore
+++ b/packages/twig-new/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 *storybook.log
+storybook-static/

--- a/packages/twig-new/package.json
+++ b/packages/twig-new/package.json
@@ -46,8 +46,8 @@
   ],
   "scripts": {
     "build:lib": "rollup -c",
+    "build:docs": "storybook build -o ./storybook-static",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
     "start:theme": "docker compose up -d",
     "cy:open": "cypress open",
     "test": "cypress run",

--- a/packages/twig-new/package.json
+++ b/packages/twig-new/package.json
@@ -1,10 +1,48 @@
 {
-  "name": "twig-new",
-  "private": true,
-  "version": "0.0.0",
+  "name": "@ilo-org/twig-new",
+  "version": "1.2.0",
   "type": "module",
   "files": [
     "dist/**/*"
+  ],
+  "license": "Apache-2.0",
+  "description": "Twig components for the ILO's Design System",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://twig.ui.ilo.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/international-labour-organization/designsystem.git",
+    "directory": "packages/twig"
+  },
+  "keywords": [
+    "ui_patterns",
+    "prototyping",
+    "twig",
+    "designsystem",
+    "components"
+  ],
+  "contributors": [
+    {
+      "name": "Justin Smith",
+      "email": "smithj@ilo.org",
+      "url": "https://github.com/justintemps"
+    },
+    {
+      "name": "Prabashwara Seneviratne",
+      "url": "https://www.bash.lk"
+    },
+    {
+      "name": "Shashika Boteju",
+      "email": "Shashikaboteju3@gmail.com",
+      "url": "https://github.com/Shashika6"
+    },
+    {
+      "name": "Giorgi Kapanadze",
+      "email": "doublegkapanadze@gmail.com",
+      "url": "https://github.com/ggkapanadze"
+    }
   ],
   "scripts": {
     "build:lib": "rollup -c",
@@ -13,10 +51,15 @@
     "start:theme": "docker compose up -d",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test": "cypress run"
+    "test": "cypress run",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --check . --ignore-path ../../.prettierignore",
+    "format:fix": "prettier --write . --ignore-path ../../.prettierignore"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.5.0",
+    "@ilo-org/eslint-config": "workspace:*",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/twig-new/package.json
+++ b/packages/twig-new/package.json
@@ -50,7 +50,6 @@
     "build-storybook": "storybook build",
     "start:theme": "docker compose up -d",
     "cy:open": "cypress open",
-    "cy:run": "cypress run",
     "test": "cypress run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/twig-new/src/components/modal/modal.component.yml
+++ b/packages/twig-new/src/components/modal/modal.component.yml
@@ -55,7 +55,7 @@ modal:
     modalLabel:
       type: string
       label: Modal Label
-      description: A modal label added to aria-label attribute to improve accessibility 
+      description: A modal label added to aria-label attribute to improve accessibility
       preview: "modal"
       required: false
   visibility: storybook

--- a/packages/twig-new/src/components/search/search.js
+++ b/packages/twig-new/src/components/search/search.js
@@ -1,4 +1,4 @@
-import { EVENTS, ARIA } from "@ilo-org/utils";
+import { EVENTS } from "@ilo-org/utils";
 
 /**
  * The Search module which handles the clear button.
@@ -87,7 +87,7 @@ export default class Search {
   /**
    * Onclick interaction with the clear button
    */
-  onClick(e) {
+  onClick() {
     this.searchInputField.value = "";
     this.searchButton.classList.remove("show");
   }

--- a/packages/twig-new/src/components/tooltip/tooltip.js
+++ b/packages/twig-new/src/components/tooltip/tooltip.js
@@ -4,7 +4,7 @@
  * @class Tooltip
  */
 
-import { createPopper, right } from "@popperjs/core";
+import { createPopper } from "@popperjs/core";
 
 export default class Tooltip {
   /**
@@ -111,7 +111,7 @@ export default class Tooltip {
     return this;
   }
 
-  postMouseOver(hoverRect) {
+  postMouseOver() {
     const ttNode = this.tooltip;
     this.setMaxWidthAndClass(this.tooltip);
     if (ttNode != null) {

--- a/packages/twig-new/stories/card_data.stories.js
+++ b/packages/twig-new/stories/card_data.stories.js
@@ -19,9 +19,10 @@ const [
 ] = story.stories;
 
 export default Meta;
-export { Default, Two_Columns, Two_Columns_No_Image, Two_Columns_No_Links };
-
-No_Image.storyName = "No Image";
-Two_Columns.storyName = "Two Columns";
-Two_Columns_No_Image.storyName = "Two Columns No Image";
-Two_Columns_No_Links.storyName = "Two Columns No Links";
+export {
+  Default,
+  No_Image,
+  Two_Columns,
+  Two_Columns_No_Image,
+  Two_Columns_No_Links,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -791,6 +791,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: ^1.5.0
         version: 1.5.0(react@16.14.0)
+      '@ilo-org/eslint-config':
+        specifier: workspace:*
+        version: link:../../config/eslint-config
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
         version: 1.1.0(rollup@3.23.0)(vite@5.3.1)


### PR DESCRIPTION
Fixes #1116 

This PR restores all the fields in package.json to be similar to the old twig package. Since the lint commands did not run without the config, this PR also restores and adapts the ESLint config and fixes the lint errors that it found.

⚠️ This should probably be merged just before the old twig package is removed. This PR assumes that several scripts will be added in other PRs.