### PR TITLE
fix(twig): breadcrumb showing the last element twice

### DIFF
--- a/.changeset/fast-elephants-drum.md
+++ b/.changeset/fast-elephants-drum.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Fixed bug where the last link in the Breadcrumb was rendering twice

--- a/packages/twig/cypress/e2e/navigation/breadcrumb.cy.js
+++ b/packages/twig/cypress/e2e/navigation/breadcrumb.cy.js
@@ -4,17 +4,34 @@ describe("breadcrumb", () => {
     cy.getPreview("breadcrumb").first().as("breadcrumbSection");
   });
 
-  it("renders the breadcrumb correctly", () => {
-    cy.get("@breadcrumbSection").within(() => {
-      cy.get(".ilo--breadcrumb--items")
-        .should("not.contain", "Link One")
-        .find("ol")
-        .should("exist");
+  it("should render five links in desktop view", () => {
+    cy.viewport(1280, 720);
+    cy.get(".ilo--breadcrumb--link").should("have.length", 5);
+  });
 
-      cy.contains("Link Two");
-      cy.contains("Link Three");
-      cy.contains("Link Four");
-      cy.contains("Link Five");
-    });
+  it("should render the first link with an :after pseudo-element that has a background image", () => {
+    cy.get(".ilo--breadcrumb--item__first .ilo--breadcrumb--link").then(
+      ($el) => {
+        const afterContent = window.getComputedStyle($el[0], "::after");
+        expect(afterContent.getPropertyValue("background-image")).to.not.equal(
+          "none"
+        );
+      }
+    );
+  });
+
+  it("should not render context menu links in mobile view initially", () => {
+    cy.viewport(375, 667);
+    cy.get(".ilo--breadcrumb--context--menu").should("be.hidden");
+  });
+
+  it("should have the correct number of links in the context menu", () => {
+    cy.get(".ilo--context-menu--item").should("have.length", 3);
+  });
+
+  it("should render context menu links when the context button is clicked in mobile view", () => {
+    cy.viewport(375, 1200);
+    cy.get(".ilo--breadcrumb--context--button").click();
+    cy.get(".ilo--breadcrumb--context--menu").should("not.be.hidden");
   });
 });

--- a/packages/twig/src/components/breadcrumb/breadcrumb.twig
+++ b/packages/twig/src/components/breadcrumb/breadcrumb.twig
@@ -3,12 +3,12 @@
 {# THE `HOME` FIELD WILL BE DEPRECATED IN FUTURE VERSIONS AND SHOULD NOT BE USED #}
 {% if home %}
 	{% set firstlink = home %}
-	{% set contextLinks = links|slice(0, links|length - 1) %}
+	{% set contextLinks = links|slice(0, links|length - 2) %}
 {% endif %}
 
 {% if not home %}
 	{% set firstlink = links|first %}
-	{% set contextLinks = links|slice(1, links|length - 1) %}
+	{% set contextLinks = links|slice(1, links|length - 2) %}
 {% endif %}
 
 {% set lastlink = links|last %}


### PR DESCRIPTION
See screenshots. 

![image-20240913-162337](https://github.com/user-attachments/assets/d3b364fc-4c5a-4dbf-8295-1b315533402d)
![image-20240912-155543](https://github.com/user-attachments/assets/f982c1a2-0069-42b1-a740-25f330481b0d)
