### PR TITLE
chore(twig) - pin tests to specific base theme version

### DIFF
--- a/packages/twig/docker-compose.yml
+++ b/packages/twig/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     backend:
-        image: "ghcr.io/international-labour-organization/ilo_base_theme:0.x"
+        image: "ghcr.io/international-labour-organization/ilo_base_theme:0.4.0"
         ports:
             - 8082:80
         volumes:


### PR DESCRIPTION
### Note :- 

* Pin CI to use specific base theme version. This is to prevent changes in the base theme from breaking the build pipeline in the design system.