### PR TITLE
fix(react-twig): refactor cta to use button component

### DIFF
--- a/.changeset/thick-feet-retire.md
+++ b/.changeset/thick-feet-retire.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/twig": patch
+---
+
+Refactor cardgroup to use button component for cta instead of using button css classes

--- a/packages/react/src/components/Cards/CardGroup/CardGroup.tsx
+++ b/packages/react/src/components/Cards/CardGroup/CardGroup.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import classnames from "classnames";
 import useGlobalSettings from "../../../hooks/useGlobalSettings";
+import { Button } from "../../Button";
 import { CardGroupProps } from "./CardGroup.props";
 import { DataCard } from "../DataCard";
 import { DetailCard } from "../DetailCard";
@@ -62,12 +63,13 @@ const CardGroup: FC<CardGroupProps> = ({
       </div>
       {cta && (
         <div className={`${baseClass}--button-wrap`}>
-          <a
-            className={`${prefix}--button ${prefix}--button--medium ${prefix}--button--secondary`}
-            href={cta.url}
-          >
-            <span className="button__label">{cta.label}</span>
-          </a>
+          <Button
+            kind="button"
+            type="secondary"
+            size="medium"
+            label={cta.label}
+            url={cta.url}
+          />
         </div>
       )}
     </div>

--- a/packages/twig/src/components/cardgroup/cardgroup.twig
+++ b/packages/twig/src/components/cardgroup/cardgroup.twig
@@ -36,12 +36,12 @@
 	</div>
 	{% if cta %}
 		<div class="{{prefix}}--cardgroup--button-wrap">
-				{% include '@components/button/button.twig' with {
+		  {% include '@components/button/button.twig' with {
           label: cta.label,
           url: cta.url,
           size: "medium",
           type: "secondary",
-        } %}
+      } %}
 		</div>
 	{% endif %}
 </div>

--- a/packages/twig/src/components/cardgroup/cardgroup.twig
+++ b/packages/twig/src/components/cardgroup/cardgroup.twig
@@ -36,9 +36,12 @@
 	</div>
 	{% if cta %}
 		<div class="{{prefix}}--cardgroup--button-wrap">
-			<a class="{{prefix}}--button {{prefix}}--button--medium {{prefix}}--button--secondary" href="{{cta.url}}">
-				<span class="button__label">{{ cta.label }}</span>
-			</a>
+				{% include '@components/button/button.twig' with {
+          label: cta.label,
+          url: cta.url,
+          size: "medium",
+          type: "secondary",
+        } %}
 		</div>
 	{% endif %}
 </div>


### PR DESCRIPTION
Fixes https://github.com/international-labour-organization/designsystem/issues/1182

### Notes

* Refactor cardgroup to use the button component directly instead of using css classes.

### Screenshot

![Screenshot 2024-08-29 at 11 33 52](https://github.com/user-attachments/assets/df31e0fe-fe33-4bde-aca4-745286e94385)
