### PR TITLE
New Icon Mixin

### DIFF
--- a/.changeset/cold-cars-sing.md
+++ b/.changeset/cold-cars-sing.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+reworked linklist icon placement

--- a/packages/react/src/components/LinkList/LinkList.tsx
+++ b/packages/react/src/components/LinkList/LinkList.tsx
@@ -45,6 +45,7 @@ const LinkList: FC<LinkListProps> = ({
                         <span className={`${baseClass}--label`}>
                           {link.label}
                         </span>
+                        <span className={`${baseClass}--icon`} />
                       </a>
                     </li>
                   ))}

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -149,6 +149,13 @@
   background-repeat: no-repeat;
 }
 
+@mixin icon($name, $color: black) {
+  $icon: map-get($icons, $name);
+  mask-image: url("#{$icon}");
+  mask-repeat: no-repeat;
+  background-color: $color;
+}
+
 // ======================================
 // Video Button
 // ======================================

--- a/packages/styles/scss/components/_accordion.scss
+++ b/packages/styles/scss/components/_accordion.scss
@@ -4,6 +4,8 @@
 @import "../config";
 
 .#{$prefix}--accordion {
+  --ilo-accordion-color-icon: var(--ilo-color-blue-dark);
+
   // This provides a reference to the outerclass within nested declarations
   $accordion: &;
 
@@ -14,6 +16,11 @@
   // If the accordion item is scrollable, then this is its max-height
   $scroll-max-height: 300px;
 
+  &--icon {
+    width: 24px;
+    height: 24px;
+  }
+
   &--button {
     display: flex;
     flex-direction: row;
@@ -21,42 +28,40 @@
     width: 100%;
     margin: 0;
     padding-block: spacing(4);
-    padding-inline-end: spacing(11);
+    padding-inline-end: spacing(1);
     background-color: $color-ux-background-default;
-    background-position: calc(100% - px-to-rem(6px)) center;
-    background-repeat: no-repeat;
-    background-size: px-to-rem(24px) px-to-rem(24px);
     border: none;
     border-top: 2px solid $color-base-neutrals-lighter;
-    fill: $color-ux-labels-actionable;
     font-family: var(--ilo-fonts-display);
     color: $color-ux-labels-actionable;
     font-weight: $type-weights-section;
     transition: all $transition-timing ease-in-out;
     @include font-styles("label-medium");
-    @include dataurlicon("plus", $color-ux-labels-actionable);
 
     &__large {
       @include font-styles("headline-6");
       padding-block: spacing(5);
-      padding-inline-end: spacing(11);
+    }
+
+    &[aria-expanded="true"] {
+      background-color: $color-base-blue-light;
+      #{$accordion}--icon {
+        @include icon("minus", var(--ilo-color-blue));
+      }
+    }
+
+    &[aria-expanded="false"] {
+      #{$accordion}--icon {
+        @include icon("plus", var(--ilo-color-blue-dark));
+      }
     }
 
     &:hover,
     &:focus {
+      --ilo-accordion-color-icon: var(--ilo-color-blue);
       border-top-color: $color-ux-borders-hover;
       color: $color-ux-labels-hover;
-      fill: $color-ux-labels-hover;
       cursor: pointer;
-
-      &[aria-expanded="true"] {
-        color: $brand-ilo-dark-blue;
-        @include dataurlicon("minus", $brand-ilo-dark-blue);
-      }
-
-      &[aria-expanded="false"] {
-        @include dataurlicon("plus", $color-ux-labels-hover);
-      }
     }
 
     @include breakpoint("md") {
@@ -64,22 +69,7 @@
       &__large {
         @include font-styles("headline-6");
         padding: spacing(5) 0;
-        padding-inline-end: spacing(11);
       }
-    }
-
-    &[aria-expanded="true"] {
-      background-color: $color-base-blue-light;
-      color: $brand-ilo-blue;
-      @include dataurlicon("minus", $brand-ilo-blue);
-    }
-
-    &[aria-expanded="false"] {
-      @include dataurlicon("plus", $color-ux-labels-actionable);
-    }
-
-    [dir="rtl"] & {
-      background-position: calc(0% + px-to-rem(6px)) center;
     }
   }
 

