### PR TITLE
Canary Batch

### DIFF
--- a/.changeset/khaki-dryers-grab.md
+++ b/.changeset/khaki-dryers-grab.md
@@ -2,4 +2,4 @@
 "@ilo-org/react": patch
 ---
 
-Value prop for the `TextInput` component
+**TextInput:** Gets value prop

--- a/.changeset/khaki-dryers-grab.md
+++ b/.changeset/khaki-dryers-grab.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+new value prop for TextInput component

--- a/.changeset/khaki-dryers-grab.md
+++ b/.changeset/khaki-dryers-grab.md
@@ -2,4 +2,4 @@
 "@ilo-org/react": patch
 ---
 
-new value prop for TextInput component
+Value prop for the `TextInput` component

--- a/.changeset/long-mirrors-repair.md
+++ b/.changeset/long-mirrors-repair.md
@@ -1,0 +1,10 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+---
+
+- Width for link-list label
+- Submit prop for the `Button` component
+- `DataCard` can recive `copy` as ReactNode
+- `Dropdown` can recive default value
+- `className` support for `Tabs`

--- a/.changeset/long-mirrors-repair.md
+++ b/.changeset/long-mirrors-repair.md
@@ -3,8 +3,8 @@
 "@ilo-org/styles": patch
 ---
 
-- Width for link-list label
-- Submit prop for the `Button` component
-- `DataCard` can recive `copy` as ReactNode
-- `Dropdown` can recive default value
-- `className` support for `Tabs`
+- **LinkList:** Change width
+- **Button:** Add submit prop
+- **DataCard:** Can receive `copy` as ReactNode
+- **Dropdown:** Can receive default value
+- **Tabs:** Can receive custom `className`

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -53,19 +53,16 @@ jobs:
           # Get short commit hash for snapshot tag
           COMMIT_HASH=$(git rev-parse --short HEAD)
 
-          # Create .changeset/pre.json for snapshot releases if it doesn't exist
-          if [ ! -f .changeset/pre.json ]; then
-            echo '{"mode": "exit", "tag": "canary"}' > .changeset/pre.json
+          # Make sure we're not in pre mode (exit if we are)
+          if [ -f .changeset/pre.json ]; then
+            pnpm changeset pre exit
           fi
 
-          # Enter pre mode if not already
-          pnpm changeset pre enter canary
-
-          # Create snapshot release
+          # Create snapshot release with commit hash
           pnpm changeset version --snapshot canary-${COMMIT_HASH}
 
-          # Publish with canary tag
-          pnpm publish --tag canary --no-git-checks
+          # Publish with canary tag (using changeset publish to respect workspace config)
+          pnpm changeset publish --tag canary --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -67,6 +67,11 @@ export type ButtonProps = Omit<
   };
 
   icon?: IconProps;
+
+  /**
+   * True if the button is type submit
+   */
+  submit?: boolean;
 };
 
 const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
@@ -83,6 +88,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       link,
       iconPosition = "left",
       icononly = false,
+      submit = false,
       ...props
     },
     ref
@@ -125,6 +131,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
         style={style}
         name={name}
         {...props}
+        type={submit ? "submit" : "button"}
       >
         {icon && <Icon {...icon} />}
         <span className="button__label">{children}</span>

--- a/packages/react/src/components/Cards/DataCard.tsx
+++ b/packages/react/src/components/Cards/DataCard.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { forwardRef, Fragment } from "react";
+import { forwardRef, Fragment, ReactNode } from "react";
 
 import useGlobalSettings from "../../hooks/useGlobalSettings";
 import { Link, LinkProps } from "../Link";
