### PR TITLE
Localnav responsive menu

### DIFF
--- a/.changeset/gold-pillows-wait.md
+++ b/.changeset/gold-pillows-wait.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+fixed the localnav menu issue for responsive screens

--- a/packages/twig/cypress/e2e/navigation/link.cy.js
+++ b/packages/twig/cypress/e2e/navigation/link.cy.js
@@ -22,7 +22,16 @@ describe("link", () => {
       // Intercept the click event and prevent navigation
       cy.get(".ilo--link").then(($link) => {
         const href = $link.prop("href");
-        cy.request(href).its("status").should("eq", 200);
+        cy.request({
+          url: href,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+            "Accept-Language": "en-US,en;q=0.5",
+          },
+        })
+          .its("status")
+          .should("eq", 200);
       });
     });
   });

--- a/packages/twig/src/components/localnav/localnav.behavior.js
+++ b/packages/twig/src/components/localnav/localnav.behavior.js
@@ -1,0 +1,1 @@
+import "../navigation/navigation.behavior.js";

--- a/packages/twig/src/components/navigation/navigation.js
+++ b/packages/twig/src/components/navigation/navigation.js
@@ -67,7 +67,9 @@ export default class Navigation {
       `.${this.prefix}--search--button`
     );
     this.searchBox = this.element.querySelector(`.${this.prefix}--search-box`);
-    this.searchInput = this.searchBox.querySelector("input");
+    this.searchInput = this.searchBox
+      ? this.searchBox.querySelector("input")
+      : null;
     this.contextButton = this.element.querySelector(
       `.${this.prefix}--language-switcher--button`
     );


### PR DESCRIPTION
# Description 

This PR fixes the responsive "burger menu" error that was introduced during `localnav` migration from `wingsuit` to `maestro`


https://github.com/user-attachments/assets/8f9339c0-8c69-4281-adeb-ba6c9b8f1576

## Future context

`navigation.scss` file contains a big overhead and we have an open issue about it #823, but the subject is a bit more complex. Despite `navigation.scss` being the complex implementation that is too big to be a "component" it also contains the styles for `localnav` and also `localnav` isn't working without the Behavior file from the `Navigation` component, so this 2 components are deeply intertwined, after finishing the #823 we should open the follow-up ticket for `localnav` separation 