--- a/packages/styles/scss/components/_blockquote.scss
+++ b/packages/styles/scss/components/_blockquote.scss
@@ -27,7 +27,6 @@ It could eventually be used for a standalone blockquote component.
       @include font-styles("pull-quote-sm");
 
       &:after {
-        background-repeat: no-repeat;
         bottom: 0;
         content: "";
         display: inline-block;
@@ -36,7 +35,7 @@ It could eventually be used for a standalone blockquote component.
         right: 0;
         transform: scaleX(-1);
         width: px-to-rem(26.5px);
-        @include dataurlicon("quote", $color-font-blockquote);
+        @include icon("quote", var(--ilo-color-purple));
       }
     }
 
@@ -47,7 +46,6 @@ It could eventually be used for a standalone blockquote component.
     }
 
     &:before {
-      background-repeat: no-repeat;
       content: "";
       display: inline-block;
       height: px-to-rem(40px);
@@ -55,7 +53,7 @@ It could eventually be used for a standalone blockquote component.
       position: absolute;
       width: px-to-rem(53px);
       top: 0;
-      @include dataurlicon("quote", $color-font-blockquote);
+      @include icon("quote", var(--ilo-color-purple));
     }
 
     @include breakpoint("md") {

--- a/packages/styles/scss/components/_callout.scss
+++ b/packages/styles/scss/components/_callout.scss
@@ -69,7 +69,7 @@
     position: relative;
 
     &__icon {
-      @include dataurlicon("chevron_down", $brand-ilo-dark-blue);
+      @include icon("chevron_down", var(--ilo-color-blue-dark));
 
       background-position: right;
       background-repeat: no-repeat;
@@ -96,23 +96,19 @@
     width: px-to-rem(24px);
 
     &__error {
-      background-color: var(--ilo-color-notification-type-error);
-      @include dataurlicon("notification_error", "white");
+      @include icon("notification_error", var(--ilo-color-white));
     }
 
     &__info {
-      background-color: var(--ilo-color-notification-type-info);
-      @include dataurlicon("notification_info", "white");
+      @include icon("notification_info", var(--ilo-color-white));
     }
 
     &__success {
-      background-color: var(--ilo-color-notification-type-success);
-      @include dataurlicon("notification_success", "white");
+      @include icon("notification_success", var(--ilo-color-white));
     }
 
     &__warning {
-      background-color: var(--ilo-color-notification-type-warning);
-      @include dataurlicon("notification_warning", "white");
+      @include icon("notification_warning", var(--ilo-color-white));
     }
   }
 

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -4,6 +4,9 @@
 @import "../mixins";
 
 .ilo--link-list {
+  --ilo-link-list-color-icon: var(--ilo-color-blue-dark);
+  --ilo-link-list-color-indent-icon: var(--ilo-color-gray-base);
+
   &--headline {
     font-family: var(--ilo-fonts-display);
     font-weight: map-get($type, "weights", "label");
@@ -33,14 +36,10 @@
       padding-left: spacing(8);
 
       .ilo--link-list--label {
-        display: block;
         padding-left: spacing(8);
         position: relative;
 
         &:before {
-          background-position: left center;
-          background-repeat: no-repeat;
-          background-size: contain;
           content: "";
           display: block;
           height: px-to-rem(24px);
@@ -48,15 +47,16 @@
           left: 0;
           position: absolute;
           top: 50%;
-          transform: translateY(-50%) rotate(-90deg);
+          transform: translateY(-50%);
           transform-origin: center;
-          @include dataurlicon("chevrondown", $color-base-neutrals-light);
+          @include icon("caret_right", var(--ilo-link-list-color-indent-icon));
         }
 
         [dir="rtl"] & {
           padding-right: spacing(6);
           &:before {
-            transform: translateY(-50%) rotate(90deg);
+            @include icon("caret_left", var(--ilo-link-list-color-indent-icon));
+            transform: translateY(-50%);
             left: unset;
             right: 0;
           }
@@ -67,28 +67,29 @@
       & .ilo--link-list--link:focus,
       &:hover,
       &:focus {
-        .ilo--link-list--label:before {
-          @include dataurlicon("chevrondown", $color-link-text-hover);
-        }
+        --ilo-link-list-color-indent-icon: var(--ilo-color-blue);
       }
     }
   }
 
+  .ilo--link-list--icon {
+    @include icon("chevron_right", var(--ilo-link-list-color-icon));
+    width: px-to-rem(24px);
+    height: px-to-rem(24px);
+  }
+
   &--link {
-    background-position: calc(100% - 4px) center;
-    background-repeat: no-repeat;
-    background-size: px-to-rem(24px) px-to-rem(24px);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     border-bottom: px-to-rem($borders-base) solid $color-base-neutrals-lighter;
     color: map-get($color, "link", "text", "default");
-    display: block;
     font-family: var(--ilo-fonts-display);
     font-weight: map-get($type, "weights", "section");
     @include font-styles("body-small");
     padding-top: spacing(4);
     padding-bottom: spacing(4);
-    padding-inline-end: spacing(8);
     text-decoration: none;
-    @include dataurlicon("chevron_right", $color-link-text-default);
     @include globaltransition("color, background-color, border-color");
 
     &:visited {
@@ -104,41 +105,32 @@
 
     &:hover,
     &:focus {
+      --ilo-link-list-color-icon: var(--ilo-color-blue);
       border-bottom: px-to-rem($borders-base) solid
         map-get($color, "link", "text", "hover");
       background-color: $color-base-blue-light;
       color: map-get($color, "link", "text", "hover");
       outline: none;
-      @include dataurlicon("chevron_right", $color-link-text-hover);
       @include globaltransition("color, background-color, border-color");
     }
 
     [dir="rtl"] & {
-      background-position: px-to-rem(4px) center;
-      @include dataurlicon("arrowleft", $color-link-text-default);
-
-      &:hover,
-      &:focus {
-        @include dataurlicon("arrowleft", $color-link-text-hover);
+      .ilo--link-list--icon {
+        @include icon("chevron_left", var(--ilo-link-list-color-icon));
       }
     }
   }
 
   &--dark {
+    --ilo-link-list-color-icon: var(--ilo-color-white);
+    --ilo-link-list-color-indent-icon: var(--ilo-color-white);
     .ilo--link-list--headline,
     .ilo--link-list--links--headline {
       color: $color-base-neutrals-white;
     }
 
-    .ilo--link-list--label {
-      &:before {
-        @include dataurlicon("chevrondown", $color-base-neutrals-white);
-      }
-    }
-
     .ilo--link-list--link {
       border-bottom: px-to-rem($borders-base) solid rgba(237, 240, 242, 0.4);
-      @include dataurlicon("chevron_right", $color-base-neutrals-white);
 
       .ilo--link-list--label {
         color: $color-base-neutrals-white;
@@ -163,27 +155,12 @@
       &:hover,
       &:focus {
         outline: none;
-        @include dataurlicon("chevron_right", $color-base-blue-medium);
 
         .ilo--link-list--label {
           color: $color-base-blue-medium;
           @include globaltransition("color");
         }
       }
-
-      [dir="rtl"] & {
-        background-position: px-to-rem(4px) center;
-        @include dataurlicon("arrowleft", $color-base-neutrals-white);
-
-        &:hover,
-        &:focus {
-          @include dataurlicon("arrowleft", $color-base-blue-medium);
-        }
-      }
     }
   }
-}
-
-.wingsuit-body .ilo--link-list--dark {
-  background-color: $color-base-blue-dark;
 }

--- a/packages/styles/scss/components/_pagination.scss
+++ b/packages/styles/scss/components/_pagination.scss
@@ -57,18 +57,12 @@
     &::before {
       transform: translate(-50%, -50%) rotate(180deg);
 
-      @include dataurlicon(
-        "double_chevron_right",
-        map-get($color, "ux", "pagination", "default", "icon")
-      );
+      @include icon("double_chevron_right", var(--ilo-color-blue-dark));
     }
 
     &:hover {
       &::before {
-        @include dataurlicon(
-          "double_chevron_right",
-          map-get($color, "ux", "pagination", "hover", "icon")
-        );
+        @include icon("double_chevron_right", var(--ilo-color-blue));
       }
     }
 
@@ -79,10 +73,7 @@
         background: var(--ilo-color-gray-light);
 
         &::before {
-          @include dataurlicon(
-            "double_chevron_right",
-            map-get($color, "ux", "pagination", "default", "icon")
-          );
+          @include icon("double_chevron_right", var(--ilo-color-blue-dark));
         }
       }
     }
@@ -93,18 +84,12 @@
       transform: translate(-50%, -50%) rotate(180deg);
       width: px-to-rem(20px);
 
-      @include dataurlicon(
-        "chevron_right",
-        map-get($color, "ux", "pagination", "default", "icon")
-      );
+      @include icon("chevron_right", var(--ilo-color-blue-dark));
     }
 
     &:hover {
       &::before {
-        @include dataurlicon(
-          "chevron_right",
-          map-get($color, "ux", "pagination", "hover", "icon")
-        );
+        @include icon("chevron_right", var(--ilo-color-blue));
       }
     }
 
@@ -115,10 +100,7 @@
         background: var(--ilo-color-gray-light);
 
         &::before {
-          @include dataurlicon(
-            "chevron_right",
-            map-get($color, "ux", "pagination", "default", "icon")
-          );
+          @include icon("chevron_right", var(--ilo-color-blue-dark));
         }
       }
     }
