### PR TITLE
Fix(Twig): remove basic variant from card pattern definition

### DIFF
--- a/.changeset/long-tips-listen.md
+++ b/.changeset/long-tips-listen.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+**Card:** Removed the basic variant from the pattern definition because it was preventing the other variants from rendering correctly

--- a/packages/twig/src/components/card/card.component.yml
+++ b/packages/twig/src/components/card/card.component.yml
@@ -190,8 +190,6 @@ card:
         stat: Stat
         factlist: Factlist
   variants:
-    basic:
-      label: Default
     feature:
       label: Feature Card
       settings:


### PR DESCRIPTION
This fixes a bug I noticed in the Twig Storybook whereby the Card component wasn't rendering the correct variant.

You can see this by looking at the [Data Variant](https://twig.ui.ilo.org/?path=/story/components-cards-card--data) on Storybook, which incorrectly renders the Multi-link Card instead.

I managed to correct this simply by removing the `basic` variant. Given that we don't have a `basic` card and that it doesn't use a `type` setting, I don't think it should have been there in the first place.