### PR TITLE
Hotfix: Data Cards can pass a `target` to file buttons

### DIFF
--- a/.changeset/healthy-foxes-beam.md
+++ b/.changeset/healthy-foxes-beam.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Data Cards can pass a `target` to buttons rendered by `dataset.files.items`. This fixes some inconsistent handling in cases where those links were pointing to files.

--- a/packages/twig/cypress/e2e/cards/data-card.cy.js
+++ b/packages/twig/cypress/e2e/cards/data-card.cy.js
@@ -22,4 +22,39 @@ describe("Data card", () => {
         });
       });
   });
+
+  it("ensures all file buttons have a target property", () => {
+    cy.visit("/patterns/datacard");
+    cy.getPreview("datacard")
+      .first()
+      .within(() => {
+        cy.get(".ilo--card__type__data--content-files")
+          .find("a, button")
+          .each(($el) => {
+            cy.wrap($el).should("have.attr", "target");
+          });
+      });
+  });
+
+  it("Ensures file buttons have the correct target", () => {
+    cy.visit("/patterns/datacard");
+    cy.getPreview("datacard")
+      .first()
+      .within(() => {
+        cy.get(".ilo--card__type__data--content-files")
+          .find("a, button")
+          .eq(0) // First element
+          .should("have.attr", "target", "_blank");
+
+        cy.get(".ilo--card__type__data--content-files")
+          .find("a, button")
+          .eq(1) // Second element
+          .should("have.attr", "target", "_parent");
+
+        cy.get(".ilo--card__type__data--content-files")
+          .find("a, button")
+          .eq(2) // Third element
+          .should("have.attr", "target", "_self");
+      });
+  });
 });

--- a/packages/twig/src/components/card_data/card_data.component.yml
+++ b/packages/twig/src/components/card_data/card_data.component.yml
@@ -8,7 +8,7 @@ datacard:
     dataset:
       type: object
       label: Dataset object
-      description: Array of Content (label, copy), Files object (optional headline, array of items with label and url) and Links object (optional headline, array of items with label and url)
+      description: Array of Content (label, copy), Files object (optional headline, array of items with label, url and target) and Links object (optional headline, array of items with label and url)
       preview:
         content:
           items:
@@ -21,8 +21,10 @@ datacard:
           items:
             - label: PDF 3.2 MB
               url: "https://www.ilo.org"
+              target: "_blank"
             - label: EPUB 5.8 MB
               url: "https://www.ilo.org"
+              target: "_parent"
             - label: MOBI 2.4 MB
               url: "https://www.ilo.org"
         cta:

--- a/packages/twig/src/components/card_data/card_data.twig
+++ b/packages/twig/src/components/card_data/card_data.twig
@@ -55,7 +55,8 @@
                   size: "small",
                   url: item.url,
                   label: item.label,
-                  prefix: prefix
+                  prefix: prefix,
+									target: item.target|default('_self')
                 } only %}
 							{% endfor %}
 						</div>


### PR DESCRIPTION
From a developer of ilo.org: 

“We need a change in the Design System, so that in card_data.twig we pass target: item.target when looping through dataset.files.items to build the file download buttons. This way we can pass “_blank” for PDFs.”

This corrects this issue and includes some tests to make sure it works.