### PR TITLE
Fix(Twig): backwards compatibility for social media component

### DIFF
--- a/.changeset/ninety-cycles-cough.md
+++ b/.changeset/ninety-cycles-cough.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Adds backward compatibility to the socialmedia component which in 1.1.1 removed the twitter icon and replaced it with X. With this, passing `twitter` to as an argument to the icon field will render an X icon.

--- a/packages/twig/cypress/e2e/navigation/social-media.cy.js
+++ b/packages/twig/cypress/e2e/navigation/social-media.cy.js
@@ -1,46 +1,73 @@
-describe("social media", () => {
+import fixture from "../../fixtures/socialmedia.json";
+
+const url = `/pattern-preview?id=socialmedia&fields=${encodeURI(
+  JSON.stringify(fixture)
+)}`;
+
+describe("Social Media", () => {
   beforeEach(() => {
-    cy.visit("/patterns/socialmedia");
-    cy.getPreview("socialmedia").first().as("socialMediaSection");
+    cy.visit(url);
+    cy.get(".ilo--social-media").as("socialMedia");
   });
 
-  it("checks if social media renders as expected", () => {
-    cy.get("@socialMediaSection").within(() => {
-      cy.get(".ilo--social-media")
-        .should("exist")
-        .within(() => {
-          cy.get(".ilo--social-media--list--item")
-            .first()
-            .within(() => {
-              cy.get("a").should("have.attr", "title", "X");
-            });
-
-          cy.get(".ilo--social-media--list--item")
-            .last()
-            .within(() => {
-              cy.get("a").should("have.attr", "title", "Youtube");
-            });
-        });
+  it("renders the headline if provided", () => {
+    cy.fixture("socialmedia").then((data) => {
+      if (data.headline) {
+        cy.get("@socialMedia")
+          .find("h5.ilo--social-media--headline")
+          .should("contain.text", data.headline);
+      } else {
+        cy.get("@socialMedia")
+          .find("h5.ilo--social-media--headline")
+          .should("not.exist");
+      }
     });
   });
 
-  it("checks for navigation in social media icons", () => {
-    cy.get("@socialMediaSection").within(() => {
-      cy.get(".ilo--social-media")
-        .should("exist")
-        .within(() => {
-          cy.get(".ilo--social-media--list--item")
-            .eq(2)
-            .within(() => {
-              cy.get("a")
-                .should(
-                  "have.attr",
-                  "href",
-                  "https://www.linkedin.com/company/international-labour-organization-ilo"
-                )
-                .should("have.attr", "target", "_blank");
-            });
-        });
-    });
+  it("renders the correct number of social media icons", () => {
+    cy.get("@socialMedia")
+      .find("li.ilo--social-media--list--item")
+      .should("have.length", fixture.icons.length);
+  });
+
+  it("should ensure each icon has a background image with a data url", () => {
+    cy.visit(url);
+    cy.get("@socialMedia")
+      .find("ul.ilo--social-media--list li a")
+      .each(($icon) => {
+        cy.wrap($icon)
+          .should("have.css", "background-image")
+          .and("match", /url\(.+\)/);
+      });
+  });
+
+  it("should ensure Twitter and X icons have the same background image", () => {
+    let xIconBg, twitterIconBg;
+
+    // Get the X icon
+    cy.get("@socialMedia")
+      .find('a:contains("X")')
+      .then(($xIcon) => {
+        xIconBg = $xIcon.css("background-image");
+      });
+
+    // Get the Twitter icon by its text content
+    cy.get("@socialMedia")
+      .find('a:contains("Twitter")')
+      .then(($twitterIcon) => {
+        twitterIconBg = $twitterIcon.css("background-image");
+      })
+      .then(() => {
+        expect(xIconBg).to.equal(twitterIconBg);
+      });
+  });
+
+  it("should ensure each icon has a title attribute", () => {
+    cy.visit(url);
+    cy.get("@socialMedia")
+      .find("ul.ilo--social-media--list li a")
+      .each(($icon) => {
+        cy.wrap($icon).should("have.attr", "title");
+      });
   });
 });

--- a/packages/twig/cypress/fixtures/socialmedia.json
+++ b/packages/twig/cypress/fixtures/socialmedia.json
@@ -1,0 +1,50 @@
+{
+  "headline": "Follow us on social media",
+  "icons": [
+    {
+      "icon": "tiktok",
+      "label": "tiktok",
+      "url": "https://tiktok.com/ilo"
+    },
+    {
+      "icon": "flickr",
+      "label": "flickr",
+      "url": "https://flickr.com/ilo"
+    },
+    {
+      "icon": "x",
+      "label": "x",
+      "url": "https://x.com/ilo"
+    },
+    {
+      "icon": "youtube",
+      "label": "youtube",
+      "url": "https://youtube.com/ilo"
+    },
+    {
+      "icon": "twitter",
+      "label": "twitter",
+      "url": "https://x.com/ilo"
+    },
+    {
+      "icon": "facebook",
+      "label": "facebook",
+      "url": "https://facebook.com/ilo"
+    },
+    {
+      "icon": "instagram",
+      "label": "instagram",
+      "url": "https://instagram.com/ilo"
+    },
+    {
+      "icon": "linkedin",
+      "label": "linkedin",
+      "url": "https://linkedin.com/ilo"
+    }
+  ],
+  "settings": {
+    "theme": "light",
+    "justify": "start",
+    "iconSize": "normal"
+  }
+}

--- a/packages/twig/src/components/socialmedia/socialmedia.twig
+++ b/packages/twig/src/components/socialmedia/socialmedia.twig
@@ -1,15 +1,15 @@
-{#
-  SOCIALMEDIA COMPONENT
-#}
+{# socialmedia.twig #}
 <div class="{{ prefix }}--social-media {{ prefix }}--social-media__theme__{{ theme|default("light") }} {{ prefix }}--social-media__justify__{{ align|default("start") }}">
     {% if headline %}
         <h5 class="{{ prefix }}--social-media--headline">{{ headline }}</h5>
     {% endif %}
     <ul class="{{ prefix }}--social-media--list">
         {% for item in icons %}
+            {# @TODO: Get rid of this during the next major release#}
+            {% set iconName = item.icon == 'twitter' ? 'x' : item.icon %}
             <li class="{{ prefix }}--social-media--list--item">
-                <a class="{{ prefix }}--social-media--list--item--icon {{ prefix }}--social-media--list--item--icon__{{ iconSize|default("normal") }} {{ prefix }}--social-media--list--item--icon__{{ item.icon }}" href={{ item.url }} title={{ item.label|capitalize }} target="_blank">
-                    {{item.label|capitalize}}
+                <a class="{{ prefix }}--social-media--list--item--icon {{ prefix }}--social-media--list--item--icon__{{ iconSize|default("normal") }} {{ prefix }}--social-media--list--item--icon__{{ iconName }}" href="{{ item.url }}" title="{{ item.label|capitalize }}" target="_blank">
+                    {{ item.label|capitalize }}
                 </a>
             </li>
         {% endfor %}


### PR DESCRIPTION
This adds backward compatibility to the socialmedia component which in 1.1.1 removed the twitter icon and replaced it with X. With this, passing `twitter` to as an argument to the icon field will render an X icon.

Before merging it, we need to add some tests to the social media component. However, the tests that we have now are really testing the component, they're testing the arguments passed to the component from patterns, which is wrong.

I tried to update the tests using the ilo_base_theme pattern preview, but was unable. I've opened [#34](https://github.com/international-labour-organization/ilo_base_theme/issues/34) in that repo to track.