### PR TITLE
ci(github): removed outdated version name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js 16.14.0
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20.16.0


### PR DESCRIPTION
When the node version was update, we accidentally forgot to update the version name in the Github action step. This remove the version entirely from the step name since we don't really need it.