### PR TITLE
Twig: add standalone blockquote component

### DIFF
--- a/.changeset/nice-turkeys-tie.md
+++ b/.changeset/nice-turkeys-tie.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/twig": minor
+"@ilo-org/styles": patch
+---
+
+**Blockquote:** Creates a new standalone component for the Blockquote which was already available as a styled element in **Richtext** but can now be used separately on its own. This also adjusts the styles of the Blockquote in line with design changes.

--- a/packages/styles/scss/components/_blockquote.scss
+++ b/packages/styles/scss/components/_blockquote.scss
@@ -1,110 +1,117 @@
 @use "../tokens" as *;
 @use "../functions" as *;
 @import "../mixins";
+@import "../config";
 
 /**
-This mixin is used in _richtext.scss component to style blockquotes.
-It could eventually be used for a standalone blockquote component.
+This mixin is also used in _richtext.scss component to style blockquotes.
 **/
 @mixin blockquote {
-  blockquote {
-    background-color: $color-ux-background-highlight;
-    background-position: right top;
-    background-repeat: no-repeat;
-    background-size: px-to-rem(72px) px-to-rem(40px);
-    display: block;
-    font-family: var(--ilo-fonts-display);
-    padding: spacing(19) 0 spacing(9) spacing(8); // check
+  background-color: var(--ilo-color-blue-lighter);
+  background-position: right top;
+  background-repeat: no-repeat;
+  background-size: px-to-rem(72px) px-to-rem(40px);
+  display: block;
+  font-family: var(--ilo-fonts-display);
+  padding: spacing(19) 0 spacing(9) spacing(8); // check
+  position: relative;
+  width: fit-content;
+  border-bottom: px-to-rem(3px) solid var(--ilo-color-gray-base);
+  @include cornercut(72px, 40px);
+
+  p {
+    color: var(--ilo-color-purple);
+    font-weight: 300;
+    padding: 0 spacing(12) 0 0;
     position: relative;
-    width: fit-content;
-    @include cornercut(72px, 40px);
+    @include font-styles("pull-quote-sm");
+
+    &:after {
+      bottom: 0;
+      content: "";
+      display: inline-block;
+      height: px-to-rem(20px);
+      position: absolute;
+      right: 0;
+      transform: scaleX(-1);
+      width: px-to-rem(26.5px);
+      @include icon("quote", var(--ilo-color-purple));
+    }
+  }
+
+  cite {
+    color: var(--ilo-color-gray-accessible);
+    font-weight: 400;
+    // @include font-styles("pull-quote-cite");
+    font-size: var(--ilo-font-size-sm);
+    line-height: 135%;
+    letter-spacing: 0;
+    font-style: normal;
+  }
+
+  &:before {
+    content: "";
+    display: inline-block;
+    height: px-to-rem(40px);
+    left: 0;
+    position: absolute;
+    width: px-to-rem(53px);
+    top: 0;
+    @include icon("quote", var(--ilo-color-purple));
+  }
+
+  @include breakpoint("md") {
+    background-size: px-to-rem(86px) px-to-rem(48px);
+    padding: spacing(16) 0 spacing(12) spacing(12);
+    @include cornercut(86px, 48px);
 
     p {
-      color: $color-font-blockquote;
-      font-weight: 300;
+      margin-bottom: spacing(6);
       padding: 0 spacing(12) 0 0;
       position: relative;
-      @include font-styles("pull-quote-sm");
+      @include font-styles("pull-quote-lg");
 
       &:after {
-        bottom: 0;
-        content: "";
-        display: inline-block;
-        height: px-to-rem(20px);
-        position: absolute;
-        right: 0;
-        transform: scaleX(-1);
-        width: px-to-rem(26.5px);
-        @include icon("quote", var(--ilo-color-purple));
+        height: px-to-rem(24px);
+        width: px-to-rem(32px);
       }
-    }
-
-    cite {
-      color: $color-font-cite;
-      font-weight: 400;
-      @include font-styles("pull-quote-cite");
     }
 
     &:before {
-      content: "";
-      display: inline-block;
-      height: px-to-rem(40px);
-      left: 0;
-      position: absolute;
-      width: px-to-rem(53px);
-      top: 0;
-      @include icon("quote", var(--ilo-color-purple));
+      height: px-to-rem(48px);
+      width: px-to-rem(64px);
+    }
+  }
+
+  [dir="rtl"] & {
+    background-position: -1px -1px;
+    padding: spacing(14) spacing(8) spacing(9) 0;
+    @include cornercut(72px, 40px, "left");
+
+    p {
+      padding: 0 0 0 spacing(12);
+
+      &:after {
+        left: 0;
+        right: auto;
+        transform: scaleX(1);
+      }
+    }
+
+    &:before {
+      left: auto;
+      right: 0;
+      transform: scaleX(-1);
     }
 
     @include breakpoint("md") {
-      background-size: px-to-rem(86px) px-to-rem(48px);
-      padding: spacing(16) 0 spacing(12) spacing(12);
-      @include cornercut(86px, 48px);
+      padding: spacing(15) spacing(12) spacing(12) 0;
 
-      p {
-        margin-bottom: spacing(6);
-        padding: 0 spacing(12) 0 0;
-        position: relative;
-        @include font-styles("pull-quote-lg");
-
-        &:after {
-          height: px-to-rem(24px);
-          width: px-to-rem(32px);
-        }
-      }
-
-      &:before {
-        height: px-to-rem(48px);
-        width: px-to-rem(64px);
-      }
-    }
-
-    [dir="rtl"] & {
-      background-position: -1px -1px;
-      padding: spacing(14) spacing(8) spacing(9) 0;
-      @include cornercut(72px, 40px, "left");
-
-      p {
-        padding: 0 0 0 spacing(12);
-
-        &:after {
-          left: 0;
-          right: auto;
-          transform: scaleX(1);
-        }
-      }
-
-      &:before {
-        left: auto;
-        right: 0;
-        transform: scaleX(-1);
-      }
-
-      @include breakpoint("md") {
-        padding: spacing(15) spacing(12) spacing(12) 0;
-
-        @include cornercut(86px, 48px, "left");
-      }
+      @include cornercut(86px, 48px, "left");
     }
   }
+}
+
+.ilo--blockquote {
+  @include blockquote;
 }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -132,7 +132,9 @@
   }
 
   // Blockquote styles
