### PR TITLE
Fix(twig): data card size and columns.

### DIFF
--- a/.changeset/modern-carrots-visit.md
+++ b/.changeset/modern-carrots-visit.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+**Data Card:** can only have two columns if `size` is set to `wide` or `narrow`

--- a/packages/twig/cypress/e2e/cards/data-card.cy.js
+++ b/packages/twig/cypress/e2e/cards/data-card.cy.js
@@ -1,60 +1,86 @@
-describe("Data card", () => {
-  it("renders the data card correctly", () => {
-    cy.visit("/admin/appearance/ui/patterns/datacard");
-    cy.getPreview("datacard")
-      .first()
-      .within(() => {
-        cy.contains("Flagship report");
-        cy.contains("Date of publication");
-        cy.contains("17 March 2022");
-        cy.contains("Files for download");
-        cy.contains("PDF 3.2 MB");
+import fixture from "../../fixtures/datacard.json";
 
-        cy.contains("Also available in");
-        cy.contains("English");
-        cy.contains("Español");
+const url = `/pattern-preview?id=datacard&fields=${encodeURI(
+  JSON.stringify(fixture)
+)}`;
 
-        cy.get("picture").within(() => {
-          cy.get("source").should("have.length", 1);
-          cy.get("source")
-            .should("have.attr", "srcset")
-            .and("include", "/images/publication.jpg");
-        });
-      });
+describe("Factlist card", () => {
+  beforeEach(() => {
+    cy.visit(url);
+    cy.get(".ilo--card__type__data").as("card");
   });
 
-  it("ensures all file buttons have a target property", () => {
-    cy.visit("/admin/appearance/ui/patterns/datacard");
-    cy.getPreview("datacard")
-      .first()
-      .within(() => {
-        cy.get(".ilo--card__type__data--content-files")
-          .find("a, button")
-          .each(($el) => {
-            cy.wrap($el).should("have.attr", "target");
-          });
-      });
+  it("should be the right size", () => {
+    cy.get("@card").should("have.class", `ilo--card__size__${fixture.size}`);
   });
 
-  it("Ensures file buttons have the correct target", () => {
-    cy.visit("/admin/appearance/ui/patterns/datacard");
-    cy.getPreview("datacard")
-      .first()
-      .within(() => {
-        cy.get(".ilo--card__type__data--content-files")
-          .find("a, button")
-          .eq(0) // First element
-          .should("have.attr", "target", "_blank");
+  it("should have the right number of columns", () => {
+    cy.get("@card").should(
+      "have.class",
+      `ilo--card__type__data__columns__${fixture.columns}`
+    );
+  });
 
-        cy.get(".ilo--card__type__data--content-files")
-          .find("a, button")
-          .eq(1) // Second element
-          .should("have.attr", "target", "_parent");
+  it("should display an image if provided", () => {
+    if (fixture.image) {
+      cy.get("@card").find(".ilo--card--image").should("exist");
+    } else {
+      cy.get("@card").find(".ilo--card--image").should("not.exist");
+    }
+  });
 
-        cy.get(".ilo--card__type__data--content-files")
-          .find("a, button")
-          .eq(2) // Third element
-          .should("have.attr", "target", "_self");
-      });
+  it("should display an eyebrow if provided", () => {
+    if (fixture.eyebrow) {
+      cy.get("@card")
+        .find(".ilo--card--eyebrow")
+        .should("exist")
+        .and("contain", fixture.eyebrow);
+    } else {
+      cy.get("@card").find(".ilo--card--eyebrow").should("not.exist");
+    }
+  });
+
+  it("should display the correct number of content items", () => {
+    if (fixture.dataset.content) {
+      cy.get("@card")
+        .find(".ilo--card--area--content")
+        .should("have.length", fixture.dataset.content.items.length);
+    }
+  });
+
+  it("should display the correct number of file links if provided", () => {
+    if (fixture.dataset.files) {
+      cy.get("@card")
+        .find(".ilo--card__type__data--content-files")
+        .find("a")
+        .should("have.length", fixture.dataset.files.items.length);
+    }
+  });
+
+  it("should display the correct number of generic links if provided", () => {
+    if (fixture.dataset.links) {
+      cy.get("@card")
+        .find(".ilo--card__type__data--content-links")
+        .find("a")
+        .should("have.length", fixture.dataset.links.items.length);
+    }
+  });
+
+  it("should display the correct number of CTA links if provided", () => {
+    if (fixture.dataset.cta) {
+      cy.get("@card")
+        .find(".ilo--card__type__data--content-cta")
+        .find("a")
+        .should("have.length", fixture.dataset.cta.items.length);
+    }
+  });
+
+  it("if the card has size narrow, it should only have one column", () => {
+    const narrowFixture = { ...fixture, size: "narrow" };
+    const narrowUrl = `/pattern-preview?id=datacard&fields=${encodeURI(
+      JSON.stringify(narrowFixture)
+    )}`;
+    cy.visit(narrowUrl);
+    cy.get("@card").should("have.class", "ilo--card__type__data__columns__one");
   });
 });

--- a/packages/twig/cypress/e2e/cards/fact-list-card.cy.js
+++ b/packages/twig/cypress/e2e/cards/fact-list-card.cy.js
@@ -11,25 +11,23 @@ describe("Factlist card", () => {
   });
 
   it("renders the title and list items correctly", () => {
-    cy.get(".ilo--card--title") // Adjust selector based on actual structure
-      .should("contain", fixture.title);
-    cy.get("ul > li").should("have.length", fixture.list.items.length); // Adjust length to match test data
+    cy.get(".ilo--card--title").should("contain", fixture.title);
+    cy.get("ul > li").should("have.length", fixture.list.items.length);
   });
 
   it("applies the correct theme class", () => {
     cy.get("@card").should(
       "have.class",
       `ilo--card__theme__${fixture.settings.theme}`
-    ); // Adjust class name if needed
+    );
   });
 
   it("ensures text and :before pseudo-elements are white in the dark theme", () => {
     cy.get("@card")
       .should("have.class", "ilo--card__theme__dark")
       .and("be.visible")
-      .and("have.css", "color", "rgb(255, 255, 255)"); // Check text color
+      .and("have.css", "color", "rgb(255, 255, 255)");
 
-    // Check :before pseudo-element color
     cy.get("@card").then(($el) => {
       const pseudoElementColor = window.getComputedStyle(
         $el[0],

--- a/packages/twig/cypress/fixtures/datacard.json
+++ b/packages/twig/cypress/fixtures/datacard.json
@@ -1,0 +1,114 @@
+{
+  "eyebrow": "Flagship Report",
+  "image": {
+    "alt": "Image alt text",
+    "loading": "lazy",
+    "url": [
+      {
+        "breakpoint": "(min-width: 0px)",
+        "src": "/images/publication.jpg"
+      }
+    ]
+  },
+  "size": "wide",
+  "columns": "two",
+  "dataset": {
+    "content": {
+      "items": [
+        {
+          "label": "Date of publication",
+          "copy": "17 March 2022"
+        },
+        {
+          "label": "Published by",
+          "copy": "ILO Department of Research"
+        }
+      ]
+    },
+    "files": {
+      "headline": "Files for download",
+      "items": [
+        {
+          "label": "PDF 3.2 MB",
+          "url": "https://www.ilo.org",
+          "target": "_blank"
+        },
+        {
+          "label": "EPUB 5.8 MB",
+          "url": "https://www.ilo.org",
+          "target": "_parent"
+        },
+        {
+          "label": "MOBI 2.4 MB",
+          "url": "https://www.ilo.org"
+        }
+      ]
+    },
+    "cta": {
+      "headline": "Read online",
+      "items": [
+        {
+          "label": "HTML Version",
+          "url": "https://www.ilo.org"
+        },
+        {
+          "label": "InfoStories",
+          "url": "https://www.ilo.org/infostories/en-GB"
+        }
+      ]
+    },
+    "links": {
+      "headline": "Also available in",
+      "items": [
+        {
+          "label": "English",
+          "url": "https://www.ilo.org/search?q=link"
+        },
+        {
+          "label": "Español",
+          "url": "https://www.ilo.org/search?q=hyperlink"
+        },
+        {
+          "label": "Dansk",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Deutsch",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Français",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Italiano",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Português",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Русский",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "中文",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "العربية",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Ελληνικά",
+          "url": "https://www.ilo.org/search?q=url"
+        },
+        {
+          "label": "Nederlands",
+          "url": "https://www.ilo.org/search?q=url"
+        }
+      ]
+    }
+  }
+}

--- a/packages/twig/src/components/card_data/card_data.component.yml
+++ b/packages/twig/src/components/card_data/card_data.component.yml
@@ -90,7 +90,7 @@ datacard:
     columns:
       type: select
       label: Columns
-      description: Displays the data in one or two columns. If not set, the card will appear as `one`.
+      description: Displays the data in one or two columns. If not set, the card will appear as `one`. Only applies when size is set to `wide` or `fluid`.
       required: false
       preview: one
       options:

--- a/packages/twig/src/components/card_data/card_data.twig
+++ b/packages/twig/src/components/card_data/card_data.twig
@@ -1,6 +1,12 @@
 {# card_data.twig #}
 
+{# Defaults to one column #}
 {% if not columns %}
+	{% set columns = "one" %}
+{% endif %}
+
+{# size overrides column if it's set to 'narrow' #}
+{% if size == "narrow" %}
 	{% set columns = "one" %}
 {% endif %}
 


### PR DESCRIPTION
Data Card should only render in two columns if `size` is set to `narrow` or `wide`

Fixes #1270