@@ -129,18 +111,12 @@
       transform: translate(-50%, -50%) rotate(0);
       width: px-to-rem(20px);
 
-      @include dataurlicon(
-        "chevron_right",
-        map-get($color, "ux", "pagination", "default", "icon")
-      );
+      @include icon("chevron_right", var(--ilo-color-blue-dark));
     }
 
     &:hover {
       &::before {
-        @include dataurlicon(
-          "chevron_right",
-          map-get($color, "ux", "pagination", "hover", "icon")
-        );
+        @include icon("chevron_right", var(--ilo-color-blue));
       }
     }
 
@@ -151,10 +127,7 @@
         background: var(--ilo-color-gray-light);
 
         &::before {
-          @include dataurlicon(
-            "chevron_right",
-            map-get($color, "ux", "pagination", "default", "icon")
-          );
+          @include icon("chevron_right", var(--ilo-color-blue-dark));
         }
       }
     }
@@ -162,18 +135,12 @@
 
   &--last-page {
     &::before {
-      @include dataurlicon(
-        "double_chevron_right",
-        map-get($color, "ux", "pagination", "default", "icon")
-      );
+      @include icon("double_chevron_right", var(--ilo-color-blue-dark));
     }
 
     &:hover {
       &::before {
-        @include dataurlicon(
-          "double_chevron_right",
-          map-get($color, "ux", "pagination", "hover", "icon")
-        );
+        @include icon("double_chevron_right", var(--ilo-color-blue));
       }
     }
 
@@ -184,10 +151,7 @@
         background: var(--ilo-color-gray-light);
 
         &::before {
-          @include dataurlicon(
-            "chevron_right",
-            map-get($color, "ux", "pagination", "default", "icon")
-          );
+          @include icon("chevron_right", var(--ilo-color-blue-dark));
         }
       }
     }

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -106,12 +106,6 @@
           outline: none;
           border-top: px-to-rem(3px) solid $color-base-blue-medium;
           @include globaltransition("color, background-color, border-color");
