### PR TITLE
fix(react-twig): refactor light social media icon color

### DIFF
--- a/.changeset/cool-baboons-mix.md
+++ b/.changeset/cool-baboons-mix.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Refactor social media icon color in light theme

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -7,9 +7,10 @@
   $c: &;
   $default-theme: "light";
   $icon-size: $spacing-spacing-4;
+  $ilo-color-blue: "rgba(30, 45, 190, 1)";
 
   @mixin get-icon($icon, $theme: $default-theme) {
-    @include dataurlicon($icon, rgba(30, 45, 190, 1));
+    @include dataurlicon($icon, $ilo-color-blue);
 
     &:hover {
       @include dataurlicon(

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -9,10 +9,7 @@
   $icon-size: $spacing-spacing-4;
 
   @mixin get-icon($icon, $theme: $default-theme) {
-    @include dataurlicon(
-      $icon,
-      map-get($color, "socialmedia", $theme, "icon", "color")
-    );
+    @include dataurlicon($icon, rgba(30, 45, 190, 1));
 
     &:hover {
       @include dataurlicon(

--- a/packages/styles/scss/components/_socialmedia.scss
+++ b/packages/styles/scss/components/_socialmedia.scss
@@ -7,10 +7,9 @@
   $c: &;
   $default-theme: "light";
   $icon-size: $spacing-spacing-4;
-  $ilo-color-blue: "rgba(30, 45, 190, 1)";
 
   @mixin get-icon($icon, $theme: $default-theme) {
-    @include dataurlicon($icon, $ilo-color-blue);
+    @include dataurlicon($icon, var(--ilo-color-blue));
 
     &:hover {
       @include dataurlicon(


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/1012

### Notes

* Refactor social media icon color in light theme