### PR TITLE
Twig: Breadcrumb isn't rendered correctly in new Storybook

### DIFF
--- a/.changeset/green-roses-lick.md
+++ b/.changeset/green-roses-lick.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Fix breadcrumb not rendering middle links in the context area

--- a/packages/twig/src/components/breadcrumb/breadcrumb.js
+++ b/packages/twig/src/components/breadcrumb/breadcrumb.js
@@ -107,7 +107,6 @@ export default class Breadcrumb {
   enable() {
     // Handle resizing events
     window.addEventListener(EVENTS.RESIZE, (e) => this.onResize(e));
-
     if (this.contextButton) {
       // When the context button gets clicked
       this.contextButton.addEventListener(EVENTS.CLICK, (e) => this.onClick(e));
@@ -115,9 +114,8 @@ export default class Breadcrumb {
       // We only need the keydown handler to manage tab navigation when the
       // context menu is visible
       this.element.addEventListener("keydown", (e) => this.onKeydown(e));
-
-      return this;
     }
+    return this;
   }
 
   /**

--- a/packages/twig/src/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/components/breadcrumb/breadcrumb.twig
@@ -1,15 +1,14 @@
 {# breadcrumb.twig #}
-
 {# If a home field is passed, it will be used as the first link #}
 {# THE `HOME` FIELD WILL BE DEPRECATED IN FUTURE VERSIONS AND SHOULD NOT BE USED #}
 {% if home %}
 	{% set firstlink = home %}
-	{% set contextLinks = links|slice(0, items|length - 1) %}
+	{% set contextLinks = links|slice(0, links|length - 1) %}
 {% endif %}
 
 {% if not home %}
 	{% set firstlink = links|first %}
-	{% set contextLinks = links|slice(1, items|length - 1) %}
+	{% set contextLinks = links|slice(1, links|length - 1) %}
 {% endif %}
 
 {% set lastlink = links|last %}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/1144

Note :- 

* Fixed the breadcrumb not rendering middle links
* Refactored from items to links. (Same as react)

Screenshot 

<img width="689" alt="Screenshot 2024-08-02 at 03 08 08" src="https://github.com/user-attachments/assets/6901da6c-ed62-4cfb-a1ef-88bdd74e23fa">