@@ -29,7 +29,7 @@ export type DataCardProps = {
     content?: {
       items: Array<{
         label: string;
-        copy: string;
+        copy: string | ReactNode;
       }>;
     };
     files?: {

--- a/packages/react/src/components/Cards/TextCard.tsx
+++ b/packages/react/src/components/Cards/TextCard.tsx
@@ -39,7 +39,7 @@ export type TextCardProps = {
   /**
    * Profile information to be displayed on the card
    */
-  profile: ProfileProps;
+  profile?: ProfileProps;
 
   /**
    * Specify the URL for the card link

--- a/packages/react/src/components/Dropdown/Dropdown.props.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.props.ts
@@ -47,6 +47,11 @@ export interface DropdownProps extends FormFieldProps<HTMLSelectElement> {
    * The Dropdown's default selection; should match one of the values in `options`
    */
   value?: string;
+
+  /**
+   * The default value of the select element
+   */
+  defaultValue?: string;
 }
 
 export type LabelledDropdownProps = LabelledFormFieldProps<DropdownProps>;

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>((props, ref) => {
     options,
     required,
     value,
+    defaultValue,
     form,
     multiple,
     selectSize,
@@ -51,6 +52,7 @@ const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>((props, ref) => {
         onChange={handleChange}
         onBlur={onBlur}
         disabled={disabled}
+        defaultValue={defaultValue}
         className={dropdownClasses}
         value={currentvalue}
         form={form}

--- a/packages/react/src/components/Tabs/Tabs.props.ts
+++ b/packages/react/src/components/Tabs/Tabs.props.ts
@@ -5,6 +5,8 @@ export interface TabsProps {
    * Specify the items inside a tab
    */
   items: Required<Array<TabItem>>;
+
+  className?: string;
 }
 
 export interface TabItem {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { TabsProps } from "./Tabs.props";
 import { Icon } from "../Icon";
 
-const Tabs: FC<TabsProps> = ({ items }) => {
+const Tabs: FC<TabsProps> = ({ items, className }) => {
   const [activeTab, setActiveTab] = useState(0);
 
   const handleTabClick = (
@@ -18,7 +18,7 @@ const Tabs: FC<TabsProps> = ({ items }) => {
   const { prefix } = useGlobalSettings();
 
   const baseClass = `${prefix}--tabs`;
-  const tabsClasses = classnames(baseClass);
+  const tabsClasses = classnames(baseClass, className);
 
   return (
     <div className={`${tabsClasses} tabs--js`}>

--- a/packages/react/src/components/TextInput/TextInput.props.ts
+++ b/packages/react/src/components/TextInput/TextInput.props.ts
@@ -18,6 +18,8 @@ export interface TextInputProps extends FormFieldProps<HTMLInputElement> {
    * The input's type.
    */
   type: TextInputTypes;
+
+  value?: string;
 }
 
 export type LabelledTextInputProps = LabelledFormFieldProps<TextInputProps>;

--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -15,6 +15,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       placeholder,
       required,
       pattern,
+      value,
       disabled = false,
       type = "text",
     },
@@ -32,6 +33,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 
     return (
       <input
+        value={value}
         ref={ref}
         id={id ? id : name}
         name={name}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -10,6 +10,7 @@ export { Button } from "./Button";
 export { ContextMenu } from "./ContextMenu";
 export { Fieldset } from "./Fieldset";
 export * from "./GlobalProvider";
+export * from "./TextInput";
 export { Notification } from "./Notification";
 export { ReadMore } from "./ReadMore";
 export { Textarea } from "./Textarea";

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { FormControlPublicProps } from "../components/FormControl/FormControl.props";
 
 // export type AccordionSize = "small" | "large";
@@ -70,7 +71,7 @@ export type CardTypes =
 export type HeadingTypes = "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export interface EventDate {
   unix?: string;
-  human?: string;
+  human?: string | ReactNode;
 }
 
 export interface FormFieldProps<T> {

--- a/packages/styles/scss/components/_linklist.scss
+++ b/packages/styles/scss/components/_linklist.scss
@@ -78,6 +78,10 @@
     height: px-to-rem(24px);
   }
 
+  .ilo--link-list--label {
+    flex-basis: 90%;
+  }
+
   &--link {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
# Canary Batch

This PR introduces the changes done in the canary branch for the @ilo-org/react and @ilo-org/styles packages.

## Changes
- Value prop for the `TextInput` component
- Width for link-list label
- Submit prop for the `Button` component
- `DataCard` can recive `copy` as ReactNode
- `Dropdown` can recive default value
- `className` support for `Tabs`
