### PR TITLE
Feat(Twig): StatefulComponent

### DIFF
--- a/packages/twig/cypress/e2e/utils/statefulComponent.cy.js
+++ b/packages/twig/cypress/e2e/utils/statefulComponent.cy.js
@@ -1,0 +1,189 @@
+import { StatefulComponent } from "../../../src/utils/statefulComponent";
+
+describe("StatefulComponent", () => {
+  let component;
+  let element;
+  let initialState;
+  let stateChangeHandler;
+
+  beforeEach(() => {
+    // Create a mock DOM element
+    element = document.createElement("div");
+    element.id = "test-component";
+    document.body.appendChild(element);
+
+    // Setup initial state
+    initialState = {
+      isOpen: false,
+      items: [],
+      nested: {
+        value: "initial",
+        count: 0,
+      },
+    };
+
+    // Create a spy for state change handler
+    stateChangeHandler = cy.spy();
+
+    // Initialize component
+    component = new StatefulComponent(element, initialState);
+  });
+
+  afterEach(() => {
+    // Clean up DOM
+    element.remove();
+  });
+
+  it("should initialize with correct state", () => {
+    expect(component.state).to.deep.equal(initialState);
+  });
+
+  it("should trigger handler when state property changes", () => {
+    component.registerStateHandler("isOpen", stateChangeHandler);
+    component.state.isOpen = true;
+    expect(stateChangeHandler).to.have.been.calledWith(true, "isOpen");
+  });
+
+  it("should not trigger handler when state property is set to same value", () => {
+    component.registerStateHandler("isOpen", stateChangeHandler);
+    component.state.isOpen = false; // Same as initial value
+    expect(stateChangeHandler).not.to.have.been.called;
+  });
+
+  it("should handle multiple handlers for same property", () => {
+    const handler1 = cy.spy();
+    const handler2 = cy.spy();
+
+    component.registerStateHandler("isOpen", handler1);
+    component.registerStateHandler("isOpen", handler2);
+
+    component.state.isOpen = true;
+
+    expect(handler1).to.have.been.calledWith(true, "isOpen");
+    expect(handler2).to.have.been.calledWith(true, "isOpen");
+  });
+
+  it("should handle nested object state changes through assignment", () => {
+    const nestedHandler = cy.spy();
+    component.registerStateHandler("nested", nestedHandler);
+
+    // Update nested object through assignment
+    component.state.nested = {
+      ...component.state.nested,
+      value: "updated",
+    };
+
+    expect(nestedHandler).to.have.been.calledWith(
+      { value: "updated", count: 0 },
+      "nested"
+    );
+  });
+
+  it("should handle array state changes through assignment", () => {
+    const arrayHandler = cy.spy();
+    component.registerStateHandler("items", arrayHandler);
+
+    // Update array through assignment
+    component.state.items = [...component.state.items, "new item"];
+
+    expect(arrayHandler).to.have.been.calledWith(["new item"], "items");
+  });
+
+  it("should maintain reference to DOM element", () => {
+    expect(component.element).to.equal(element);
+  });
+
+  it("should handle multiple state changes in sequence", () => {
+    const isOpenHandler = cy.spy();
+    const itemsHandler = cy.spy();
+
+    component.registerStateHandler("isOpen", isOpenHandler);
+    component.registerStateHandler("items", itemsHandler);
+
+    component.state.isOpen = true;
+    component.state.items = [...component.state.items, "item1"];
+    component.state.isOpen = false;
+
+    expect(isOpenHandler).to.have.been.calledTwice;
+    expect(itemsHandler).to.have.been.calledOnce;
+  });
+
+  it("should handle complex nested state updates through assignment", () => {
+    const nestedHandler = cy.spy();
+    component.registerStateHandler("nested", nestedHandler);
+
+    // Update nested state through assignment
+    component.state.nested = {
+      value: "new",
+      count: 1,
+      deeper: {
+        level: 2,
+      },
+    };
+
+    expect(nestedHandler).to.have.been.calledWith(
+      {
+        value: "new",
+        count: 1,
+        deeper: {
+          level: 2,
+        },
+      },
+      "nested"
+    );
+  });
+
+  it("should handle undefined initial state", () => {
+    const emptyComponent = new StatefulComponent(element);
+    expect(emptyComponent.state).to.deep.equal({});
+  });
+
+  it("should handle multiple array operations through assignment", () => {
+    const arrayHandler = cy.spy();
+    component.registerStateHandler("items", arrayHandler);
+
+    // Add item
+    component.state.items = [...component.state.items, "item1"];
+    expect(arrayHandler).to.have.been.calledWith(["item1"], "items");
+
+    // Remove item
+    component.state.items = component.state.items.filter(
+      (item) => item !== "item1"
+    );
+    expect(arrayHandler).to.have.been.calledWith([], "items");
+
+    // Update item
+    component.state.items = ["item1", "item2"];
+    component.state.items = component.state.items.map((item) =>
+      item === "item1" ? "updated" : item
+    );
+    expect(arrayHandler).to.have.been.calledWith(["updated", "item2"], "items");
+  });
+
+  it("should handle nested array updates through assignment", () => {
+    const initialState = {
+      nestedArray: [
+        [1, 2],
+        [3, 4],
+      ],
+    };
+    const component = new StatefulComponent(element, initialState);
+    const arrayHandler = cy.spy();
+
+    component.registerStateHandler("nestedArray", arrayHandler);
+
+    // Update nested array
+    component.state.nestedArray = [
+      [...component.state.nestedArray[0], 3],
+      component.state.nestedArray[1],
+    ];
+
+    expect(arrayHandler).to.have.been.calledWith(
+      [
+        [1, 2, 3],
+        [3, 4],
+      ],
+      "nestedArray"
+    );
+  });
+});

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -6,6 +6,58 @@
  * - Track component state changes
  * - React to state updates via event listeners
  * - Share state management logic across multiple components
