### PR TITLE
Wingsuit export 

### DIFF
--- a/.changeset/neat-berries-pretend.md
+++ b/.changeset/neat-berries-pretend.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": minor
+---
+
+We have introduced `*.component.yml` files as the new standard for pattern configuration. These files will serve as the source of truth for future releases. While `*.wingsuit.yml` files are still supported, they will be deprecated. Also this version removes [Wingsuit](https://wingsuit-designsystem.github.io/) and several other dependencies that were used to build the Twig Storybook packages. In doing so, we've rebuilt the package from the ground up and re-implemented the build workflows.

--- a/.changeset/short-dingos-repair.md
+++ b/.changeset/short-dingos-repair.md
@@ -1,9 +1,0 @@
----
-"@ilo-org/twig": major
----
-
-This version removes [Wingsuit](https://wingsuit-designsystem.github.io/) and several other dependencies that were used to build the Twig Storybook packages. In doing so, we've rebuilt the package from the ground up and re-implemented the build workflows.
-
-**Breaking Changes**
-
-- Pattern definition files have been renamed from `*.wingsuit.yml` to `*.component.yml`

--- a/packages/twig/rollup.config.js
+++ b/packages/twig/rollup.config.js
@@ -47,6 +47,17 @@ const copyConfig = copy({
       },
     },
     {
+      src: "src/components/**/**.component.yml",
+      dest: "dist/components/",
+      rename: (name, extension, fullPath) => {
+        const componentFolder = fullPath.match(
+          /(.*)\/(.*)\/(.*).component.yml$/
+        )?.[2];
+        const componentName = name.split(".").at();
+        return `${componentFolder}/${componentName}.wingsuit.${extension}`;
+      },
+    },
+    {
       src: "src/components/**/**.twig",
       dest: "dist/components/",
       rename: (name, extension, fullPath) => {


### PR DESCRIPTION
## Description

Creating a `2.0` for only the filename change will be a bit overkill; since we haven't introduced any `specification` change for the pattern definition file, we can also export `*.wingsuit.yml` files to support `1.x` 


## Dist Folder
![image](https://github.com/user-attachments/assets/5af4e692-c2a3-473b-9383-5741a959eae2)
