### PR TITLE
Twig Docs: Story containers are too narrow

### DIFF
--- a/packages/maestro/src/generator/create.ts
+++ b/packages/maestro/src/generator/create.ts
@@ -34,7 +34,7 @@ function parameters(
   pattern: UIPatternValue
 ): MaestroStory["meta"]["parameters"] {
   return {
-    layout: "centered",
+    layout: "padded",
     docs: {
       description: {
         component: pattern.description,


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/1143

**Note :-** 

* Currently Maestro sets the components to be centered.

**Fix :-** 

* Layout should be changed to padded instead as it gives more space for the component to fit

**Screenshot :-** 

<img width="1095" alt="Screenshot 2024-08-04 at 15 47 17" src="https://github.com/user-attachments/assets/22581fda-a102-44f8-b202-8ea7eaabe18e">