-  @include blockquote;
+  blockquote {
+    @include blockquote;
+  }
 
   // List styles (invincible list)
   @include invincible-list;

--- a/packages/styles/scss/components/index.scss
+++ b/packages/styles/scss/components/index.scss
@@ -1,4 +1,5 @@
 @use "accordion";
+@use "blockquote";
 @use "breadcrumb";
 @use "button";
 @use "callout";

--- a/packages/twig/cypress/e2e/content/blockquote.cy.js
+++ b/packages/twig/cypress/e2e/content/blockquote.cy.js
@@ -1,0 +1,40 @@
+import fixture from "../../fixtures/blockquote.json";
+
+const url = `/pattern-preview?id=blockquote&fields=${encodeURI(
+  JSON.stringify(fixture)
+)}`;
+
+describe("Blockquote", () => {
+  beforeEach(() => {
+    cy.visit(url);
+    cy.get(".ilo--blockquote").as("blockquote");
+  });
+
+  it("should render the correct quote and citation", () => {
+    cy.get("@blockquote")
+      .find("p")
+      .should("exist")
+      .and("contain", fixture.quote);
+
+    cy.get("@blockquote")
+      .find("cite")
+      .should("exist")
+      .and("contain", fixture.cite);
+  });
+
+  it("should show opening quote marks", () => {
+    cy.get("@blockquote").then(($el) => {
+      const before = window.getComputedStyle($el[0], "::before");
+      expect(before.getPropertyValue("mask-image")).to.not.eq("none");
+    });
+  });
+
+  it("should show closing quote marks", () => {
+    cy.get("@blockquote")
+      .find("p")
+      .then(($el) => {
+        const after = window.getComputedStyle($el[0], "::after");
+        expect(after.getPropertyValue("mask-image")).to.not.eq("none");
+      });
+  });
+});

--- a/packages/twig/cypress/fixtures/blockquote.json
+++ b/packages/twig/cypress/fixtures/blockquote.json
@@ -1,0 +1,4 @@
+{
+  "quote": "This is a blockquote",
+  "cite": "Author"
+}

