### PR TITLE
Twig: add script to clear base theme cache

### DIFF
--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -49,6 +49,7 @@
     "build:docs": "storybook build -o ./storybook-static",
     "storybook": "storybook dev -p 6006",
     "start:theme": "docker compose up -d",
+    "cr:theme": "docker exec twig-backend-1 drush cache-rebuild",
     "cy:open": "cypress open",
     "test": "cypress run",
     "lint": "eslint .",


### PR DESCRIPTION
While testing the Twig package, it periodically becomes necessary to clear the Drupal cache of the base theme to make sure that you're testing the most recent build assets. This is done via a straightforward docker compose command:

```
$ docker exec twig-backend-1 drush cache-rebuild
```

However, it's annoying to have to type the whole thing and I kept forgetting the name of the docker container, so I add a simple script to package.json

```
pnpm --filter twig cr:theme
```

which does the same thing.