+ * - Create reactive UI components that respond to state changes
+ *
+ * @example
+ * // Example subclass implementation
+ * class MyComponent extends StatefulComponent {
+ *   constructor(element) {
+ *     // Initialize state with default values
+ *     const initialState = {
+ *       isOpen: false,
+ *       selectedItem: null,
+ *       items: []
+ *     };
+ *
+ *     // Call super with element and initial state
+ *     super(element, initialState);
+ *
+ *     // Initialize component-specific properties
+ *     this.prefix = 'my-component';
+ *
+ *     // Initialize the component
+ *     this.init();
+ *   }
+ *
+ *   init() {
+ *     this.cacheDomReferences()
+ *       .bindHandlers()
+ *       .registerStateHandlers();
+ *     return this;
+ *   }
+ *
+ *   registerStateHandlers() {
+ *     // Register handlers for state changes
+ *     this.registerStateHandler('isOpen', (value) => {
+ *       if (value) {
+ *         this.open();
+ *       } else {
+ *         this.close();
+ *       }
+ *     });
+ *
+ *     this.registerStateHandler('selectedItem', (value) => {
+ *       this.updateSelectedItem(value);
+ *     });
+ *
+ *     return this;
+ *   }
+ *
+ *   // Example method that updates state
+ *   toggle() {
+ *     this.state.isOpen = !this.state.isOpen;
+ *   }
+ * }
  *
  * @class StatefulComponent
  */