--- a/packages/twig/src/components/blockquote/blockquote.component.yml
+++ b/packages/twig/src/components/blockquote/blockquote.component.yml
@@ -1,0 +1,74 @@
+blockquote:
+  namespace: Components/Content
+  use: "@components/blockquote/blockquote.twig"
+  label: Accordion
+  description: The accordion component allows the user to show and hide sections of related content on a page. Items in the accordion can be expanded by default or scrollable if the content is very long.
+
+  fields:
+    items:
+      type: object
+      label: Items
+      description: The accordion items. Each item takes a label, content, and id. You can also set the defaultExpanded and scroll properties for each item.
+      required: true
+      preview:
+        - label: Topics
+          content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Employment Promotion and Job Creation</li><li>Social Protection</li><li>International Labour Standards</li><li>Social Dialogue and Tripartism</li><li>Occupational Safety and Health</li><li>Labor Migration</li><li>Child Labour and Forced Labour Elimination</li><li>Gender Equality and Non-Discrimination</li></ul></div>'
+          id: item1
+          defaultExpanded: false
+          scroll: false
+        - label: Sectors
+          content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Agriculture, Forestry, and Fishing</li><li>Construction</li><li>Manufacturing</li><li>Transport and Storage</li><li>Wholesale and Retail Trade</li><li>Information and Communication</li><li>Finance and Insurance</li><li>Health and Social Work</li><li>Educational Services</li><li>Public Administration and Defense</li><li>Other Services</li></ul></div>'
+          id: item2
+          defaultExpanded: false
+          scroll: false
+
+  settings:
+    size:
+      type: select
+      label: Size
+      description: The size of the accordion button.
+      required: false
+      options:
+        small: Small
+        large: Large
+      preview: small
+    allowMultipleExpanded:
+      type: boolean
+      label: Allow Multiple Expanded
+      description: Allow multiple accordion items to be expandable at once.
+      preview: true
+      required: false
+  variants:
+    default:
+      label: Default
+    scrollable:
+      label: "Scrollable"
+      description: "You can make an accordion item scrollable simply by passing it scroll: true in the preview."
+      fields:
+        items:
+          - label: Topics
+            content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Employment Promotion and Job Creation</li><li>Social Protection</li><li>International Labour Standards</li><li>Social Dialogue and Tripartism</li><li>Occupational Safety and Health</li><li>Labor Migration</li><li>Child Labour and Forced Labour Elimination</li><li>Gender Equality and Non-Discrimination</li></ul></div>'
+            id: item1
+            defaultExpanded: false
+            scroll: true
+          - label: Sectors
+            content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Agriculture, Forestry, and Fishing</li><li>Construction</li><li>Manufacturing</li><li>Transport and Storage</li><li>Wholesale and Retail Trade</li><li>Information and Communication</li><li>Finance and Insurance</li><li>Health and Social Work</li><li>Educational Services</li><li>Public Administration and Defense</li><li>Other Services</li></ul></div>'
+            id: item2
+            defaultExpanded: false
+            scroll: true
+    focus:
+      label: "Focus elements"
+      description: "This variant includes checkboxes inside the accordion item."
+      fields:
+        items:
+          - label: User Preferences
+            content: '<div style="padding: 20px"><form><input type="checkbox" id="option1" name="option1"><label for="option1">Option 1</label><br><input type="checkbox" id="option2" name="option2"><label for="option2">Option 2</label><br><input type="checkbox" id="option3" name="option3"><label for="option3">Option 3</label><br><input type="checkbox" id="option4" name="option4"><label for="option4">Option 4</label><br><input type="checkbox" id="option5" name="option5"><label for="option5">Option 5</label></form></div>'
+            id: item1
+            defaultExpanded: false
+            scroll: false
+          - label: More Preferences
+            content: '<div style="padding: 20px"><form><input type="checkbox" id="option3" name="option3"><label for="option3">Option 3</label><br><input type="checkbox" id="option4" name="option4"><label for="option4">Option 4</label></form></div>'
+            id: item2
+            defaultExpanded: false
+            scroll: false
+            visibility: storybook

--- a/packages/twig/src/components/blockquote/blockquote.component.yml
+++ b/packages/twig/src/components/blockquote/blockquote.component.yml
@@ -1,74 +1,17 @@
 blockquote:
   namespace: Components/Content
   use: "@components/blockquote/blockquote.twig"
-  label: Accordion
-  description: The accordion component allows the user to show and hide sections of related content on a page. Items in the accordion can be expanded by default or scrollable if the content is very long.
-
+  label: Blockquote
+  description: The Blockquote component is used to display quoted text with proper attribution, helping to highlight references and citations effectively.
   fields:
