### PR TITLE
fix(twig): make image optional in multilink card

### DIFF
--- a/.changeset/blue-flies-report.md
+++ b/.changeset/blue-flies-report.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+Make image optional in multilink card

--- a/packages/react/src/components/Cards/MultilinkCard/MultiLinkCard.tsx
+++ b/packages/react/src/components/Cards/MultilinkCard/MultiLinkCard.tsx
@@ -26,6 +26,7 @@ const MultilinkCard: FC<MultilinkCardProps> = ({
     [`${baseClass}__size__${size}`]: size,
     [`${baseClass}__isvideo`]: isvideo,
     [`${baseClass}__linklist`]: linklist,
+    [`${baseClass}__no-image`]: !image,
   });
 
   return (

--- a/packages/styles/scss/components/_multilinkcard.scss
+++ b/packages/styles/scss/components/_multilinkcard.scss
@@ -125,6 +125,14 @@
                 display: none;
               }
             }
+
+            &#{$self}--no-image {
+              --max-width: #{px-to-rem(920px)};
+
+              #{$self}--content {
+                width: 100%;
+              }
+            }
           }
         }
       }

--- a/packages/twig/src/components/card_multilink/card_multilink.twig
+++ b/packages/twig/src/components/card_multilink/card_multilink.twig
@@ -1,12 +1,13 @@
 {# card_multilink.twig #}
 
-<div class="{{prefix}}--card {{prefix}}--card__type__multilink {% if link|length > 0 %} {{prefix}}--card__action {% endif %} {{prefix}}--card__size__{{size}} {% if isvideo|boolval %} {{prefix}}--card__isvideo {% endif %} {% if linklist %} {{prefix}}--card__linklist {% endif %} {% if size == "wide" or size == "fluid" %} {{prefix}}--card__align__{{alignment}} {% endif %}">
+<div class="{{prefix}}--card {{prefix}}--card__type__multilink {% if link|length > 0 %} {{prefix}}--card__action {% endif %} {{prefix}}--card__size__{{size}} {% if isvideo|boolval %} {{prefix}}--card__isvideo {% endif %} {% if linklist %} {{prefix}}--card__linklist {% endif %} {% if size == "wide" or size == "fluid" %} {{prefix}}--card__align__{{alignment}} {% endif %} {% if not image %} {{prefix}}--card--no-image {% endif %}">
 	{% if link|length > 0 %}
 		<a class="{{prefix}}--card--link" href="{{link}}" title="{{title}}">
 			<span class="{{prefix}}--card--link--text">{{title}}</span>
 		</a>
 	{% endif %}
 	<div class="{{prefix}}--card--wrap">
+		{% if image %}
 		<div class="{{prefix}}--card--image--wrapper">
 			{% include "@components/picture/picture.twig" with {
         image: image,
@@ -14,6 +15,7 @@
       }
       %}
 		</div>
+			{% endif %}
 		<div class="{{prefix}}--card--content">
 			{% if eyebrow %}
 				<p class="{{prefix}}--card--eyebrow">{{eyebrow}}</p>


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/864

### Notes

* Make image optional in multilink card
* Add max-width to wide and fluid when image is available. 

### Screenshot

![Screenshot 2024-08-23 at 19 40 25](https://github.com/user-attachments/assets/3bef35f4-304f-4d4b-a776-cde8bade2c0a)
