### PR TITLE
Language Toggler 

### DIFF
--- a/.changeset/red-fishes-kiss.md
+++ b/.changeset/red-fishes-kiss.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": minor
+---
+
+Implemented a new LanguageToggler component

--- a/packages/react/src/components/LanguageToggle/LanguageToggle.tsx
+++ b/packages/react/src/components/LanguageToggle/LanguageToggle.tsx
@@ -1,0 +1,117 @@
+import {
+  forwardRef,
+  HTMLAttributes,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { useGlobalSettings } from "../../hooks";
+import classNames from "classnames";
+import { ThemeTypes } from "../../types";
+import { ContextMenu, ContextMenuProps } from "../ContextMenu";
+
+export type LanguageToggleProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * The language string to display
+   */
+  language: string;
+
+  /**
+   * Specify an optional className to be added to your LanguageToggle component.
+   */
+  theme?: ThemeTypes;
+
+  /**
+   * Hide the glob icon
+   */
+  hideIcon?: boolean;
+
+  /**
+   * Specify the languages to be displayed in the Context Menu
+   */
+  options?: ContextMenuProps["links"];
+
+  className?: string;
+};
+
+const LanguageToggle = forwardRef<HTMLDivElement, LanguageToggleProps>(
+  (
+    { className, language, theme = "light", hideIcon, options, ...rest },
+    ref
+  ) => {
+    const { prefix } = useGlobalSettings();
+
+    const [isCtxMenuOpen, setIsCtxMenuOpen] = useState(true);
+
+    const containerRef = useRef<HTMLButtonElement>(null);
+    const contextMenuRef = useRef<HTMLDivElement>(null);
+
+    const baseClass = `${prefix}--language-toggle`;
+
+    useLayoutEffect(() => {
+      function handleClickOutside(event: MouseEvent) {
+        if (!contextMenuRef.current || !containerRef.current) return;
+
+        if (
+          !contextMenuRef.current.contains(event.target as Node) &&
+          !containerRef.current.contains(event.target as Node)
+        ) {
+          setIsCtxMenuOpen(false);
+        }
+      }
+
+      document.addEventListener("mousedown", handleClickOutside);
+
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    });
+
+    useLayoutEffect(() => {
+      if (!containerRef.current || !contextMenuRef.current) return;
+
+      if (isCtxMenuOpen) {
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const contextMenuRect = contextMenuRef.current.getBoundingClientRect();
+
+        contextMenuRef.current.style.left = `${containerRect.left + (containerRect.width - contextMenuRect.width) / 2}px`;
+        contextMenuRef.current.style.top = `${containerRect.bottom}px`;
+      }
+    }, [isCtxMenuOpen]);
+
+    return (
+      <div
+        ref={ref}
+        className={classNames(baseClass, className, `${baseClass}--${theme}`, {
+          [`${baseClass}--open`]: isCtxMenuOpen,
+        })}
+        {...rest}
+      >
+        <button
+          className={`${baseClass}--container`}
+          ref={containerRef}
+          onClick={() => {
+            setIsCtxMenuOpen(!isCtxMenuOpen);
+          }}
+        >
+          {!hideIcon && <span className={`${baseClass}--icon`} />}
+          <span className={`${baseClass}--action`}>{language}</span>
+          <span className={`${baseClass}--arrow`} />
+        </button>
+        {options && (
+          <div
+            className={classNames(`${baseClass}--context-menu`, {
+              [`${baseClass}--context-menu__open`]: isCtxMenuOpen,
+            })}
+            ref={contextMenuRef}
+          >
+            <ContextMenu links={options} />
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+export { LanguageToggle };

--- a/packages/react/src/components/LanguageToggle/index.ts
+++ b/packages/react/src/components/LanguageToggle/index.ts
@@ -1,0 +1,1 @@
+export * from "./LanguageToggle";

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -41,3 +41,4 @@ export { CardGroup } from "./Cards/CardGroup";
 export { Breadcrumb } from "./Breadcrumb";
 export { Tabs } from "./Tabs";
 export * from "./Cards";
+export * from "./LanguageToggle";

--- a/packages/react/src/stories/LanguageToggle/LanguageToggle.stories.tsx
+++ b/packages/react/src/stories/LanguageToggle/LanguageToggle.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import {
+  LanguageToggle,
+  LanguageToggleProps,
+} from "../../components/LanguageToggle";
+
+const meta: Meta<typeof LanguageToggle> = {
+  title: "Components/Navigation/LanguageToggle",
+  component: LanguageToggle,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: `The LanguageToggle component displays a language toggle.`,
+      },
+    },
+  },
+  argTypes: {
+    theme: {
+      control: { type: "select" },
+      options: ["light", "dark"],
+    },
+    hideIcon: {
+      control: { type: "boolean" },
+    },
+  },
+};
+
+const Default: StoryObj<LanguageToggleProps> = {
+  args: {
+    language: "English",
+    options: [
+      { label: "Spanish", url: "#" },
+      { label: "German", url: "#" },
+      { label: "French", url: "#" },
+    ],
+  },
+};
+
+export default meta;
+export { Default };

--- a/packages/styles/scss/components/_languagetoggle.scss
+++ b/packages/styles/scss/components/_languagetoggle.scss
@@ -1,0 +1,77 @@
+@use "../tokens" as *;
+@use "../functions" as *;
+@import "../mixins";
+
+.ilo--language-toggle {
+  --ilo--language-toggle-color: var(--ilo-color-white);
+  --ilo--language-toggle-color-hover: var(--ilo-color-blue);
+  --ilo--language-toggle-bg: transparent;
+  --ilo--language-toggle-bg-hover: transparent;
+
+  &--dark {
+    --ilo--language-toggle-color: var(--ilo-color-blue-dark);
+    --ilo--language-toggle-color-hover: var(--ilo-color-white);
+  }
+
+  &:hover,
+  &--open {
+    --ilo--language-toggle-color: var(--ilo--language-toggle-color-hover);
+    --ilo--language-toggle-bg: var(--ilo--language-toggle-bg-hover);
+  }
+
+  &--container {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: px-to-rem(4px);
+    cursor: pointer;
+    width: fit-content;
+    background-color: var(--ilo--language-toggle-bg);
+
+    &:hover {
+      background-color: var(--ilo--language-toggle-bg-hover);
+    }
+  }
+
+  &--icon {
+    display: block;
+    width: px-to-rem(24px);
+    height: px-to-rem(24px);
+    @include icon("globe", var(--ilo--language-toggle-color));
+  }
+
+  &--arrow {
+    display: block;
+    width: px-to-rem(24px);
+    height: px-to-rem(24px);
+    @include icon("chevron_down", var(--ilo--language-toggle-color));
+  }
+
+  &--action {
+    color: var(--ilo--language-toggle-color);
+
+    //move this when the new typography is ready ##896
+    font-weight: 700;
+    font-size: px-to-rem(14px);
+    line-height: 135%;
+    letter-spacing: -2%;
+  }
+
+  &--context-menu {
+    position: absolute;
+    margin-top: spacing(2);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition:
+      opacity 0.3s ease,
+      visibility 0.3s ease,
+      transform 0.3s ease;
+
+    &__open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+  }
+}

--- a/packages/styles/scss/components/index.scss
+++ b/packages/styles/scss/components/index.scss
@@ -55,3 +55,4 @@
 @use "tooltip";
 @use "video";
 @use "socialmedia";
+@use "languagetoggle";


### PR DESCRIPTION
# Description 

This PR introduces a new `LanguageToggler` component. It's a generic implementation that can be used across all three implementations right now 

https://github.com/user-attachments/assets/9f5c34e4-db20-4966-9b34-2cab1f1c83b3


## API

The new codewise components look like this

```jsx
<LanguageToggle
  language="English"
  options={[
    {
      label: 'Spanish',
      url: '#'
    },
    {
      label: 'German',
      url: '#'
    },
    {
      label: 'French',
      url: '#'
    }
  ]}
/>
```

- It respects the theme
- It allows you to hide the `globe` icon, with the `hideIcon` prop
- It uses the native context menu as the breadcrumb
- It allows you to pass all props to the native `div` element 

## Styles

The styles are done with the #999 rules. It utilizes the CSS variables + new foundation and new `icon` mixin. Background color is implemented via component variables so it can be easily manipulated by the parent element(`Navigation`)

 