-
-          &.has--tooltip {
-            .ilo--tooltip--wrapper {
-              @include dataurlicon("info", $color-base-blue-medium);
-            }
-          }
         }
       }
 

--- a/packages/styles/scss/components/_tag.scss
+++ b/packages/styles/scss/components/_tag.scss
@@ -88,7 +88,7 @@
 
     &.icon__position--right {
       .ilo--icon {
-        @include dataurlicon("close", map-get($color, "tag", "text", "active"));
+        @include icon("close", var(--ilo-color-blue-dark));
         background-position: center;
         background-repeat: no-repeat;
         background-size: contain;
@@ -111,10 +111,7 @@
 
       &.icon__position--right {
         .ilo--icon {
-          @include dataurlicon(
-            "close",
-            map-get($color, "tag", "text", "hover")
-          );
+          @include icon("close", var(--ilo-color-blue));
         }
       }
     }
@@ -148,7 +145,7 @@
 
     &.icon__position--right {
       .ilo--icon {
-        @include dataurlicon("close", map-get($color, "tag", "text", "active"));
+        @include icon("close", var(--ilo-color-blue-dark));
 
         height: 100%;
         max-height: 28px;
@@ -169,10 +166,7 @@
 
       &.icon__position--right {
         .ilo--icon {
-          @include dataurlicon(
-            "close",
-            map-get($color, "tag", "text", "hover")
-          );
+          @include icon("close", var(--ilo-color-blue));
         }
       }
     }

--- a/packages/twig/cypress/e2e/navigation/link.cy.js
+++ b/packages/twig/cypress/e2e/navigation/link.cy.js
@@ -22,7 +22,16 @@ describe("link", () => {
       // Intercept the click event and prevent navigation
       cy.get(".ilo--link").then(($link) => {
         const href = $link.prop("href");
-        cy.request(href).its("status").should("eq", 200);
+        cy.request({
+          url: href,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+            "Accept-Language": "en-US,en;q=0.5",
+          },
+        })
+          .its("status")
+          .should("eq", 200);
       });
     });
   });