@@ -19,7 +71,8 @@ export default class StatefulComponent {
   constructor(element, initialState = {}) {
     this.element = element;
     this.initialState = initialState;
-    this.state = this.setupState(this.initialState);
+    this.state = this.#setupState(this.initialState);
+    this.stateHandlers = new Map();
 
     this.#init();
   }
@@ -30,7 +83,38 @@ export default class StatefulComponent {
    * @private
    */
   #init() {
-    this.setupState = this.setupState.bind(this);
+    this.setupState = this.#setupState.bind(this);
+    this.registerStateHandler = this.registerStateHandler.bind(this);
+  }
+
+  /**
+   * Registers a handler function to be called when a specific state property changes
+   *
+   * @param {string} prop - The state property to watch
+   * @param {Function} handler - The function to call when the property changes
+   * @param {any} handler.value - The new value of the state property
+   * @param {string} handler.prop - The name of the state property that changed
+   * @example
+   * // Register a handler for a state property
+   * this.registerStateHandler('isOpen', (value) => {
+   *   if (value) {
+   *     this.open();
+   *   } else {
+   *     this.close();
+   *   }
+   * });
+   *
+   * // Register a handler that uses both value and prop
+   * this.registerStateHandler('items', (value, prop) => {
+   *   console.log(`${prop} changed to:`, value);
+   *   this.renderItems(value);
+   * });
+   */
+  registerStateHandler(prop, handler) {
+    if (!this.stateHandlers.has(prop)) {
+      this.stateHandlers.set(prop, []);
+    }
+    this.stateHandlers.get(prop).push(handler);
   }
 
   /**
@@ -39,12 +123,23 @@ export default class StatefulComponent {
    * @private
    * @param {Object} initialState - The initial state to proxy
    * @returns {Proxy} A proxy object that will dispatch events when properties are changed
+   * @example
+   * // The state object can be used like a normal object
+   * this.state.isOpen = true;  // Triggers handlers and events
+   * this.state.items.push(item);  // Also triggers handlers and events
    */
-  setupState(initialState = {}) {
+  #setupState(initialState = {}) {
     return new Proxy(initialState, {
       set: (target, prop, value) => {
         if (value !== target[prop]) {
           target[prop] = value;
+
+          // Call registered handlers for this property
+          const handlers = this.stateHandlers.get(prop);
+          if (handlers) {
+            handlers.forEach((handler) => handler(value, prop));
+          }
+
           this.element.dispatchEvent(
             new CustomEvent("stateChange", {
               detail: {

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -1,6 +1,6 @@
 /**
  * A base class that provides state management functionality for components.
- * It creates a reactive state system that automatically dispatches events when state changes.
+ * It creates a reactive state system that triggers handlers automatically when state changes.
  *
  * This class is useful when you need to:
  * - Track component state changes

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -1,0 +1,62 @@
+/**
+ * A base class that provides state management functionality for components.
+ * It creates a reactive state system that automatically dispatches events when state changes.
+ *
+ * This class is useful when you need to:
+ * - Track component state changes
+ * - React to state updates via event listeners
+ * - Share state management logic across multiple components
+ *
+ * @class StatefulComponent
+ */
+export default class StatefulComponent {
+  /**
+   * Creates a new StatefulComponent instance
+   *
+   * @param {HTMLElement} element - The DOM element this component is attached to
+   * @param {Object} initialState - The initial state object for this component
+   */
+  constructor(element, initialState = {}) {
+    this.element = element;
+    this.initialState = initialState;
+    this.state = this.setupState(this.initialState);
+
+    this.init();
+  }
+
+  /**
+   * Initializes the component by binding necessary methods
+   *
+   * @private
+   */
+  init() {
+    this.setupState = this.setupState.bind(this);
+  }
+
+  /**
+   * Creates a Proxy-based reactive state system that dispatches events on state changes
+   *
+   * @private
+   * @param {Object} initialState - The initial state to proxy
+   * @returns {Proxy} A proxy object that will dispatch events when properties are changed
+   */
+  setupState(initialState = {}) {
+    return new Proxy(initialState, {
+      set: (target, prop, value) => {
+        if (value !== target[prop]) {
+          target[prop] = value;
+          this.element.dispatchEvent(
+            new CustomEvent("stateChange", {
+              detail: {
+                prop,
+                value,
+                state: this.state,
+              },
+            })
+          );
+          return true;
+        }
+      },
+    });
+  }
+}

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -57,7 +57,7 @@
  *
  * @class StatefulComponent
  */
-export default class StatefulComponent {
+export class StatefulComponent {
   /**
    * Creates a new StatefulComponent instance
    *
@@ -136,6 +136,7 @@ export default class StatefulComponent {
             handlers.forEach((handler) => handler(value, prop));
           }
         }
+        return true;
       },
     });
   }

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -21,7 +21,7 @@ export default class StatefulComponent {
     this.initialState = initialState;
     this.state = this.setupState(this.initialState);
 
-    this.init();
+    this.#init();
   }
 
   /**
@@ -29,7 +29,7 @@ export default class StatefulComponent {
    *
    * @private
    */
-  init() {
+  #init() {
     this.setupState = this.setupState.bind(this);
   }
 

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -1,12 +1,8 @@
 /**
- * A base class that provides state management functionality for components.
+ * A base class that provides simple state management functionality for components.
  * It creates a reactive state system that triggers handlers automatically when state changes.
  *
- * This class is useful when you need to:
- * - Track component state changes
- * - React to state updates via event listeners
- * - Share state management logic across multiple components
- * - Create reactive UI components that respond to state changes
+ * This is useful for components that can have multiple different states.
  *
  * @example
  * // Example subclass implementation
@@ -139,17 +135,6 @@ export default class StatefulComponent {
           if (handlers) {
             handlers.forEach((handler) => handler(value, prop));
           }
-
-          this.element.dispatchEvent(
-            new CustomEvent("stateChange", {
-              detail: {
-                prop,
-                value,
-                state: this.state,
-              },
-            })
-          );
-          return true;
         }
       },
     });

--- a/packages/twig/src/utils/statefulComponent.js
+++ b/packages/twig/src/utils/statefulComponent.js
@@ -4,6 +4,11 @@
  *
  * This is useful for components that can have multiple different states.
  *
+ * Important: State updates must be done through reassignment. This means:
+ * - Arrays must be cloned and replaced to be updated
+ * - Objects must be cloned and replaced to be updated
+ * - Direct mutations of arrays/objects will not trigger state updates
+ *
  * @example
  * // Example subclass implementation
  * class MyComponent extends StatefulComponent {
@@ -49,10 +54,24 @@
  *     return this;
  *   }
  *
- *   // Example method that updates state
+ *   // Example methods that update state correctly
  *   toggle() {
  *     this.state.isOpen = !this.state.isOpen;
  *   }
+ *
+ *   // Correct way to update an array
+ *   addItem(newItem) {
+ *     this.state.items = [...this.state.items, newItem];
+ *   }
+ *
+ *   // Correct way to update an object
+ *   updateUser(userData) {
+ *     this.state.user = { ...this.state.user, ...userData };
+ *   }
+ *
+ *   // Incorrect way to update state (will not trigger updates):
+ *   // this.state.items.push(newItem); // ❌
+ *   // this.state.user.name = 'John';  // ❌
  * }
  *
  * @class StatefulComponent


### PR DESCRIPTION
## Introduction

This PR proposes a utility class to the Twig package called `StatefulComponent`. It provides simple reactive state system that triggers handlers automatically when state changes.

## Background

While working on #823, I noticed that the Navigation component has to manage a bunch of state (whether the mobile drawers are open are closed in desktop or mobile where there are more than one). There are several others components like LanguageToggle and Breadcrumb that have to manage state as well, albeit it a little less. 

We have tickets open for new components like a photogallery that might have to manage a lot more state.

At the same time, I really like that the Twig package is lightweight in terms of JavaScript. We've done a good job of "just using the platform" wherever possible and I think we should continue doing so. Fortunately, modern JavaScript provides all the tools we need to manage state in Twig components in a straightforward, declarative way without having to reach for libraries. 

## StatefulComponent

This is a superclass that can be extended to add statement management functionality as needed. It uses a simple object Proxy to track state and fire callbacks when state changes. That's all there is to it.

## Usage

This is a superclass that can add state management to components as needed. Here's an example:

```js
class MyComponent extends StatefulComponent {
 constructor(element) {
   // Initialize state with default values
   const initialState = {
     isOpen: false,
     selectedItem: null,
     items: []
   };
 
   // Call super with element and initial state
   super(element, initialState);
 
   // Initialize component-specific properties
   this.prefix = 'my-component';
 
   // Initialize the component
   this.init();
 }
 
 init() {
   this.cacheDomReferences()
     .bindHandlers()
     .registerStateHandlers();
   return this;
 }
 
 registerStateHandlers() {
   // Register handlers for state changes
   this.registerStateHandler('isOpen', (value) => {
     if (value) {
       this.open();
     } else {
       this.close();
     }
   });
 
   this.registerStateHandler('selectedItem', (value) => {
     this.updateSelectedItem(value);
   });
 
   return this;
 }
 
 // Example method that updates state
 toggle() {
   this.state.isOpen = !this.state.isOpen;
 }
}
```

All we have to do is initialize state in the constructor and from then on, we can register event handlers that will file whenever that state changes. From then on, things like click handlers can simply set state as needed with a simple assignment and the stateHandlers will do the rest. Best of all, you can easily use state in checks without having to resort to hacks like checking the DOM or looking at data attributes.

## ⚠️ Caveat

As of the time of the first pull request, this will only work for direct assignments! For example, this will fire an update:

```js
this.state.myValue = true
```

But this won't 😒 

```js
this.state.items.push("item-1");
```

We don't have a use case for the second scenario YET but I think we probably will. And anyway, if you've worked with any framework or state management lib at all, you would expect the second option to work.

This can be done by recursively adding Proxies to objects passed as values, which I think is worth the effort. I'm going to research a little more and then add. 



