### PR TITLE
Canary Batch

### DIFF
--- a/.changeset/brave-singers-vanish.md
+++ b/.changeset/brave-singers-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+default value for the active tab

--- a/.changeset/brave-singers-vanish.md
+++ b/.changeset/brave-singers-vanish.md
@@ -2,4 +2,4 @@
 "@ilo-org/react": patch
 ---
 
-default value for the active tab
+**Tab:** Default value for the active tab

--- a/.changeset/chilly-pens-try.md
+++ b/.changeset/chilly-pens-try.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+corrected typography for the `ScoreCard`

--- a/.changeset/chilly-pens-try.md
+++ b/.changeset/chilly-pens-try.md
@@ -2,4 +2,4 @@
 "@ilo-org/styles": patch
 ---
 
-corrected typography for the `ScoreCard`
+**ScoreCard:** Corrected typography

--- a/.changeset/short-lies-suffer.md
+++ b/.changeset/short-lies-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+`ReactNode` support for the `Score` and `MultiLink` cards

--- a/.changeset/short-lies-suffer.md
+++ b/.changeset/short-lies-suffer.md
@@ -2,4 +2,5 @@
 "@ilo-org/react": patch
 ---
 
-`ReactNode` support for the `Score` and `MultiLink` cards
+**ScoreCard:** Add `ReactNode` support
+**MultilinkCard::** Add `ReactNode` support

--- a/packages/react/src/components/Cards/MultiLinkCard.tsx
+++ b/packages/react/src/components/Cards/MultiLinkCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, isValidElement, ReactNode } from "react";
 import classNames from "classnames";
 
 import useGlobalSettings from "../../hooks/useGlobalSettings";
@@ -36,7 +36,7 @@ export type MultiLinkCardProps = {
   /**
    * Introductory text in the card
    */
-  intro?: string;
+  intro?: ReactNode;
 
   /**
    * Link to the card
@@ -134,7 +134,12 @@ const MultiLinkCard = forwardRef<HTMLDivElement, MultiLinkCardProps>(
                 </picture>
               </div>
             )}
-            {intro && <p className={`${baseClass}--intro`}>{intro}</p>}
+            {intro &&
+              (isValidElement(intro) ? (
+                <div className={`${baseClass}--intro`}>{intro}</div>
+              ) : (
+                <p className={`${baseClass}--intro`}>{intro}</p>
+              ))}
             {linklist && <LinkList {...linklist} />}
           </div>
         </div>

--- a/packages/react/src/components/Cards/ScoreCard.tsx
+++ b/packages/react/src/components/Cards/ScoreCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, ReactNode } from "react";
 import classNames from "classnames";
 
 import useGlobalSettings from "../../hooks/useGlobalSettings";
@@ -59,7 +59,7 @@ export type ScoreCardProps = {
   content?: {
     items: {
       icon: string;
-      label: string;
+      label: string | ReactNode;
       unix?: string;
     }[];
   };
@@ -70,11 +70,14 @@ export type ScoreCardProps = {
   cta?: {
     items: React.ReactElement<ButtonProps>[];
   };
+
+  className?: string;
 };
 
 const ScoreCard = forwardRef<HTMLDivElement, ScoreCardProps>(
   (
     {
+      className,
       theme = "light",
       titleLevel: TitleElement = "p",
       size = "narrow",
@@ -104,7 +107,7 @@ const ScoreCard = forwardRef<HTMLDivElement, ScoreCardProps>(
     });
 
     return (
-      <div className={cardClasses} ref={ref}>
+      <div className={classNames(cardClasses, className)} ref={ref}>
         <a className={`${baseClass}--link`} href={link} title={title}>
           <span className={`${baseClass}--link--text`}>{title}</span>
         </a>

--- a/packages/react/src/components/Tabs/Tabs.props.ts
+++ b/packages/react/src/components/Tabs/Tabs.props.ts
@@ -12,11 +12,16 @@ export interface TabsProps {
    * Give the component a `light` or `dark` theme
    */
   theme?: ThemeTypes;
-  
+
   /**
    * Add an optional className to the Tabs
    */
   className?: string;
+
+  /**
+   * Specify the default active tab
+   */
+  defaultActiveTab?: number;
 }
 
 export interface TabItem {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -4,8 +4,13 @@ import classnames from "classnames";
 import { TabsProps } from "./Tabs.props";
 import { Icon } from "../Icon";
 
-const Tabs: FC<TabsProps> = ({ items, className, theme = "light" }) => {
-  const [activeTab, setActiveTab] = useState(0);
+const Tabs: FC<TabsProps> = ({
+  items,
+  className,
+  theme = "light",
+  defaultActiveTab = 0,
+}) => {
+  const [activeTab, setActiveTab] = useState(defaultActiveTab);
 
   const handleTabClick = (
     index: SetStateAction<number>,

--- a/packages/styles/scss/components/_scorecard.scss
+++ b/packages/styles/scss/components/_scorecard.scss
@@ -54,10 +54,9 @@
       }
 
       #{$self}--title {
-        @include font-styles("headline-5");
-        font-family: var(--ilo-fonts-display);
-        font-weight: 700;
+        @include typography("heading-3");
         margin-bottom: spacing(6);
+        color: var(--ilo-color-blue-dark);
       }
 
       #{$self}--area {
@@ -152,9 +151,7 @@
 
             #{$self}--title {
               grid-area: title;
-              font-size: var(--ilo-font-size-lg);
-              line-height: var(--ilo-line-height-lg);
-              letter-spacing: var(--ilo-letter-spacing-sm);
+              @include typography("heading-4");
             }
 
             #{$self}--area--content {


### PR DESCRIPTION
# Canary Batch

This PR introduces the changes done in the canary branch for the @ilo-org/react and @ilo-org/styles packages.

## Changes
- corrected typography for the `ScoreCard`
- `Tabs` can now accept a default value for the opened tab 
- `MultiLinkCard` now can accept intro as a `ReactNode`
- `ScoreCard` can receive `className` and content as a `ReactNode` too 