### PR TITLE
fix(react/twig/styles): refactor callout

### DIFF
--- a/.changeset/warm-berries-rescue.md
+++ b/.changeset/warm-berries-rescue.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+"@ilo-org/twig": patch
+---
+
+**Callout:** Fix unreadable background color and some other minor issues

--- a/packages/react/src/components/Callout/Callout.tsx
+++ b/packages/react/src/components/Callout/Callout.tsx
@@ -36,7 +36,7 @@ export type CalloutProps = {
   isCollapsible?: boolean;
 
   /**
-   * Specify if callout is open (only important for collapsible items)
+   * Specify if callout is open by default (only important for collapsible items)
    */
   isOpen?: boolean;
 
@@ -82,20 +82,22 @@ const Callout = forwardRef<HTMLDivElement, CalloutProps>(
 
     const calloutClasses = classNames(baseClass, className, {
       [`${baseClass}__${type}`]: type,
-      [`${baseClass}--open`]: toggleOpen,
-      [`${baseClass}--collapse`]: isCollapsible,
+      [`${baseClass}__open`]: toggleOpen,
+      [`${baseClass}__collapse`]: isCollapsible,
     });
 
     const toggleLabel = toggleOpen ? toggleOpenLabel : toggleClosedLabel;
 
     return (
       <div className={calloutClasses} ref={ref}>
-        <div className={`${baseClass}__sidebar`}>
-          <span className={`${baseClass}--icon icon icon__${type}`}></span>
+        <div className={`${baseClass}--sidebar`}>
+          <span
+            className={`${baseClass}--icon ${baseClass}--icon__alert__${type}`}
+          ></span>
         </div>
-        <div className={`${baseClass}__content`}>
-          <div className={`${baseClass}__header`}>
-            <h5 className={`${baseClass}__title`}>{headline}</h5>
+        <div className={`${baseClass}--content`}>
+          <div className={`${baseClass}--header`}>
+            <h5 className={`${baseClass}--title`}>{headline}</h5>
             {isCollapsible && (
               <button
                 className={`${baseClass}--toggle`}
@@ -113,9 +115,9 @@ const Callout = forwardRef<HTMLDivElement, CalloutProps>(
               </button>
             )}
           </div>
-          <p className={`${baseClass}__description`}>{copy}</p>
+          <p className={`${baseClass}--description`}>{copy}</p>
           {cta && (
-            <div className={`${baseClass}__footer`}>
+            <div className={`${baseClass}--footer`}>
               <Button
                 type="secondary"
                 size="small"

--- a/packages/react/src/stories/Callout/Callout.stories.tsx
+++ b/packages/react/src/stories/Callout/Callout.stories.tsx
@@ -37,6 +37,8 @@ const Default: StoryObj<CalloutProps> = {
     type: "info",
     isCollapsible: false,
     isOpen: true,
+    toggleOpenLabel: "Less",
+    toggleClosedLabel: "More",
   },
   name: "Info",
 };

--- a/packages/react/tests/Callout.test.tsx
+++ b/packages/react/tests/Callout.test.tsx
@@ -1,0 +1,140 @@
+import { expect, describe, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { Callout } from "../src/components/Callout";
+import { CalloutTypes } from "../src/types";
+
+// Mock the useGlobalSettings hook
+vi.mock("../src/hooks/useGlobalSettings", () => ({
+  default: () => ({ prefix: "ilo" }),
+}));
+
+const fixture = {
+  headline: "Important Notice",
+  copy: "This is the main content of the callout component",
+  type: "info" as CalloutTypes,
+  isCollapsible: true,
+  isOpen: false,
+  toggleOpenLabel: "More",
+  toggleClosedLabel: "Less",
+  cta: {
+    label: "Take action",
+    url: "https://www.ilo.org",
+  },
+};
+
+describe("Callout", () => {
+  it("should render with the correct alert type", () => {
+    const { container } = render(<Callout type={fixture.type} />);
+    expect(container.firstChild).toHaveClass(`ilo--callout__${fixture.type}`);
+  });
+
+  it("should render the title correctly", () => {
+    render(<Callout headline={fixture.headline} />);
+    const element = screen.getByText(fixture.headline);
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass("ilo--callout--title");
+  });
+
+  it("should render the content correctly", () => {
+    render(<Callout copy={fixture.copy} />);
+    const element = screen.getByText(fixture.copy);
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass("ilo--callout--description");
+  });
+
+  it("should render the alert icon", () => {
+    const { container } = render(<Callout type={fixture.type} />);
+    const element = container.querySelector(".ilo--callout--icon");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass(`ilo--callout--icon__alert__${fixture.type}`);
+  });
+
+  it("should render the button when provided", () => {
+    render(<Callout cta={fixture.cta} />);
+    const element = screen.getByText(fixture.cta.label);
+
+    expect(element).toBeInTheDocument();
+    expect(element.closest("a")).toHaveAttribute("href", fixture.cta.url);
+  });
+
+  it("should have the correct collapsible state", () => {
+    const { container } = render(
+      <Callout isCollapsible={fixture.isCollapsible} isOpen={fixture.isOpen} />
+    );
+    const element = container.querySelector(".ilo--callout");
+
+    expect(element).toHaveClass("ilo--callout__collapse");
+    expect(element).not.toHaveClass("ilo--callout__open");
+  });
+
+  it("should render the toggle button when collapsible", () => {
+    const { container } = render(
+      <Callout
+        isCollapsible={true}
+        isOpen={false}
+        toggleOpenLabel={fixture.toggleOpenLabel}
+        toggleClosedLabel={fixture.toggleClosedLabel}
+      />
+    );
+
+    const toggleButton = container.querySelector("button");
+    expect(toggleButton).toBeInTheDocument();
+
+    const buttonText = screen.getByText(fixture.toggleClosedLabel);
+    expect(buttonText).toBeInTheDocument();
+  });
+
+  it("should toggle open/closed state when clicked", () => {
+    const { container } = render(
+      <Callout
+        isCollapsible={true}
+        isOpen={false}
+        toggleOpenLabel={fixture.toggleOpenLabel}
+        toggleClosedLabel={fixture.toggleClosedLabel}
+      />
+    );
+
+    const element = container.querySelector(".ilo--callout");
+    const toggleButton = screen.getByRole("button");
+
+    // Initially closed
+    expect(element).not.toHaveClass("ilo--callout__open");
+    expect(screen.getByText(fixture.toggleClosedLabel)).toBeInTheDocument();
+
+    // Click to open
+    fireEvent.click(toggleButton);
+    expect(element).toHaveClass("ilo--callout__open");
+    expect(screen.getByText(fixture.toggleOpenLabel)).toBeInTheDocument();
+
+    // Click to close
+    fireEvent.click(toggleButton);
+    expect(element).not.toHaveClass("ilo--callout__open");
+    expect(screen.getByText(fixture.toggleClosedLabel)).toBeInTheDocument();
+  });
+
+  it("should not render toggle button when not collapsible", () => {
+    render(
+      <Callout
+        isCollapsible={false}
+        isOpen={false}
+        toggleOpenLabel={fixture.toggleOpenLabel}
+        toggleClosedLabel={fixture.toggleClosedLabel}
+      />
+    );
+
+    const toggleButton = screen.queryByRole("button");
+    expect(toggleButton).not.toBeInTheDocument();
+  });
+
+  it("should render with custom className", () => {
+    const customClass = "custom-class";
+    const { container } = render(<Callout className={customClass} />);
+
+    const element = container.querySelector(".ilo--callout");
+    expect(element).toHaveClass(customClass);
+  });
+});

--- a/packages/styles/scss/components/_callout.scss
+++ b/packages/styles/scss/components/_callout.scss
@@ -8,13 +8,13 @@
   transition: max-height 225ms ease-out;
   $callout: &;
 
-  &--collapse:not(.ilo--callout--open) {
-    max-height: 64px;
+  &__collapse {
+    max-height: px-to-rem(64px);
     overflow: hidden;
   }
 
-  &--open {
-    max-height: 300px;
+  &__open {
+    max-height: px-to-rem(300px);
     overflow: hidden;
 
     #{$callout}--toggle--icon {
@@ -22,7 +22,39 @@
     }
   }
 
-  &__sidebar {
+  &__error {
+    background: var(--ilo-color-red-ramp);
+
+    #{$callout}--sidebar {
+      background: var(--ilo-color-red);
+    }
+  }
+
+  &__info {
+    background: var(--ilo-color-blue-light);
+
+    #{$callout}--sidebar {
+      background: var(--ilo-color-blue);
+    }
+  }
+
+  &__success {
+    background: var(--ilo-color-green-ramp);
+
+    #{$callout}--sidebar {
+      background: var(--ilo-color-green);
+    }
+  }
+
+  &__warning {
+    background: var(--ilo-color-yellow-ramp);
+
+    #{$callout}--sidebar {
+      background: var(--ilo-color-yellow);
+    }
+  }
+
+  &--sidebar {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -34,43 +66,40 @@
     }
   }
 
-  &__content {
+  &--content {
+    color: var(--ilo-color-gray-charcoal);
     padding: spacing(6);
     width: 100%;
     font-size: px-to-rem(14px);
   }
 
-  &__header {
+  &--header {
     display: flex;
     justify-content: space-between;
     padding-block-end: spacing(3);
   }
 
-  &__title {
-    @include font-styles("nav-bold-b");
-    font-family: var(--ilo-fonts-display);
+  &--title {
+    @include typography("highlight-medium");
     font-weight: 700;
   }
 
-  &__description {
+  &--description {
     font-weight: 400;
   }
 
   &--toggle {
-    @include font-styles("nav-bold-b");
-
+    @include typography("highlight-medium-bold");
     background: none;
     border: none;
     color: var(--ilo-color-blue-dark);
     cursor: pointer;
-    font-family: var(--ilo-fonts-display);
     font-weight: 500;
     padding-inline-end: spacing(8);
     position: relative;
 
-    &__icon {
+    &--icon {
       @include icon("chevron_down", var(--ilo-color-blue-dark));
-
       background-position: right;
       background-repeat: no-repeat;
       display: inline-block;
@@ -84,63 +113,33 @@
     }
   }
 
-  &__footer {
+  &--footer {
     padding-block-start: spacing(5);
   }
 
-  .icon {
+  &--icon {
     background-repeat: no-repeat;
     background-size: contain;
     display: block;
     height: px-to-rem(24px);
     width: px-to-rem(24px);
 
-    &__error {
-      @include icon("notification_error", var(--ilo-color-white));
-    }
+    &__alert {
+      &__error {
+        @include icon("notification_error", var(--ilo-color-white));
+      }
 
-    &__info {
-      @include icon("notification_info", var(--ilo-color-white));
-    }
+      &__info {
+        @include icon("notification_info", var(--ilo-color-white));
+      }
 
-    &__success {
-      @include icon("notification_success", var(--ilo-color-white));
-    }
+      &__success {
+        @include icon("notification_success", var(--ilo-color-white));
+      }
 
-    &__warning {
-      @include icon("notification_warning", var(--ilo-color-white));
-    }
-  }
-
-  &__error {
-    background: var(--ilo-color-red-ramp);
-
-    #{$callout}__sidebar {
-      background: var(--ilo-color-red);
-    }
-  }
-
-  &__info {
-    background: var(--ilo-color-blue-ramp);
-
-    #{$callout}__sidebar {
-      background: var(--ilo-color-blue);
-    }
-  }
-
-  &__success {
-    background: var(--ilo-ramp-green);
-
-    #{$callout}__sidebar {
-      background: var(--ilo-color-green);
-    }
-  }
-
-  &__warning {
-    background: var(--ilo-color-yellow-ramp);
-
-    #{$callout}__sidebar {
-      background: var(--ilo-color-yellow);
+      &__warning {
+        @include icon("notification_warning", var(--ilo-color-white));
+      }
     }
   }
 }

--- a/packages/twig/cypress/e2e/feedback/callout.cy.js
+++ b/packages/twig/cypress/e2e/feedback/callout.cy.js
@@ -1,13 +1,133 @@
-describe("callout", () => {
+import fixture from "../../fixtures/callout.json";
+
+const url = `/pattern-preview?id=callout&fields=${encodeURI(
+  JSON.stringify(fixture)
+)}`;
+
+describe("Callout", () => {
   beforeEach(() => {
-    cy.visit("/admin/appearance/ui/patterns/callout");
-    cy.getPreview("callout").first().as("calloutSection");
+    cy.visit(url);
+    cy.get(".ilo--callout").as("callout");
   });
 
-  it("renders the callout correctly", () => {
-    cy.get("@calloutSection").within(() => {
-      cy.contains("This is a callout component");
-      cy.contains("Take action");
-    });
+  it("should render with the correct alert type", () => {
+    cy.get("@callout").should(
+      "have.class",
+      `ilo--callout__${fixture.settings.alert}`
+    );
+  });
+
+  it("should render the title correctly", () => {
+    cy.get("@callout")
+      .find(".ilo--callout--title")
+      .should("exist")
+      .and("contain", fixture.title);
+  });
+
+  it("should render the content correctly", () => {
+    cy.get("@callout")
+      .find(".ilo--callout--description")
+      .should("exist")
+      .and("contain", fixture.content);
+  });
+
+  it("should render the alert icon", () => {
+    cy.get("@callout")
+      .find(".ilo--callout--icon")
+      .should("exist")
+      .and(
+        "have.class",
+        `ilo--callout--icon__alert__${fixture.settings.alert}`
+      );
+  });
+
+  it("should render the button when provided", () => {
+    cy.get("@callout")
+      .find(".ilo--callout--footer")
+      .should("exist")
+      .within(() => {
+        cy.get("a")
+          .should("exist")
+          .and("have.attr", "href", fixture.button.url)
+          .and("have.attr", "target", fixture.button.target)
+          .and("contain", fixture.button.label);
+      });
+  });
+
+  it("should have the correct collapsible state", () => {
+    if (fixture.settings.isCollapsible) {
+      cy.get("@callout").should("have.class", "ilo--callout__collapse");
+
+      if (fixture.settings.isOpen) {
+        cy.get("@callout").should("have.class", "ilo--callout__open");
+      } else {
+        cy.get("@callout").should("not.have.class", "ilo--callout__open");
+      }
+    } else {
+      cy.get("@callout").should("not.have.class", "ilo--callout__collapse");
+    }
+  });
+
+  it("should render the toggle button when collapsible", () => {
+    if (fixture.settings.isCollapsible) {
+      cy.get("@callout")
+        .find(".ilo--callout--toggle")
+        .should("exist")
+        .and("have.attr", "data-open", fixture.toggleOpenLabel)
+        .and("have.attr", "data-closed", fixture.toggleClosedLabel);
+
+      cy.get("@callout")
+        .find(".ilo--callout--button-text")
+        .should("exist")
+        .and(
+          "contain",
+          fixture.settings.isOpen
+            ? fixture.toggleOpenLabel
+            : fixture.toggleClosedLabel
+        );
+    } else {
+      cy.get("@callout").find(".ilo--callout--toggle").should("not.exist");
+    }
+  });
+
+  it("should toggle open/closed state when clicked", () => {
+    // Create new fixture with isOpen set to false
+    const closedFixture = {
+      ...fixture,
+      settings: {
+        ...fixture.settings,
+        isOpen: false,
+        isCollapsible: true,
+      },
+    };
+
+    // Create a new URL with the closed fixture
+    const closedUrl = `/pattern-preview?id=callout&fields=${encodeURI(
+      JSON.stringify(closedFixture)
+    )}`;
+
+    // Visit the closed URL
+    cy.visit(closedUrl);
+
+    // Get the callout element
+    cy.get(".ilo--callout").as("callout");
+
+    // Click the toggle button
+    cy.get("@callout").find(".ilo--callout--toggle").click();
+
+    // Check that the class has changed
+    cy.get("@callout").should("have.class", "ilo--callout__open");
+    cy.get("@callout")
+      .find(".ilo--callout--button-text")
+      .should("contain", fixture.toggleOpenLabel);
+
+    // Click again to toggle back
+    cy.get("@callout").find(".ilo--callout--toggle").click();
+
+    // Check that it's back to the original state
+    cy.get("@callout").should("not.have.class", "ilo--callout__open");
+    cy.get("@callout")
+      .find(".ilo--callout--button-text")
+      .should("contain", fixture.toggleClosedLabel);
   });
 });

--- a/packages/twig/cypress/fixtures/callout.json
+++ b/packages/twig/cypress/fixtures/callout.json
@@ -1,0 +1,19 @@
+{
+  "title": "Important Notice",
+  "content": "This is the main content of the callout component that can contain rich text and other HTML elements",
+  "button": {
+    "label": "Take action",
+    "url": "https://www.ilo.org",
+    "target": "_blank",
+    "icon": false,
+    "className": "optionalclass"
+  },
+  "toggleOpenLabel": "Less",
+  "toggleClosedLabel": "More",
+  "settings": {
+    "alert": "info",
+    "prefix": "ilo",
+    "isCollapsible": true,
+    "isOpen": false
+  }
+}

--- a/packages/twig/src/components/callout/callout.js
+++ b/packages/twig/src/components/callout/callout.js
@@ -141,7 +141,7 @@ export default class Callout {
       ? this.toggleLabelOpen
       : this.toggleLabelClosed;
 
-    this.element.classList.toggle("ilo--callout--open");
+    this.element.classList.toggle("ilo--callout__open");
     this.toggleLabel.innerText = label;
 
     return this;

--- a/packages/twig/src/components/callout/callout.twig
+++ b/packages/twig/src/components/callout/callout.twig
@@ -1,13 +1,11 @@
-{#
-  CALLOUT COMPONENT
-#}
-<div class="{{prefix}}--callout {{prefix}}--callout__{{alert}} {% if isCollapsible|boolval and isOpen|boolval %} {{prefix}}--callout--open {% endif %} {% if isCollapsible|boolval %} {{prefix}}--callout--collapse {% endif %}" data-loadcomponent="Callout">
-	<div class="{{prefix}}--callout__sidebar">
-		<span class="{{prefix}}--callout--icon icon icon__{{alert}}"></span>
+{# callout.twig #}
+<div class="{{prefix}}--callout {{prefix}}--callout__{{alert}} {% if isCollapsible|boolval and isOpen|boolval %} {{prefix}}--callout__open {% endif %} {% if isCollapsible|boolval %} {{prefix}}--callout__collapse {% endif %}" data-loadcomponent="Callout">
+	<div class="{{prefix}}--callout--sidebar">
+		<span class="{{prefix}}--callout--icon {{prefix}}--callout--icon__alert__{{alert}}"></span>
 	</div>
-	<div class="{{prefix}}--callout__content">
-		<div class="{{prefix}}--callout__header">
-			<h5 class="{{prefix}}--callout__title">{{ title }}</h5>
+	<div class="{{prefix}}--callout--content">
+		<div class="{{prefix}}--callout--header">
+			<h5 class="{{prefix}}--callout--title">{{ title }}</h5>
 			{% if isCollapsible|boolval %}
 				<button class="{{prefix}}--callout--toggle" type="button" data-open="{{ toggleOpenLabel }}" data-closed="{{ toggleClosedLabel }}">
 					<span class="{{prefix}}--callout--button-text">
@@ -21,9 +19,9 @@
 				</button>
 			{% endif %}
 		</div>
-		<p class="{{prefix}}--callout__description">{{ content }}</p>
+		<p class="{{prefix}}--callout--description">{{ content }}</p>
 		{% if button %}
-			<div class="{{prefix}}--callout__footer">
+			<div class="{{prefix}}--callout--footer">
 				{% include '@components/button/button.twig' with {
           label: button.label,
           url: button.url,


### PR DESCRIPTION
Fixes some issues to the Callout component including wrong background text for `info` state. Also refactors the css to use the correct modified bem convention.