-    items:
-      type: object
-      label: Items
-      description: The accordion items. Each item takes a label, content, and id. You can also set the defaultExpanded and scroll properties for each item.
-      required: true
-      preview:
-        - label: Topics
-          content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Employment Promotion and Job Creation</li><li>Social Protection</li><li>International Labour Standards</li><li>Social Dialogue and Tripartism</li><li>Occupational Safety and Health</li><li>Labor Migration</li><li>Child Labour and Forced Labour Elimination</li><li>Gender Equality and Non-Discrimination</li></ul></div>'
-          id: item1
-          defaultExpanded: false
-          scroll: false
-        - label: Sectors
-          content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Agriculture, Forestry, and Fishing</li><li>Construction</li><li>Manufacturing</li><li>Transport and Storage</li><li>Wholesale and Retail Trade</li><li>Information and Communication</li><li>Finance and Insurance</li><li>Health and Social Work</li><li>Educational Services</li><li>Public Administration and Defense</li><li>Other Services</li></ul></div>'
-          id: item2
-          defaultExpanded: false
-          scroll: false
-
-  settings:
-    size:
-      type: select
-      label: Size
-      description: The size of the accordion button.
-      required: false
-      options:
-        small: Small
-        large: Large
-      preview: small
-    allowMultipleExpanded:
-      type: boolean
-      label: Allow Multiple Expanded
-      description: Allow multiple accordion items to be expandable at once.
-      preview: true
-      required: false
-  variants:
-    default:
-      label: Default
-    scrollable:
-      label: "Scrollable"
-      description: "You can make an accordion item scrollable simply by passing it scroll: true in the preview."
-      fields:
-        items:
-          - label: Topics
-            content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Employment Promotion and Job Creation</li><li>Social Protection</li><li>International Labour Standards</li><li>Social Dialogue and Tripartism</li><li>Occupational Safety and Health</li><li>Labor Migration</li><li>Child Labour and Forced Labour Elimination</li><li>Gender Equality and Non-Discrimination</li></ul></div>'
-            id: item1
-            defaultExpanded: false
-            scroll: true
-          - label: Sectors
-            content: '<div style="padding: 20px"><ul class="ilo--list--unordered"><li>Agriculture, Forestry, and Fishing</li><li>Construction</li><li>Manufacturing</li><li>Transport and Storage</li><li>Wholesale and Retail Trade</li><li>Information and Communication</li><li>Finance and Insurance</li><li>Health and Social Work</li><li>Educational Services</li><li>Public Administration and Defense</li><li>Other Services</li></ul></div>'
-            id: item2
-            defaultExpanded: false
-            scroll: true
-    focus:
-      label: "Focus elements"
-      description: "This variant includes checkboxes inside the accordion item."
-      fields:
-        items:
-          - label: User Preferences
-            content: '<div style="padding: 20px"><form><input type="checkbox" id="option1" name="option1"><label for="option1">Option 1</label><br><input type="checkbox" id="option2" name="option2"><label for="option2">Option 2</label><br><input type="checkbox" id="option3" name="option3"><label for="option3">Option 3</label><br><input type="checkbox" id="option4" name="option4"><label for="option4">Option 4</label><br><input type="checkbox" id="option5" name="option5"><label for="option5">Option 5</label></form></div>'
-            id: item1
-            defaultExpanded: false
-            scroll: false
-          - label: More Preferences
-            content: '<div style="padding: 20px"><form><input type="checkbox" id="option3" name="option3"><label for="option3">Option 3</label><br><input type="checkbox" id="option4" name="option4"><label for="option4">Option 4</label></form></div>'
-            id: item2
-            defaultExpanded: false
-            scroll: false
-            visibility: storybook
+    quote:
+      type: string
+      label: Quote
+      description: The main quoted text content.
+      preview: "The fundamental ideas that forged the ILO one hundred and three years ago still underpin the global pledge to leave no one behind."
+    cite:
+      type: string
+      label: Citation
+      description: The source or author of the quote.
+      preview: ILO Director-General Gilbert F. Houngbo
+  visibility: storybook

--- a/packages/twig/src/components/blockquote/blockquote.twig
+++ b/packages/twig/src/components/blockquote/blockquote.twig
@@ -1,0 +1,6 @@
+{# blockquote.twig #}
+
+<blockquote class="{{prefix}}--blockquote">
+  <p>{{ quote }}</p>
+  <cite>{{ cite }}</cite>
+</blockquote>

--- a/packages/twig/stories/blockquote.stories.js
+++ b/packages/twig/stories/blockquote.stories.js
@@ -1,0 +1,16 @@
+import Blockquote from "../src/components/blockquote/blockquote.twig";
+import BlockquotePatterns from "../src/components/blockquote/blockquote.component.yml";
+import { Maestro } from "@ilo-org/maestro";
+
+const story = Maestro.create(Blockquote, BlockquotePatterns);
+
+const Meta = {
+  title: "Components/Content/Blockquote",
+  tags: ["autodocs"],
+  ...story.meta,
+};
+
+const [Default] = story.stories;
+
+export default Meta;
+export { Default };


### PR DESCRIPTION
This creates a stand-alone Blockquote component, which was already available as a styled element in **Richtext** but can now be used separately on its own. 

This also adjusts the styles of the Blockquote in line with design changes and fixes #1283 and #1240 

