### PR TITLE
Changelog

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -22,6 +22,13 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-essentials"),
     getAbsolutePath("@storybook/addon-interactions"),
     getAbsolutePath("storybook-addon-rtl"),
+    {
+      name: "@storybook/addon-docs",
+      options: {
+        transcludeMarkdown: true,
+        configureJSX: true,
+      },
+    },
   ],
   framework: {
     name: getAbsolutePath("@storybook/react-vite"),

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -26,7 +26,12 @@ const preview: Preview = {
     options: {
       storySort: {
         method: "alphabetical",
-        order: ["ILO Design System for React", "Getting Started"],
+        order: [
+          "ILO Design System for React",
+          "Getting Started",
+          ["Introduction"],
+          "Components",
+        ],
         locales: "en-US",
       },
     },
@@ -42,12 +47,6 @@ const preview: Preview = {
     },
     viewMode: "docs",
     layout: "padded",
-    docs: {
-      theme: theme,
-      source: {
-        excludeDecorators: true,
-      },
-    },
   },
 };
 

--- a/packages/react/src/stories/docs/changelog.mdx
+++ b/packages/react/src/stories/docs/changelog.mdx
@@ -1,0 +1,15 @@
+import Changelog from "../../../CHANGELOG.md?raw";
+import "./styles/changelog.scss";
+import { Meta, Markdown } from "@storybook/blocks";
+
+<Meta title="Getting Started / Changelog" />
+
+# Changelog
+
+The `@ilo-org/react` package follows [Semantic Versioning](https://semver.org/). This changelog lists the changes for each version of the package.
+
+🚧 Keep in mind `@ilo-org/` packages are versioned independatly.
+
+<div className="changelog">
+  <Markdown>{Changelog.substring(Changelog.indexOf("\n") + 1)}</Markdown>
+</div>

--- a/packages/react/src/stories/docs/styles/changelog.scss
+++ b/packages/react/src/stories/docs/styles/changelog.scss
@@ -1,0 +1,59 @@
+.changelog {
+  border: 1px solid var(--ilo-color-blue-ramp);
+  padding: 20px;
+  h2 {
+    color: var(--ilo-color-blue);
+    border-color: var(--ilo-color-blue-ramp);
+
+    &:after {
+      content: "";
+      position: absolute;
+      border-left: 10px solid transparent;
+      border-top: 10px solid var(--ilo-color-red);
+    }
+  }
+
+  h3 {
+    color: var(--ilo-color-blue-dark);
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 1.5em;
+    color: var(--ilo-color-gray-charcoal) !important;
+    margin-bottom: 40px;
+
+    li {
+      position: relative;
+      padding-left: 1.5em;
+      font-family: monospace;
+      font-size: 13px;
+
+      &::before {
+        content: "\25B6";
+        color: var(--ilo-color-purple);
+        position: absolute;
+        left: 0;
+      }
+    }
+  }
+
+  code {
+    background-color: var(--ilo-color-red-light) !important;
+    padding: 4px 7px !important;
+    border: 1px solid var(--ilo-color-red-dark) !important;
+    border-radius: var(--ilo-border-radius) !important;
+    font-family: monospace;
+    font-style: italic;
+  }
+
+  pre {
+    margin: 20px 0 !important;
+  }
+
+  a:not([aria-hidden="true"]) {
+    color: var(--ilo-color-blue);
+    text-decoration: none;
+    border-bottom: 1px solid var(--ilo-color-blue);
+  }
+}

--- a/packages/twig/.storybook/main.js
+++ b/packages/twig/.storybook/main.js
@@ -28,6 +28,13 @@ const config = {
     getAbsolutePath("@chromatic-com/storybook"),
     getAbsolutePath("@storybook/addon-interactions"),
     getAbsolutePath("storybook-addon-rtl"),
+    {
+      name: "@storybook/addon-docs",
+      options: {
+        transcludeMarkdown: true,
+        configureJSX: true,
+      },
+    },
   ],
   framework: {
     name: getAbsolutePath("@storybook/html-vite"),

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -61,6 +61,7 @@
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-swc": "^0.3.1",
+    "@storybook/addon-docs": "^8.1.9",
     "@storybook/addon-essentials": "^8.1.9",
     "@storybook/addon-interactions": "^8.1.9",
     "@storybook/addon-links": "^8.1.9",

--- a/packages/twig/stories/docs/changelog.mdx
+++ b/packages/twig/stories/docs/changelog.mdx
@@ -1,0 +1,15 @@
+import Changelog from "../../CHANGELOG.md?raw";
+import "./styles/changelog.scss";
+import { Meta, Markdown } from "@storybook/blocks";
+
+<Meta title="Get Started / Changelog" />
+
+# Changelog
+
+The `@ilo-org/twig` package follows [Semantic Versioning](https://semver.org/). This changelog lists the changes for each version of the package.
+
+🚧 Keep in mind `@ilo-org/` packages are versioned independatly.
+
+<div className="changelog">
+  <Markdown>{Changelog.substring(Changelog.indexOf("\n") + 1)}</Markdown>
+</div>

--- a/packages/twig/stories/docs/styles/changelog.scss
+++ b/packages/twig/stories/docs/styles/changelog.scss
@@ -1,0 +1,59 @@
+.changelog {
+  border: 1px solid var(--ilo-color-blue-ramp);
+  padding: 20px;
+  h2 {
+    color: var(--ilo-color-blue);
+    border-color: var(--ilo-color-blue-ramp);
+
+    &:after {
+      content: "";
+      position: absolute;
+      border-left: 10px solid transparent;
+      border-top: 10px solid var(--ilo-color-red);
+    }
+  }
+
+  h3 {
+    color: var(--ilo-color-blue-dark);
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 1.5em;
+    color: var(--ilo-color-gray-charcoal) !important;
+    margin-bottom: 40px;
+
+    li {
+      position: relative;
+      padding-left: 1.5em;
+      font-family: monospace;
+      font-size: 13px;
+
+      &::before {
+        content: "\25B6";
+        color: var(--ilo-color-purple);
+        position: absolute;
+        left: 0;
+      }
+    }
+  }
+
+  code {
+    background-color: var(--ilo-color-red-light) !important;
+    padding: 4px 7px !important;
+    border: 1px solid var(--ilo-color-red-dark) !important;
+    border-radius: var(--ilo-border-radius) !important;
+    font-family: monospace;
+    font-style: italic;
+  }
+
+  pre {
+    margin: 20px 0 !important;
+  }
+
+  a:not([aria-hidden="true"]) {
+    color: var(--ilo-color-blue);
+    text-decoration: none;
+    border-bottom: 1px solid var(--ilo-color-blue);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       '@rollup/plugin-swc':
         specifier: ^0.3.1
         version: 0.3.1(@swc/core@1.7.1)(rollup@3.23.0)
+      '@storybook/addon-docs':
+        specifier: ^8.1.9
+        version: 8.1.9(prettier@3.3.3)
       '@storybook/addon-essentials':
         specifier: ^8.1.9
         version: 8.1.9(@types/react@18.3.3)(prettier@3.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -3345,7 +3348,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.14.2
+      '@babel/types': 7.25.6
       esutils: 2.0.3
     dev: true
 
@@ -4842,7 +4845,7 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@3.23.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.3.1(@types/node@20.16.0)
+      vite: 5.3.1
     transitivePeerDependencies:
       - rollup
 
@@ -4955,38 +4958,6 @@ packages:
       react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
     dev: true
 
-  /@radix-ui/react-dialog@1.1.1(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.1(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      aria-hidden: 1.2.4
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-      react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
-    dev: true
-
   /@radix-ui/react-dialog@1.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==}
     peerDependencies:
@@ -5041,29 +5012,6 @@ packages:
       '@types/react-dom': 18.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: true
-
-  /@radix-ui/react-dismissable-layer@1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
     dev: true
 
   /@radix-ui/react-dismissable-layer@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
@@ -5124,27 +5072,6 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
-  /@radix-ui/react-focus-scope@1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-    dev: true
-
   /@radix-ui/react-focus-scope@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
     peerDependencies:
@@ -5201,26 +5128,6 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
-  /@radix-ui/react-portal@1.1.1(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-    dev: true
-
   /@radix-ui/react-portal@1.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
     peerDependencies:
@@ -5262,26 +5169,6 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
-  /@radix-ui/react-presence@1.1.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-    dev: true
-
   /@radix-ui/react-presence@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==}
     peerDependencies:
@@ -5320,25 +5207,6 @@ packages:
       '@types/react-dom': 18.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: true
-
-  /@radix-ui/react-primitive@2.0.0(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-    dependencies:
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@types/react': 18.3.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
     dev: true
 
   /@radix-ui/react-primitive@2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
@@ -5908,21 +5776,21 @@ packages:
     dependencies:
       '@babel/core': 7.25.2
       '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
-      '@storybook/blocks': 8.1.9(@types/react@18.3.3)(prettier@3.3.3)(react-dom@18.0.0)(react@18.3.1)
+      '@storybook/blocks': 8.1.9(@types/react@18.3.3)(prettier@3.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/client-logger': 8.1.9
-      '@storybook/components': 8.1.9(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
+      '@storybook/components': 8.1.9(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-plugin': 8.1.9
       '@storybook/csf-tools': 8.1.9
       '@storybook/global': 5.0.0
       '@storybook/node-logger': 8.1.9
       '@storybook/preview-api': 8.1.9
-      '@storybook/react-dom-shim': 8.1.9(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/theming': 8.1.9(react-dom@18.0.0)(react@18.3.1)
+      '@storybook/react-dom-shim': 8.1.9(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/theming': 8.1.9(react-dom@18.3.1)(react@18.3.1)
       '@storybook/types': 8.1.9
       '@types/react': 18.3.3
       fs-extra: 11.2.0
       react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
       rehype-external-links: 3.0.0
       rehype-slug: 6.0.0
       ts-dedent: 2.2.0
@@ -6090,51 +5958,6 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/blocks@8.1.9(@types/react@18.3.3)(prettier@3.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-AB7icCijK2rft5kmzFF7bHuTdVIf6u5r26r4auqYxxVsHV87+k12kLvC8AyEssVIKMo+2vzImmdlhIScpCjrdQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@storybook/channels': 8.1.9
-      '@storybook/client-logger': 8.1.9
-      '@storybook/components': 8.1.9(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/core-events': 8.1.9
-      '@storybook/csf': 0.1.11
-      '@storybook/docs-tools': 8.1.9(prettier@3.3.3)
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.2.10(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/manager-api': 8.1.9(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/preview-api': 8.1.9
-      '@storybook/theming': 8.1.9(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/types': 8.1.9
-      '@types/lodash': 4.17.7
-      color-convert: 2.0.1
-      dequal: 2.0.3
-      lodash: 4.17.21
-      markdown-to-jsx: 7.3.2(react@18.3.1)
-      memoizerific: 1.11.3
-      polished: 4.3.1
-      react: 18.3.1
-      react-colorful: 5.6.1(react-dom@18.0.0)(react@18.3.1)
-      react-dom: 18.0.0(react@18.3.1)
-      telejson: 7.2.0
-      tocbot: 4.29.0
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - encoding
-      - prettier
-      - supports-color
-    dev: true
-
   /@storybook/blocks@8.1.9(@types/react@18.3.3)(prettier@3.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-AB7icCijK2rft5kmzFF7bHuTdVIf6u5r26r4auqYxxVsHV87+k12kLvC8AyEssVIKMo+2vzImmdlhIScpCjrdQ==}
     peerDependencies:
@@ -6236,7 +6059,7 @@ packages:
       magic-string: 0.30.11
       ts-dedent: 2.2.0
       typescript: 4.9.3
-      vite: 5.3.1(@types/node@20.16.0)
+      vite: 5.3.1
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -6349,29 +6172,6 @@ packages:
       memoizerific: 1.11.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      util-deprecate: 1.0.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-    dev: true
-
-  /@storybook/components@8.1.9(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-YGDYTJfobtNDBJrvXNgmExX3LGnb9jGPGdroS4uHewLFaqEI3Fqu3RiFLaJf40TlZ27uWLprysdLRol8j+wYEw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.1(@types/react@18.3.3)(react-dom@18.0.0)(react@18.3.1)
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
-      '@storybook/client-logger': 8.1.9
-      '@storybook/csf': 0.1.11
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.2.10(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/theming': 8.1.9(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/types': 8.1.9
-      memoizerific: 1.11.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -6606,17 +6406,6 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/icons@1.2.10(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-310apKdDcjbbX2VSLWPwhEwAgjxTzVagrwucVZIdGPErwiAppX8KvBuWZgPo+rQLVrtH8S+pw1dbUwjcE6d7og==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-    dev: true
-
   /@storybook/icons@1.2.10(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-310apKdDcjbbX2VSLWPwhEwAgjxTzVagrwucVZIdGPErwiAppX8KvBuWZgPo+rQLVrtH8S+pw1dbUwjcE6d7og==}
     engines: {node: '>=14.0.0'}
@@ -6638,29 +6427,6 @@ packages:
       '@storybook/preview-api': 8.1.9
       '@vitest/utils': 1.6.0
       util: 0.12.5
-    dev: true
-
-  /@storybook/manager-api@8.1.9(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-iafn/C9Bg9UHae7FoL5rNLCeQQnzvm+kKRlQzP5iVSJurnaYnajzej4baoZmF/eZJTFLdyp8klsqcl+NLJh8iA==}
-    dependencies:
-      '@storybook/channels': 8.1.9
-      '@storybook/client-logger': 8.1.9
-      '@storybook/core-events': 8.1.9
-      '@storybook/csf': 0.1.11
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.2.10(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/router': 8.1.9
-      '@storybook/theming': 8.1.9(react-dom@18.0.0)(react@18.3.1)
-      '@storybook/types': 8.1.9
-      dequal: 2.0.3
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-      store2: 2.14.3
-      telejson: 7.2.0
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: true
 
   /@storybook/manager-api@8.1.9(react-dom@18.3.1)(react@18.3.1):
@@ -6727,16 +6493,6 @@ packages:
 
   /@storybook/preview@8.1.9:
     resolution: {integrity: sha512-yLwe9RJRlF+h9D73pyo4fUXFxN/krTgLKT08IoyWwq7/onzVlujYdDl56EsM+Aw5OktBuwAvTiaw0WCdiFP4sA==}
-    dev: true
-
-  /@storybook/react-dom-shim@8.1.9(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-nRpw1SxkSCf8+MrsgL37lpihcr0fwtG0tHShW6F2+Lrx0nlzaOTH/VOvAwZJLNYpqddqln6vQ6Yk7Wxvw2IIkw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
     dev: true
 
   /@storybook/react-dom-shim@8.1.9(react-dom@18.3.1)(react@18.3.1):
@@ -6861,25 +6617,6 @@ packages:
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.6.0
       util: 0.12.5
-    dev: true
-
-  /@storybook/theming@8.1.9(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-CVM3F4Fa9cIFL4u/BhbANWytShBFeFBZeCFwvcJizJUL+nSgVlxeYilxwQB/1AxyJn/+OprW3nCw5aSbui/EEA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@18.3.1)
-      '@storybook/client-logger': 8.1.9
-      '@storybook/global': 5.0.0
-      memoizerific: 1.11.3
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
     dev: true
 
   /@storybook/theming@8.1.9(react-dom@18.3.1)(react@18.3.1):
@@ -8273,7 +8010,7 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /aria-query@5.1.3:
@@ -8499,7 +8236,7 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /astral-regex@2.0.0:
@@ -17090,16 +16827,6 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
-  /react-colorful@5.6.1(react-dom@18.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.0.0(react@18.3.1)
-    dev: true
-
   /react-colorful@5.6.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
@@ -17168,16 +16895,6 @@ packages:
       scheduler: 0.20.2
     dev: false
 
-  /react-dom@18.0.0(react@18.3.1):
-    resolution: {integrity: sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==}
-    peerDependencies:
-      react: ^18.0.0
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.21.0
-    dev: true
-
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -17233,7 +16950,7 @@ packages:
       '@types/react': 18.3.3
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /react-remove-scroll@2.5.7(@types/react@18.3.3)(react@18.3.1):
@@ -17250,7 +16967,7 @@ packages:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.6(@types/react@18.3.3)(react@18.3.1)
       react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
-      tslib: 2.3.1
+      tslib: 2.7.0
       use-callback-ref: 1.3.2(@types/react@18.3.3)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.3.1)
     dev: true
@@ -17269,7 +16986,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /react-transition-group@4.4.1(react-dom@18.3.1)(react@18.3.1):
@@ -17397,7 +17114,7 @@ packages:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /rechoir@0.6.2:
@@ -17980,12 +17697,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
-
-  /scheduler@0.21.0:
-    resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: true
 
   /scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -19739,7 +19450,7 @@ packages:
     dependencies:
       '@types/react': 18.3.3
       react: 18.3.1
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /use-sidecar@1.1.2(@types/react@18.3.3)(react@18.3.1):
@@ -19755,7 +19466,7 @@ packages:
       '@types/react': 18.3.3
       detect-node-es: 1.1.0
       react: 18.3.1
-      tslib: 2.3.1
+      tslib: 2.7.0
     dev: true
 
   /use@3.1.1:
@@ -20042,7 +19753,6 @@ packages:
       rollup: 4.21.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@5.3.1(@types/node@20.16.0):
     resolution: {integrity: sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==}
@@ -20078,6 +19788,7 @@ packages:
       rollup: 4.21.2
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /vitest@2.0.5(@types/node@20.16.0)(@vitest/ui@2.0.5)(jsdom@25.0.0):
     resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}


### PR DESCRIPTION
## Description 

This PR adds the changelog tab to both `react` and `twig` storybooks. 

## Implementation

The implementation uses the same `CHANGELOG.md` file generated by `changeset`. So we don't have any extra complexity or additional build steps. Also:

-  `mdx`  theme was normalized across the storybooks 
-  we have a `Changelog` menu in the sidebar
-  all major changelog UI elements are styled with `ILO Theme` 

## Demo
> React

![image](https://github.com/user-attachments/assets/036767cd-3b8e-4c0c-8660-1ff4aaf1f299)

> Twig

![image](https://github.com/user-attachments/assets/8dcfe343-913d-4f41-bfad-97bbf2b9cd72)