--- a/packages/twig/cypress/e2e/navigation/pagination.cy.js
+++ b/packages/twig/cypress/e2e/navigation/pagination.cy.js
@@ -53,13 +53,13 @@ describe("pagination", () => {
     });
   });
 
-  it("renders an icon as a background-image in each link's :before pseudo-element", () => {
+  it("renders an icon as a mask-image in each link's :before pseudo-element", () => {
     cy.get("@paginationSection").within(() => {
       cy.get(".ilo--pagination--link").each(($el) => {
         // Access the pseudo-element styles using window.getComputedStyle
         cy.wrap($el).then(($element) => {
           const before = window.getComputedStyle($element[0], "::before");
-          const backgroundImage = before.getPropertyValue("background-image");
+          const backgroundImage = before.getPropertyValue("mask-image");
 
           // Assert that the background image is an SVG data URL
           expect(backgroundImage).to.match(/url\(\"data:image\/svg\+xml.*\"\)/);

--- a/packages/twig/src/components/accordion/accordion-item.twig
+++ b/packages/twig/src/components/accordion/accordion-item.twig
@@ -11,7 +11,8 @@
 <li class="{{prefix}}--accordion--item" id="{{ accordion_id }}">
 	<div class="ilo--h3">
 		<button class="{{prefix}}--accordion--button {{prefix}}--accordion--button__{{ size|default('small') }}" aria-expanded="{{ defaultExpanded }}" aria-controls="{{ panel_id }}" id="{{ button_id }}">
-			{{label}}
+			<span class="{{prefix}}--accordion--label">{{label}}</span>
+			<span class="{{prefix}}--accordion--icon"></span>
 		</button>
 	</div>
 	<div class="{{prefix}}--accordion--panel {{ expanded_class }} {{ scroll_class }}" id="{{ panel_id }}" aria-labelledby="{{ button_id }}" role="region" aria-hidden={{defaultExpanded ? 'false' : 'true'}}>

--- a/packages/twig/src/components/linklist/linklist.twig
+++ b/packages/twig/src/components/linklist/linklist.twig
@@ -16,6 +16,7 @@
         <li class="{{prefix}}--link-list--links--item{{ link.indented|boolval ? ' indented'}}">
           <a href="{{link.url}}" class="{{prefix}}--link-list--link">
             <span class="{{prefix}}--link-list--label">{{link.label}}</span>
+            <span class="{{prefix}}--link-list--icon"></span>
           </a>
         </li>
         {% endfor %}


### PR DESCRIPTION
# Description

This PR introduces a new mixin that supports base64 icon placement with new theme support (#999)

## API

The API for the new mixin is almost the same, to maintain the same DX 

```scss
@include icon("chevron_right", var(--ilo-color-blue));
```

1. The icon machine name from `@ilo-org/icon`, `required`
2. The CSS variable that indicates the color of the icon

## Implementation

Base64 encoded `svg` has no direct support for CSS variables since it is evaluated as a static string,  one possible solution to get rid of `dataurilicon` was to eliminate the base64 encoded svgs but it has its disadvantages

- We are maintaining two design systems for `react` and for `twig` and having a single source of truth from the styles package is a good thing
- We could use the `icon` component for both `twig` and `react,` but for `twig` users `js` bundle for the icon component will become the required dependency, which isn't common behavior for the `drupal` & `symphony`  projects
- Right now `twig` and `react` have radically different coverage for the components in terms of `js` so maintaining icons from the styles package will increase the phase for the development
- The rewrite overhead (time-wise)

So, the current implementation keeps the icons in `base64`  and adds CSS variables support with the utilization of the `mask-image`. You can read more about [mask-image ](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image) here;tldr, we place the icon as a mask element and add color to it using background-color.

There is a disadvantage too, if one `node` uses both `icon` mixin and background color they should be split markup-wise or pseudo selectors should be used 


## Component migration

First I tried to port all the components, but it would `block` further development of the components, so we can address every component in the scope of #971. The PR has a few examples of how to port the component to the new mixin. 

### Migrated components

| Component | Status | 
| ------------| ----------|
| Accordion   |  💬 icon is styled as a separate tag | 
| Blockquote |   ✅         |           
| Callout |   ✅         |      
| Linklist |   💬 reduced file size, +improved  rtl, missing ident icon  |         
| Pagination |   ✅  on of the biggest user of `dataurlicon`        |           
| Tag |   ✅         |           

  
     



