### PR TITLE
React/Twig: Dark Theme for Tabs and Profile

### DIFF
--- a/.changeset/many-apricots-know.md
+++ b/.changeset/many-apricots-know.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": minor
+"@ilo-org/styles": minor
+"@ilo-org/twig": minor
+---
+
+**Tabs:** Now supports `dark` theme

--- a/.changeset/perfect-bats-shop.md
+++ b/.changeset/perfect-bats-shop.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+**Profile:** Fix dark theme link hover background color

--- a/.changeset/stale-trains-listen.md
+++ b/.changeset/stale-trains-listen.md
@@ -2,4 +2,4 @@
 "@ilo-org/react": patch
 ---
 
-**Profile:** Add chevron to link
+**Profile:** Add chevron to link and make some accessibility improvements.

--- a/.changeset/stale-trains-listen.md
+++ b/.changeset/stale-trains-listen.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**Profile:** Add chevron to link

--- a/packages/react/src/components/Profile/Profile.tsx
+++ b/packages/react/src/components/Profile/Profile.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 
 import useGlobalSettings from "../../hooks/useGlobalSettings";
 import { ThemeTypes, SizeTypes } from "../../types";
+import { Icon } from "../Icon";
 
 export type ProfileProps = {
   /**
@@ -84,7 +85,7 @@ const Profile = forwardRef<HTMLElement, ProfileProps>(
         <img
           className={`${baseClass}--avatar`}
           src={avatar}
-          alt={`Avatar for ${name}`}
+          alt={`Photo of ${name}`}
         />
         <figcaption>
           <div className={`${baseClass}--figcaption--content`}>
@@ -99,6 +100,7 @@ const Profile = forwardRef<HTMLElement, ProfileProps>(
           <div className={`${baseClass}--link`}>
             <a href={link.url} target="__blank" rel="noopener noreferrer">
               <span className={`${baseClass}--link--label`}>{link.label}</span>
+              <Icon name="ChevronRight" size={24} hidden={true} />
             </a>
           </div>
         )}

--- a/packages/react/src/components/Tabs/Tabs.args.tsx
+++ b/packages/react/src/components/Tabs/Tabs.args.tsx
@@ -35,7 +35,7 @@ const withIcon: TabsProps = {
     {
       icon: {
         hidden: false,
-        name: "notificationinfooutlined",
+        name: "NotificationInfoOutlined",
       },
       label:
         "Tab Label With A Really Really Lenghty Title Even Though We Do Not Recommend Such A Lengthy Title",
@@ -56,7 +56,7 @@ const withIcon: TabsProps = {
     {
       icon: {
         hidden: false,
-        name: "notificationinfooutlined",
+        name: "NotificationInfoOutlined",
       },
       label: "Tab Label 2",
       content: (

--- a/packages/react/src/components/Tabs/Tabs.props.ts
+++ b/packages/react/src/components/Tabs/Tabs.props.ts
@@ -1,14 +1,21 @@
 import { ReactNode } from "react";
 import { IconProps } from "../Icon/Icon.props";
+import { ThemeTypes } from "../../types";
+
 export interface TabsProps {
   /**
    * Specify the items inside a tab
    */
-  items: Required<Array<TabItem>>;
+  items: TabItem[];
+
+  /**
+   * Specify the theme for the tabs
+   */
+  theme?: ThemeTypes;
 }
 
 export interface TabItem {
   icon?: IconProps;
-  label: Required<string>;
-  content: Required<ReactNode>;
+  label: string;
+  content: ReactNode;
 }

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -21,7 +21,7 @@ const Tabs: FC<TabsProps> = ({ items, theme = "light" }) => {
   const tabsClasses = classnames(baseClass, `${baseClass}__theme__${theme}`);
 
   return (
-    <div className={`${tabsClasses} tabs--js`}>
+    <div className={tabsClasses}>
       <ul className={`${baseClass}--selection`} role="tablist" tabIndex={0}>
         {items.map((tab, index) => (
           <li

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -5,7 +5,6 @@ import { TabsProps } from "./Tabs.props";
 import { Icon } from "../Icon";
 
 const Tabs: FC<TabsProps> = ({ items, className, theme = "light" }) => {
-
   const [activeTab, setActiveTab] = useState(0);
 
   const handleTabClick = (
@@ -19,7 +18,11 @@ const Tabs: FC<TabsProps> = ({ items, className, theme = "light" }) => {
   const { prefix } = useGlobalSettings();
 
   const baseClass = `${prefix}--tabs`;
-  const tabsClasses = classnames(baseClass, classname, `${baseClass}__theme__${theme}`);
+  const tabsClasses = classnames(
+    baseClass,
+    className,
+    `${baseClass}__theme__${theme}`
+  );
 
   return (
     <div className={tabsClasses}>

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { TabsProps } from "./Tabs.props";
 import { Icon } from "../Icon";
 
-const Tabs: FC<TabsProps> = ({ items }) => {
+const Tabs: FC<TabsProps> = ({ items, theme = "light" }) => {
   const [activeTab, setActiveTab] = useState(0);
 
   const handleTabClick = (
@@ -18,19 +18,20 @@ const Tabs: FC<TabsProps> = ({ items }) => {
   const { prefix } = useGlobalSettings();
 
   const baseClass = `${prefix}--tabs`;
-  const tabsClasses = classnames(baseClass);
+  const tabsClasses = classnames(baseClass, `${baseClass}__theme__${theme}`);
 
   return (
     <div className={`${tabsClasses} tabs--js`}>
-      <ul className={`${baseClass}--selection`} role="tablist">
+      <ul className={`${baseClass}--selection`} role="tablist" tabIndex={0}>
         {items.map((tab, index) => (
           <li
             key={`#tab--${index}`}
-            role="tab"
+            role="presentation"
             className={`${baseClass}--selection--item ${
               activeTab === index ? "active" : ""
             }`}
             onClick={(e) => handleTabClick(index, e)}
+            id={`tab--${index}`}
           >
             <a
               href={`#tab--${index}`}
@@ -41,6 +42,7 @@ const Tabs: FC<TabsProps> = ({ items }) => {
               aria-controls={`tab--${index}`}
               aria-selected={index === activeTab ? true : false}
               title={tab.label}
+              tabIndex={index === activeTab ? 0 : -1}
             >
               <span className={`${baseClass}--selection--label`}>
                 {tab.label}
@@ -52,7 +54,14 @@ const Tabs: FC<TabsProps> = ({ items }) => {
           </li>
         ))}
       </ul>
-      <div className={`${baseClass}--content`}>{items[activeTab].content}</div>
+      <div
+        className={`${baseClass}--content`}
+        role="tabpanel"
+        aria-labelledby={`tab--${activeTab}`}
+        tabIndex={0}
+      >
+        {items[activeTab].content}
+      </div>
     </div>
   );
 };

--- a/packages/react/src/stories/Profile/Profile.stories.tsx
+++ b/packages/react/src/stories/Profile/Profile.stories.tsx
@@ -14,6 +14,12 @@ const meta: Meta<typeof Profile> = {
       },
     },
   },
+  argTypes: {
+    theme: {
+      control: "radio",
+      options: ["light", "dark"],
+    },
+  },
 };
 
 const Default: StoryObj<ProfileProps> = {

--- a/packages/react/src/stories/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/stories/Tabs/Tabs.stories.tsx
@@ -5,6 +5,14 @@ import TabsArgs from "../../components/Tabs/Tabs.args";
 const TabsMeta: Meta<typeof Tabs> = {
   title: "Components/User Interface/Tabs",
   component: Tabs,
+  argTypes: {
+    theme: {
+      control: "select",
+      options: ["light", "dark"],
+      description: "Theme of the tabs component",
+      defaultValue: "light",
+    },
+  },
 };
 
 export default TabsMeta;

--- a/packages/react/tests/Profile.test.tsx
+++ b/packages/react/tests/Profile.test.tsx
@@ -1,0 +1,72 @@
+import { expect, describe, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Profile } from "../src/components/Profile";
+
+const fixture = {
+  avatar: "/test-avatar.jpg",
+  name: "Test Name",
+  description: "Test description text",
+  role: "Test Role",
+  link: {
+    label: "Learn more",
+    url: "https://example.com",
+  },
+};
+
+describe("Profile", () => {
+  it("should render with the name", () => {
+    render(<Profile {...fixture} />);
+    const element = screen.getByText(fixture.name);
+    expect(element).toBeInTheDocument();
+  });
+
+  it("should render with the avatar", () => {
+    render(<Profile avatar={fixture.avatar} name={fixture.name} />);
+    const element = screen.getByRole("img") as HTMLImageElement;
+    expect(element).toBeInTheDocument();
+    expect(element.src).toContain(fixture.avatar);
+    expect(element.alt).toBe(`Photo of ${fixture.name}`);
+  });
+
+  it("should render with the role", () => {
+    render(<Profile {...fixture} />);
+    const element = screen.getByText(fixture.role);
+    expect(element).toBeInTheDocument();
+  });
+
+  it("should render with the description", () => {
+    render(<Profile {...fixture} />);
+    const element = screen.getByText(fixture.description);
+    expect(element).toBeInTheDocument();
+  });
+
+  it("should render with the link", () => {
+    render(<Profile {...fixture} />);
+    const element = screen.getByRole("link");
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("href", fixture.link.url);
+    expect(element).toHaveAttribute("target", "__blank");
+    expect(element).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByText(fixture.link.label)).toBeInTheDocument();
+  });
+
+  it("should render with the correct theme class", () => {
+    render(<Profile {...fixture} theme="dark" />);
+    const figure = screen.getByRole("figure");
+    expect(figure).toHaveClass("ilo--profile__theme__dark");
+  });
+
+  it("should render with the default light theme", () => {
+    render(<Profile {...fixture} />);
+    const figure = screen.getByRole("figure");
+    expect(figure).toHaveClass("ilo--profile__theme__light");
+  });
+
+  it("should render with a custom className", () => {
+    const customClass = "custom-class";
+    render(<Profile {...fixture} className={customClass} />);
+    const figure = screen.getByRole("figure");
+    expect(figure).toHaveClass(customClass);
+  });
+});

--- a/packages/react/tests/Tabs.test.tsx
+++ b/packages/react/tests/Tabs.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Tabs } from "../src/components/Tabs";
+
+describe("Tabs", () => {
+  const mockItems = [
+    {
+      label: "Tab 1",
+      content: "Tab 1 content",
+    },
+    {
+      label: "Tab 2",
+      content: "Tab 2 content",
+    },
+  ];
+
+  it("renders tabs with correct labels", () => {
+    render(<Tabs items={mockItems} theme="light" />);
+
+    expect(screen.getByText("Tab 1")).toBeInTheDocument();
+    expect(screen.getByText("Tab 2")).toBeInTheDocument();
+  });
+
+  it("shows first tab content by default", () => {
+    render(<Tabs items={mockItems} theme="light" />);
+
+    expect(screen.getByText("Tab 1 content")).toBeVisible();
+    expect(screen.queryByText("Tab 2 content")).toBeNull();
+  });
+
+  it("switches content when clicking different tab", () => {
+    render(<Tabs items={mockItems} theme="light" />);
+
+    const tab2 = screen.getByText("Tab 2");
+    fireEvent.click(tab2);
+
+    expect(screen.queryByText("Tab 1 content")).toBeNull();
+    expect(screen.getByText("Tab 2 content")).toBeVisible();
+  });
+
+  it("applies correct ARIA attributes", () => {
+    render(<Tabs items={mockItems} theme="light" />);
+
+    const tab1 = screen.getByText("Tab 1").closest("[role='tab']");
+    const tab2 = screen.getByText("Tab 2").closest("[role='tab']");
+
+    expect(tab1).toHaveAttribute("aria-selected", "true");
+    expect(tab2).toHaveAttribute("aria-selected", "false");
+
+    const panel1 = screen.getByText("Tab 1 content");
+    expect(panel1).toHaveAttribute("role", "tabpanel");
+    expect(panel1).toHaveAttribute("aria-labelledby", "tab--0");
+  });
+
+  it("sets correct tabindex attributes", () => {
+    render(<Tabs items={mockItems} theme="light" />);
+
+    // Tablist should be focusable
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveAttribute("tabindex", "0");
+
+    // First tab should be focusable (selected)
+    const tab1 = screen.getByText("Tab 1").closest("[role='tab']");
+    expect(tab1).toHaveAttribute("tabindex", "0");
+
+    // Second tab should not be focusable (not selected)
+    const tab2 = screen.getByText("Tab 2").closest("[role='tab']");
+    expect(tab2).toHaveAttribute("tabindex", "-1");
+
+    // Tabpanel should be focusable
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("tabindex", "0");
+  });
+
+  it("renders tabs with icons when provided", () => {
+    const itemsWithIcons = [
+      {
+        label: "Tab 1",
+        icon: { name: "search" },
+        content: "Content",
+      },
+    ];
+
+    render(<Tabs items={itemsWithIcons} theme="light" />);
+
+    const tab = screen.getByText("Tab 1").closest("a");
+    expect(tab).toHaveClass("icon");
+  });
+
+  it("applies theme class when theme prop is provided", () => {
+    render(<Tabs items={mockItems} theme="dark" />);
+
+    const tabsContainer = screen.getByRole("tablist").closest(".ilo--tabs");
+    expect(tabsContainer).toHaveClass("ilo--tabs__theme__dark");
+  });
+});

--- a/packages/styles/scss/components/_profile.scss
+++ b/packages/styles/scss/components/_profile.scss
@@ -81,7 +81,7 @@
       flex-flow: row nowrap;
       align-items: center;
       gap: spacing(2);
-      @include globaltransition("color");
+      @include globaltransition("color background-color");
 
       &:hover,
       &:focus,
@@ -137,6 +137,10 @@
       #{$c}--link,
       a {
         color: var(--ilo-color-white);
+      }
+
+      a:hover {
+        background-color: var(--ilo-color-blue-lighter);
       }
     }
   }

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -5,26 +5,26 @@
 
 .ilo--tabs {
   &__theme__light {
-    --selection-background-color: var(--ilo-color-white);
-    --button-background-color: var(--ilo-color-gray-light);
-    --button-background-color-hover: var(--ilo-color-blue-lighter);
-    --button-background-color-selected: var(--ilo-color-white);
-    --button-border-top-hover: var(--ilo-color-blue);
-    --button-border-top-selected: var(--ilo-color-blue-dark);
-    --button-color: var(--ilo-color-blue-dark);
-    --button-color-hover: var(--ilo-color-blue);
-    --content-background-color: var(--ilo-color-white);
+    --ilo-tabs-selection-bg-color: var(--ilo-color-white);
+    --ilo-tabs-btn-bg-color: var(--ilo-color-gray-light);
+    --ilo-tabs-btn-bg-color-hover: var(--ilo-color-blue-lighter);
+    --ilo-tabs-btn-bg-color-selected: var(--ilo-color-white);
+    --ilo-tabs-btn-border-top-hover: var(--ilo-color-blue);
+    --ilo-tabs-btn-border-top-selected: var(--ilo-color-blue-dark);
+    --ilo-tabs-btn-color: var(--ilo-color-blue-dark);
+    --ilo-tabs-btn-color-hover: var(--ilo-color-blue);
+    --ilo-tabs-content-bg-color: var(--ilo-color-white);
   }
 
   &__theme__dark {
-    --selection-background-color: var(--ilo-color-blue-dark);
-    --button-background-color: var(--ilo-color-blue-ramp);
-    --button-background-color-hover: var(--ilo-color-blue-dark);
-    --button-background-color-selected: var(--ilo-color-blue-dark);
-    --button-border-top-selected: var(--ilo-color-white);
-    --button-color: var(--ilo-color-white);
-    --button-color-hover: var(--ilo-color-white);
-    --content-background-color: var(--ilo-color-blue-dark);
+    --ilo-tabs-selection-bg-color: var(--ilo-color-blue-dark);
+    --ilo-tabs-btn-bg-color: var(--ilo-color-blue-ramp);
+    --ilo-tabs-btn-bg-color-hover: var(--ilo-color-blue-dark);
+    --ilo-tabs-btn-bg-color-selected: var(--ilo-color-blue-dark);
+    --ilo-tabs-btn-border-top-selected: var(--ilo-color-white);
+    --ilo-tabs-btn-color: var(--ilo-color-white);
+    --ilo-tabs-btn-color-hover: var(--ilo-color-white);
+    --ilo-tabs-content-bg-color: var(--ilo-color-blue-dark);
   }
 
   * {
@@ -34,15 +34,15 @@
   .ilo--tabs--selection {
     --tabscount: 1;
     display: block;
-    background-color: var(--selection-background-color);
+    background-color: var(--ilo-tabs-selection-bg-color);
 
     &--button {
       align-items: center;
-      background-color: var(--button-background-color);
+      background-color: var(--ilo-tabs-btn-bg-color);
       border-top-width: px-to-rem(3px);
       border-top-style: solid;
       border-top-color: transparent;
-      color: var(--button-color);
+      color: var(--ilo-tabs-btn-color);
       font-family: var(--ilo-fonts-display);
       font-weight: 600;
       display: flex;
@@ -56,14 +56,14 @@
 
       // Selected
       &[aria-selected="true"] {
-        background-color: var(--button-background-color-selected);
-        border-top-color: var(--button-border-top-selected);
+        background-color: var(--ilo-tabs-btn-bg-color-selected);
+        border-top-color: var(--ilo-tabs-btn-border-top-selected);
       }
 
       &:hover {
-        background-color: var(--button-background-color-hover);
-        border-top-color: var(--button-border-top-hover);
-        color: var(--button-color-hover);
+        background-color: var(--ilo-tabs-btn-bg-color-hover);
+        border-top-color: var(--ilo-tabs-btn-border-top-hover);
+        color: var(--ilo-tabs-btn-color-hover);
       }
 
       &[aria-selected="true"] {
@@ -106,7 +106,7 @@
   }
 
   .ilo--tabs--content {
-    background-color: var(--content-background-color);
+    background-color: var(--ilo-tabs-content-bg-color);
     padding: spacing(10) spacing(6) spacing(14) spacing(6);
 
     [aria-expanded="false"] {

--- a/packages/styles/scss/components/_tabs.scss
+++ b/packages/styles/scss/components/_tabs.scss
@@ -4,212 +4,134 @@
 @import "../mixins";
 
 .ilo--tabs {
-  border-bottom: px-to-rem(3px) solid $color-base-neutrals-lighter;
-  border-left: px-to-rem(3px) solid $color-base-neutrals-lighter;
-  border-right: px-to-rem(3px) solid $color-base-neutrals-lighter;
-
-  &:not(.tabs--js) {
-    .ilo--tabs--selection {
-      margin-bottom: spacing(6);
-
-      &--button {
-        background: map-get($color, "link", "background", "default");
-        border-bottom: $widths-border-sm solid
-          map-get($color, "link", "underline", "default");
-        color: map-get($color, "link", "text", "default");
-        font-size: inherit;
-        font-weight: inherit;
-        line-height: inherit;
-        text-decoration: none;
-        @include globaltransition("color, background-color, border-color");
-
-        &:visited {
-          background: map-get($color, "link", "background", "visited");
-          border-bottom: $widths-border-sm solid
-            map-get($color, "link", "underline", "visited");
-          color: map-get($color, "link", "text", "visited");
-        }
-
-        &:hover {
-          background: map-get($color, "link", "background", "hover");
-          border-bottom: $widths-border-med solid
-            map-get($color, "link", "underline", "hover");
-          color: map-get($color, "link", "text", "hover");
-          text-decoration: none;
-          @include globaltransition("color, background-color, border-color");
-        }
-
-        &:active {
-          background: map-get($color, "link", "background", "default");
-          border-bottom: $widths-border-sm solid
-            map-get($color, "link", "underline", "default");
-          color: map-get($color, "link", "text", "default");
-          outline: none;
-        }
-
-        &:focus {
-          background: map-get($color, "link", "background", "default");
-          border-bottom: $widths-border-sm solid
-            map-get($color, "link", "underline", "default");
-          color: map-get($color, "link", "text", "default");
-          outline: none;
-        }
-      }
-    }
+  &__theme__light {
+    --selection-background-color: var(--ilo-color-white);
+    --button-background-color: var(--ilo-color-gray-light);
+    --button-background-color-hover: var(--ilo-color-blue-lighter);
+    --button-background-color-selected: var(--ilo-color-white);
+    --button-border-top-hover: var(--ilo-color-blue);
+    --button-border-top-selected: var(--ilo-color-blue-dark);
+    --button-color: var(--ilo-color-blue-dark);
+    --button-color-hover: var(--ilo-color-blue);
+    --content-background-color: var(--ilo-color-white);
   }
 
-  &.tabs--js {
-    .ilo--tabs--selection {
-      --tabscount: 1;
-      display: block;
-
-      &--button {
-        align-items: center;
-        background-color: $color-base-neutrals-lighter;
-        border-bottom: px-to-rem(3px) solid $color-base-neutrals-white;
-        color: $color-ux-labels-actionable;
-        font-family: var(--ilo-fonts-display);
-        font-weight: 600;
-        display: flex;
-        gap: spacing(1);
-        height: px-to-rem(60px);
-        justify-content: flex-start;
-        padding-left: spacing(2);
-        padding-right: spacing(6);
-        text-decoration: none;
-        @include font-styles("label-medium");
-        @include globaltransition("color, background-color, border-color");
-
-        &[aria-selected="true"] {
-          background-color: $color-base-neutrals-white;
-          border-top: px-to-rem(3px) solid $color-ux-labels-actionable;
-          pointer-events: none;
-          @include globaltransition("color, background-color, border-color");
-        }
-
-        &[aria-selected="false"]:not(:hover) {
-          border-top: px-to-rem(3px) solid transparent;
-        }
-
-        &.icon {
-          .ilo--icon {
-            height: px-to-rem(16px);
-            order: 1;
-            width: px-to-rem(16px);
-          }
-
-          .ilo--tabs--selection--label {
-            order: 2;
-            flex: 1 1;
-          }
-        }
-
-        &:hover,
-        &[aria-selected="true"]:hover {
-          background-color: $color-base-blue-light;
-          color: $color-base-blue-medium;
-          outline: none;
-          border-top: px-to-rem(3px) solid $color-base-blue-medium;
-          @include globaltransition("color, background-color, border-color");
-        }
-      }
-
-      &--label {
-        overflow: hidden;
-        padding-top: spacing(1);
-        white-space: nowrap;
-        text-overflow: ellipsis;
-      }
-
-      &--item {
-        overflow: hidden;
-        display: block;
-        width: 100%;
-
-        &:last-of-type {
-          .ilo--tabs--selection--button {
-            border-bottom: none;
-            border-right: none;
-          }
-        }
-      }
-    }
-
-    .ilo--tabs--content {
-      background-color: $color-base-neutrals-white;
-      padding: spacing(10) spacing(6) spacing(14) spacing(6);
-
-      [aria-expanded="false"] {
-        display: none;
-      }
-
-      [aria-expanded="true"] {
-        display: block;
-      }
-    }
-
-    @include breakpoint("md") {
-      .ilo--tabs--content {
-        padding: spacing(10) spacing(16) spacing(16) spacing(16);
-      }
-
-      .ilo--tabs--selection {
-        display: flex;
-        max-width: 100%;
-        overflow-x: hidden;
-        overflow-y: hidden;
-
-        &--button {
-          border-bottom: none;
-          border-right: px-to-rem(5px) solid $color-base-neutrals-white;
-        }
-
-        &--item {
-          width: min(calc(var(--tabscount) / 1 * 100%), 100%);
-        }
-      }
-    }
-
-    @include breakpoint("lg") {
-      .ilo--tabs--selection {
-        &--item {
-          width: min(calc(var(--tabscount) / 1 * 100%), 100%);
-        }
-      }
-    }
+  &__theme__dark {
+    --selection-background-color: var(--ilo-color-blue-dark);
+    --button-background-color: var(--ilo-color-blue-ramp);
+    --button-background-color-hover: var(--ilo-color-blue-dark);
+    --button-background-color-selected: var(--ilo-color-blue-dark);
+    --button-border-top-selected: var(--ilo-color-white);
+    --button-color: var(--ilo-color-white);
+    --button-color-hover: var(--ilo-color-white);
+    --content-background-color: var(--ilo-color-blue-dark);
   }
-}
 
-// This was proposed by base theme but isn't implemented in the design system yet
-.ilo--tabs--secondary {
-  display: flex;
-  flex-wrap: wrap;
-  margin-block: 2rem;
-  gap: 10px;
+  * {
+    @include globaltransition("color, background-color, border-color");
+  }
 
-  .ilo--tabs--selection--button {
+  .ilo--tabs--selection {
+    --tabscount: 1;
     display: block;
-    padding: 0.2em 1em;
-    font-size: 16px;
-    font-weight: 600;
-    color: #230050;
-    text-decoration: none;
+    background-color: var(--selection-background-color);
 
-    &[aria-selected="false"] {
-      border-bottom: 2px solid transparent;
-      background-color: var(--ilo-color-background-highlight);
+    &--button {
+      align-items: center;
+      background-color: var(--button-background-color);
+      border-top-width: px-to-rem(3px);
+      border-top-style: solid;
+      border-top-color: transparent;
+      color: var(--button-color);
+      font-family: var(--ilo-fonts-display);
+      font-weight: 600;
+      display: flex;
+      gap: spacing(1);
+      height: px-to-rem(60px);
+      justify-content: flex-start;
+      padding-left: spacing(2);
+      padding-right: spacing(6);
+      text-decoration: none;
+      @include typography("highlight-large");
+
+      // Selected
+      &[aria-selected="true"] {
+        background-color: var(--button-background-color-selected);
+        border-top-color: var(--button-border-top-selected);
+      }
 
       &:hover {
-        color: var(--ilo-color-blue);
-        border-bottom-color: var(--ilo-color-blue);
-        background-color: var(--ilo-color-background-hover);
+        background-color: var(--button-background-color-hover);
+        border-top-color: var(--button-border-top-hover);
+        color: var(--button-color-hover);
+      }
+
+      &[aria-selected="true"] {
+        pointer-events: none;
+      }
+
+      &.icon {
+        .ilo--icon {
+          height: px-to-rem(16px);
+          order: 1;
+          width: px-to-rem(16px);
+        }
+
+        .ilo--tabs--selection--label {
+          order: 2;
+          flex: 1 1;
+        }
       }
     }
 
-    &[aria-selected="true"] {
-      color: var(--ilo-color-blue-dark);
-      border-bottom: 2px solid var(--ilo-color-blue-dark);
-      pointer-events: none;
+    &--label {
+      overflow: hidden;
+      padding-top: spacing(1);
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    &--item {
+      overflow: hidden;
+      display: block;
+      width: 100%;
+
+      &:last-of-type {
+        .ilo--tabs--selection--button {
+          border-bottom: none;
+          border-right: none;
+        }
+      }
+    }
+  }
+
+  .ilo--tabs--content {
+    background-color: var(--content-background-color);
+    padding: spacing(10) spacing(6) spacing(14) spacing(6);
+
+    [aria-expanded="false"] {
+      display: none;
+    }
+
+    [aria-expanded="true"] {
+      display: block;
+    }
+  }
+
+  @include breakpoint("md") {
+    .ilo--tabs--content {
+      padding: spacing(10) spacing(16) spacing(16) spacing(16);
+    }
+
+    .ilo--tabs--selection {
+      display: flex;
+      flex-flow: row nowrap;
+      gap: spacing(1);
+      max-width: 100%;
+
+      &--item {
+        width: min(calc(var(--tabscount) / 1 * 100%), 100%);
+      }
     }
   }
 }

--- a/packages/styles/scss/theme/_foundation.scss
+++ b/packages/styles/scss/theme/_foundation.scss
@@ -14,7 +14,7 @@
   --ilo-color-blue-light: rgba(190, 220, 250, 1);
   --ilo-color-blue-dark: rgba(35, 0, 80, 1);
   --ilo-color-blue-medium: rgba(210, 213, 242, 1);
-  --ilo-color-blue-ramp: rgba(30, 45, 190, 0.4);
+  --ilo-color-blue-ramp: rgba(33, 18, 124, 1);
   --ilo-color-blue-dark-ramp: rgba(35, 0, 80, 0.5);
   --ilo-color-gray-charcoal: rgba(45, 45, 45, 1);
   --ilo-color-gray-accessible: rgba(109, 109, 109, 1);

--- a/packages/twig/cypress/e2e/user-interface/tabs.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/tabs.cy.js
@@ -1,48 +1,89 @@
-describe("tabs", () => {
+import fixture from "../../fixtures/tabs.json";
+
+const url = `/pattern-preview?id=tabs&fields=${encodeURI(
+  JSON.stringify(fixture)
+)}`;
+
+console.log(url);
+
+describe("Tabs Component", () => {
   beforeEach(() => {
-    cy.visit("/admin/appearance/ui/patterns/tabs");
-    cy.getPreview("tabs").first().as("tabsSection");
+    cy.visit(url);
+    cy.get(".ilo--tabs").as("tabs");
   });
 
-  it("renders the tabs component correctly", () => {
-    cy.get("@tabsSection").within(() => {
-      cy.contains("Tab Label With A Really");
-      cy.contains("Tab Label 2");
-      cy.contains("Women construction workers in Nepal");
+  it("should render the tabs component with correct number of items", () => {
+    cy.get("@tabs")
+      .find(".ilo--tabs--selection--item")
+      .should("have.length", fixture.items.length);
+  });
 
-      cy.get("picture").within(() => {
-        cy.get("source").should("have.length", 3);
-        cy.get("source")
-          .should("have.attr", "srcset")
-          .and("include", "/images/large.jpg");
-        cy.get("img")
-          .should("have.attr", "src")
-          .and("include", "/images/small.jpg");
-      });
+  it("should render tab labels correctly", () => {
+    fixture.items.forEach((item, index) => {
+      cy.get("@tabs")
+        .find(".ilo--tabs--selection--label")
+        .eq(index)
+        .should("contain", item.label);
     });
   });
 
-  it("checks if tab switch works as expected", () => {
-    cy.get("@tabsSection").within(() => {
-      // Check if first tab is selected
+  it("should show first tab content by default", () => {
+    cy.get("@tabs")
+      .find("[role='tabpanel']")
+      .first()
+      .should("have.attr", "aria-expanded", "true");
+  });
 
-      cy.get(".ilo--tabs--selection--button")
-        .first()
-        .should("have.attr", "aria-selected", "true");
+  it("should switch content when clicking different tabs", () => {
+    // Click second tab
+    cy.get("@tabs").find(".ilo--tabs--selection--button").eq(1).click();
 
-      // Fetch second tab and click it
+    // First tab panel should be hidden
+    cy.get("@tabs")
+      .find("[role='tabpanel']")
+      .first()
+      .should("have.attr", "aria-expanded", "false");
 
-      cy.get(".ilo--tabs--selection--button")
-        .should("exist")
-        .eq(1)
-        .should("have.attr", "aria-selected", "false")
-        .click();
+    // Second tab panel should be visible
+    cy.get("@tabs")
+      .find("[role='tabpanel']")
+      .eq(1)
+      .should("have.attr", "aria-expanded", "true");
+  });
 
-      // Check if second tab is selected after click
+  it("should render icons when provided", () => {
+    const fixtureWithIcons = {
+      ...fixture,
+      items: fixture.items.map((item) => ({
+        ...item,
+        icon: "notification_info_outlined",
+      })),
+    };
 
-      cy.get(".ilo--tabs--selection--button")
-        .eq(1)
-        .should("have.attr", "aria-selected", "true");
+    cy.visit(
+      `/pattern-preview?id=tabs&fields=${encodeURI(
+        JSON.stringify(fixtureWithIcons)
+      )}`
+    );
+
+    cy.get("@tabs")
+      .find(".ilo--tabs--selection--button")
+      .should("have.class", "icon");
+
+    cy.get("@tabs").find(".ilo--icon").should("exist");
+  });
+
+  it("should apply the correct theme class", () => {
+    const themes = ["light", "dark"];
+
+    themes.forEach((theme) => {
+      cy.visit(
+        `/pattern-preview?id=tabs&fields=${encodeURI(
+          JSON.stringify({ ...fixture, settings: { theme } })
+        )}`
+      );
+
+      cy.get(`.ilo--tabs`).should("have.class", `ilo--tabs__theme__${theme}`);
     });
   });
 });

--- a/packages/twig/cypress/e2e/user-interface/tabs.cy.js
+++ b/packages/twig/cypress/e2e/user-interface/tabs.cy.js
@@ -4,8 +4,6 @@ const url = `/pattern-preview?id=tabs&fields=${encodeURI(
   JSON.stringify(fixture)
 )}`;
 
-console.log(url);
-
 describe("Tabs Component", () => {
   beforeEach(() => {
     cy.visit(url);

--- a/packages/twig/cypress/fixtures/tabs.json
+++ b/packages/twig/cypress/fixtures/tabs.json
@@ -1,0 +1,27 @@
+{
+  "items": [
+    {
+      "label": "Tab 1",
+      "component": "image",
+      "componentdata": {
+        "alt": "My alt text",
+        "caption": "Women construction workers in Nepal build roads and bridges as part of a National Rural Transport Programme co-sponsored by the ILO.",
+        "credit": "© Marcel Crozet/ILO",
+        "url": [
+          {
+            "breakpoint": 0,
+            "src": "/images/small.jpg"
+          }
+        ]
+      }
+    },
+    {
+      "label": "Tab 2",
+      "component": "richtext",
+      "componentdata": { "content": "<div>Hello world</div>" }
+    }
+  ],
+  "settings": {
+    "theme": "light"
+  }
+}

--- a/packages/twig/src/components/tabs/tabs.component.yml
+++ b/packages/twig/src/components/tabs/tabs.component.yml
@@ -31,6 +31,14 @@ tabs:
           componentdata:
             content: "<h2>International Labour Organization</h2> <p>The <b>International Labour Organization</b> (<b>ILO</b>) is a <a href='https://www.un.org'>United Nations</a> agency whose mandate is to advance social and economic justice by setting international labour standards. Founded in October 1919 under the League of Nations, it is the first and oldest specialised agency of the UN. The ILO has 187 member states: 186 out of 193 UN member states plus the Cook Islands.</p> <p>Whereas also the failure of any nation to adopt humane conditions of labour is an obstacle in the way of other nations which desire to improve the conditions in their own countries.</p> <figure><img alt='placeholder image' class='right' src='/images/ilo-headquarters.jpg'><figcaption>The ILO's headquarters in Geneva, Switzerland. ©Steiner SA</figcaption></figure> <h3>ILO Constitution</h3> <p>The driving forces for the ILO's creation arose from security, humanitarian, political and economic considerations.</p> <blockquote> <p>The fundamental ideas that forged the ILO one hundred and three years ago still underpin the global pledge to leave no one behind.</p> <cite>ILO Director-General Gilbert F. Houngbo</cite> </blockquote> Reflecting these ideas, the Preamble of the ILO Constitution states:</p> <ol> <li>Whereas universal and lasting peace can be established only if it is based upon social justice;</li> <li>And whereas conditions of labour exist involving such injustice, hardship and privation to large numbers of people as to produce unrest so great that the peace and harmony of the world are imperilled; and an improvement of those conditions is urgently required;</li> <li>Whereas also the failure of any nation to adopt humane conditions of labour is an obstacle in the way of other nations which desire to improve the conditions in their own countries.</li> </ol>"
       required: true
+  settings:
+    theme:
+      type: select
+      label: Theme
+      description: The theme of the tabs
+      options:
+        light: "Light"
+        dark: "Dark"
   variants:
     default:
       label: Default

--- a/packages/twig/src/components/tabs/tabs.js
+++ b/packages/twig/src/components/tabs/tabs.js
@@ -83,8 +83,6 @@ export default class Tabs {
    * @chainable
    */
   enable() {
-    this.element.classList.add("tabs--js");
-
     Array.from(this.tabButtons).forEach((button) => {
       button.addEventListener(EVENTS.CLICK, (e) => this.OnClickHandler(e));
       button.addEventListener(EVENTS.KEY_DOWN, (e) => this.KeyPressHandler(e));

--- a/packages/twig/src/components/tabs/tabs.twig
+++ b/packages/twig/src/components/tabs/tabs.twig
@@ -1,12 +1,13 @@
+{% set theme = theme|default('light') %}
 {% set uid = "now"|date('Uv') %}
 {% set tabids = [] %}
 {% for item in items %}
   {% set tabids = tabids|merge([random(100000)]) %}
 {% endfor %}
-<div class="{{prefix}}--tabs" data-prefix="{{prefix}}" id="tabs--{{uid}}" data-loadcomponent="Tabs">
+<div class="{{prefix}}--tabs {{prefix}}--tabs__theme__{{theme}}" data-prefix="{{prefix}}" id="tabs--{{uid}}" data-loadcomponent="Tabs">
     <ul class="{{prefix}}--tabs--selection" aria-controls="tabs--{{uid}}" role="tablist" style="--tabscount: {{items|length}};">
       {% for item in items %}
-        <li class="{{prefix}}--tabs--selection--item" role="presentation"> {# changed role to presentation for list item #}
+        <li class="{{prefix}}--tabs--selection--item" role="presentation">
           <a href="#tab--{{tabids[loop.index - 1]}}" class="{{prefix}}--tabs--selection--button{% if item.icon is defined %} icon{% endif %}" aria-controls="tab--{{tabids[loop.index - 1]}}" role="tab" tabindex="0" {% if loop.index == 1 %}aria-selected="true"{% else %}aria-selected="false"{% endif %} title="{{item.label}}">
             <span class="{{prefix}}--tabs--selection--label">{{item.label}}</span>
             {% if item.icon is defined %}


### PR DESCRIPTION
## Tab

- This implements the `dark` theme in both Twig and React. 
- The stylesheets for the Tab component got refactored and simplified quite a bit in the process
- Adds a bunch of tests in both React and Twig
- Fixes #1351 

👉 [Link to test](https://deploy-preview-1386--ilo-ui-react.netlify.app/?path=/story/components-user-interface-tabs--default&args=theme:dark)

<img width="882" alt="image" src="https://github.com/user-attachments/assets/d454d19a-77c9-4664-9226-fdf2783a611f" />

## Profile

- Puts the finishing touches on the Dark theme which was already mostly implemented already
- Adds a bunch of tests in both React and Twig
- Fixes #1336 

<img width="369" alt="image" src="https://github.com/user-attachments/assets/2549b4d2-df08-4e7a-aa58-770d54ac49fa" />

👉 [Link to test](https://deploy-preview-1386--ilo-ui-react.netlify.app/?path=/story/components-content-profile--default&args=className:storybook;role:ILO+Director-General;theme:dark&globals=backgrounds.value:!rgba(35,0,80,1))
