### PR TITLE
docs(twig): refactor fonts to use overpass where needed

### DIFF
--- a/packages/twig/.storybook/manager-head.html
+++ b/packages/twig/.storybook/manager-head.html
@@ -1,8 +1,19 @@
 <!-- .storybook/manager-head.html -->
+<style>
+  @import url("/fonts/fonts-google.css");
+  @import url("https://fonts.googleapis.com/css2?family=Overpass&display=swap");
+  @import url("https://fonts.googleapis.com/css2?family=Fira Code&display=swap");
+</style>
 
 <!-- Canonical URL -->
-
 <link href="https://twig.ui.ilo.org" rel="canonical" />
 
 <!-- Favicon -->
-<link rel="icon" type="image/svg+xml" href="images/favicon.svg">
+<link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
+
+<!-- Fonts -->
+<style>
+  .sidebar-container, .docblock-argstable-body, .docblock-argstable-head {
+    font-family: "Overpass", sans-serif !important; /* Customize the sidebar font */
+  }
+</style>

--- a/packages/twig/.storybook/preview.js
+++ b/packages/twig/.storybook/preview.js
@@ -4,6 +4,7 @@ import "@ilo-org/fonts/font-css/fonts-google.css";
 import "@ilo-org/styles/scss/index.scss";
 import "@ilo-org/styles/scss/global.scss";
 import { BehaviorDecorator } from "@ilo-org/maestro/storybook";
+import "./styles.scss";
 
 /** @type { import('@storybook/html').Preview } */
 const preview = {

--- a/packages/twig/.storybook/styles.scss
+++ b/packages/twig/.storybook/styles.scss
@@ -1,0 +1,30 @@
+@import "@ilo-org/themes/build/scss/tokens";
+@import "@ilo-org/styles/scss/monorepo";
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--ilo-fonts-display) !important;
+}
+
+body {
+  font-family: var(--ilo-fonts-copy) !important;
+}
+
+button[title="Zoom in"]:hover,
+button[title="Zoom out"]:hover,
+button[title="Reset zoom"]:hover {
+  color: $brand-ilo-dark-blue;
+  background-color: $brand-ilo-light-blue;
+}
+
+a[class*="ilo--button"] {
+  color: $brand-ilo-dark-blue;
+
+  &:hover {
+    color: $brand-ilo-blue;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/1141

Note :- 

Use Overpass in the following storybook elements.

- [ ] Sidebar
- [ ] Story Content
- [ ] Args Table
- [ ] Docs Pages 
