### PR TITLE
fix(styles): implemented mixins for image styles

### DIFF
--- a/.changeset/witty-kiwis-wonder.md
+++ b/.changeset/witty-kiwis-wonder.md
@@ -1,0 +1,8 @@
+---
+"@ilo-org/styles": patch
+---
+
+Implemented mixins for images and image captions and synced components with design.
+Image: synced image caption with design
+RichText: synced image caption with design
+Video: synced image caption with design

--- a/.changeset/witty-kiwis-wonder.md
+++ b/.changeset/witty-kiwis-wonder.md
@@ -3,6 +3,6 @@
 ---
 
 Implemented mixins for images and image captions and synced components with design.
-Image: synced image caption with design
-RichText: synced image caption with design
-Video: synced image caption with design
+**Image:** synced image caption with design
+**RichText:** synced image caption with design
+**Video:** synced image caption with design

--- a/packages/react/src/components/Image/Image.tsx
+++ b/packages/react/src/components/Image/Image.tsx
@@ -12,18 +12,10 @@ const Image: FC<ImageProps> = ({ alt, caption, className, credit, url }) => {
     [baseClass]: true,
   });
 
-  const imgClasses = classNames("", {
-    [`${baseClass}--img`]: true,
-  });
-
-  const captionClasses = classNames("", {
-    [`${baseClass}--caption`]: true,
-  });
-
   return (
     <figure className={imageClasses}>
       <div className={`${imageClasses}--wrapper`}>
-        <picture className={imgClasses}>
+        <picture>
           {url &&
             url
               .sort((a: ImageUrl, b: ImageUrl) => a.breakpoint - b.breakpoint)
@@ -40,7 +32,7 @@ const Image: FC<ImageProps> = ({ alt, caption, className, credit, url }) => {
         </picture>
         {credit && <Credit credit={credit} />}
       </div>
-      {caption && <figcaption className={captionClasses}>{caption}</figcaption>}
+      {caption && <figcaption>{caption}</figcaption>}
     </figure>
   );
 };

--- a/packages/styles/scss/components/_image.scss
+++ b/packages/styles/scss/components/_image.scss
@@ -2,6 +2,20 @@
 @use "../functions" as *;
 @import "../mixins";
 
+@mixin image-caption-styles {
+  figcaption {
+    border-inline-start: var(--ilo-border-lg) solid
+      var(--ilo-color-borders-default);
+    color: var(--ilo-color-gray-accessible);
+    font-size: var(--ilo-font-size-sm);
+    line-height: var(--ilo-line-height-xlg);
+    font-weight: var(--ilo-font-weight-regular);
+    letter-spacing: var(--ilo-letter-spacing-md);
+    margin-top: spacing(4);
+    padding-inline-start: spacing(2);
+  }
+}
+
 .ilo--image {
   position: relative;
 
@@ -20,15 +34,6 @@
     width: 100%;
   }
 
-  &--caption {
-    border-left: var(--ilo-border-lg) solid var(--ilo-color-borders-default);
-    color: var(--ilo-color-gray-accessible);
-    font-weight: var(--ilo-font-weight-regular);
-    margin-top: spacing(4);
-    padding-left: spacing(2);
-    @include font-styles("image-caption");
-  }
-
   .ilo--credit {
     bottom: 0;
     left: 0;
@@ -40,16 +45,11 @@
   }
 
   [dir="rtl"] & {
-    .ilo--image--caption {
-      border-left: none;
-      border-right: var(--ilo-border-lg) solid var(--ilo-color-borders-default);
-      padding-left: 0;
-      padding-right: spacing(2);
-    }
-
     .ilo--credit {
       left: auto;
       right: 0;
     }
   }
+
+  @include image-caption-styles;
 }

--- a/packages/styles/scss/components/_image.scss
+++ b/packages/styles/scss/components/_image.scss
@@ -18,7 +18,8 @@
 
 @mixin image-caption-dark-styles {
   figcaption {
-    color: var(--ilo-color-gray-light);
+    color: var(--ilo-color-white);
+    border-inline-color: var(--ilo-color-gray-light-semi-transparent);
   }
 }
 
@@ -54,10 +55,15 @@
       bottom: -#{px-to-rem(4px)};
     }
   }
+
   [dir="rtl"] & {
     .ilo--credit {
       left: auto;
       right: 0;
     }
+  }
+
+  &__theme__dark {
+    @include image-caption-dark-styles;
   }
 }

--- a/packages/styles/scss/components/_image.scss
+++ b/packages/styles/scss/components/_image.scss
@@ -16,6 +16,23 @@
   }
 }
 
+@mixin image-caption-dark-styles {
+  figcaption {
+    color: var(--ilo-color-gray-light);
+  }
+}
+
+@mixin image-styles {
+  figure {
+    width: 100%;
+    line-height: 0;
+  }
+
+  img {
+    width: 100%;
+  }
+}
+
 .ilo--image {
   position: relative;
 
@@ -25,14 +42,8 @@
     width: 100%;
   }
 
-  &--img {
-    line-height: 0;
-  }
-
-  &--img,
-  img {
-    width: 100%;
-  }
+  @include image-styles;
+  @include image-caption-styles;
 
   .ilo--credit {
     bottom: 0;
@@ -43,13 +54,10 @@
       bottom: -#{px-to-rem(4px)};
     }
   }
-
   [dir="rtl"] & {
     .ilo--credit {
       left: auto;
       right: 0;
     }
   }
-
-  @include image-caption-styles;
 }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -1,6 +1,7 @@
 @use "../tokens" as *;
 @use "../functions" as *;
 @import "./blockquote";
+@import "./image";
 @import "../mixins";
 
 .ilo--richtext {
@@ -119,15 +120,7 @@
     width: 100%;
   }
 
-  // Figcaption styles
-  figcaption {
-    border-left: var(--ilo-border-lg) solid var(--ilo-color-borders-default);
-    color: var(--ilo-richtext-figcaption-color);
-    font-weight: var(--ilo-font-weight-regular);
-    margin-top: spacing(4);
-    padding-left: spacing(2);
-    @include font-styles("image-caption");
-  }
+  @include image-caption-styles;
 
   // Horizontal rule (hr) styles
   hr {
@@ -220,16 +213,6 @@
 
     figure {
       width: 100%;
-    }
-  }
-
-  // RTL (Right-to-left) support
-  [dir="rtl"] & {
-    figcaption {
-      border-left: none;
-      border-right: var(--ilo-border-lg) solid var(--ilo-color-borders-default);
-      padding-left: 0;
-      padding-right: spacing(2);
     }
   }
 }

--- a/packages/styles/scss/components/_richtext.scss
+++ b/packages/styles/scss/components/_richtext.scss
@@ -6,14 +6,12 @@
 
 .ilo--richtext {
   --ilo-richtext-color: var(--ilo-color-blue-dark);
-  --ilo-richtext-figcaption-color: var(--ilo-color-gray-accessible);
   --ilo-richtext-hr-color: var(--ilo-color-gray-light);
   --ilo-richtext-link-color: var(--ilo-color-purple);
   --ilo-richtext-link-visited-color: var(--ilo-color-purple);
 
   &__theme__light {
     --ilo-richtext-color: var(--ilo-color-blue-dark);
-    --ilo-richtext-figcaption-color: var(--ilo-color-gray-accessible);
     --ilo-richtext-hr-color: var(--ilo-color-gray-light);
     --ilo-richtext-link-color: var(--ilo-color-purple);
     --ilo-richtext-link-visited-color: var(--ilo-color-purple);
@@ -25,7 +23,6 @@
 
   &__theme__dark {
     --ilo-richtext-color: var(--ilo-color-white);
-    --ilo-richtext-figcaption-color: var(--ilo-color-gray-light);
     --ilo-richtext-hr-color: var(--ilo-color-gray-light);
     --ilo-richtext-link-color: var(--ilo-color-blue-medium);
     --ilo-richtext-link-visited-color: var(--ilo-color-blue-medium);
@@ -33,6 +30,8 @@
     a {
       @include linkstyles("dark");
     }
+
+    @include image-caption-dark-styles;
   }
 
   color: var(--ilo-richtext-color);
@@ -110,16 +109,7 @@
     font-weight: 700;
   }
 
-  // Image styles
-  img {
-    width: 100%;
-  }
-
-  // Figure styles
-  figure {
-    width: 100%;
-  }
-
+  @include image-styles;
   @include image-caption-styles;
 
   // Horizontal rule (hr) styles
@@ -209,10 +199,6 @@
 
     p {
       font-size: var(--ilo-font-size-lg);
-    }
-
-    figure {
-      width: 100%;
     }
   }
 }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -1,5 +1,6 @@
 @use "../tokens" as *;
 @use "../functions" as *;
+@import "./image";
 @import "../mixins";
 
 .ilo--video {
@@ -17,15 +18,6 @@
     width: 100%;
   }
 
-  &--caption {
-    border-left: px-to-rem(3px) solid $color-ux-caption-border-left;
-    color: $color-font-caption;
-    font-weight: 400;
-    margin-top: spacing(4);
-    padding-left: spacing(2);
-    @include font-styles("image-caption");
-  }
-
   &--element {
     height: auto;
     object-fit: cover;
@@ -37,6 +29,8 @@
     position: relative;
     overflow: hidden;
   }
+
+  @include image-caption-styles;
 
   // ? drupal style reset issue
   button {
@@ -337,14 +331,5 @@
         }
       }
     }
-  }
-}
-
-[dir="rtl"] {
-  .ilo--video--caption {
-    border-left: none;
-    border-right: 3px solid #b8c4cc;
-    padding-left: 0;
-    padding-right: spacing(2);
   }
 }

--- a/packages/themes/tokens/type/base.json
+++ b/packages/themes/tokens/type/base.json
@@ -197,11 +197,6 @@
       "letter-spacing": { "value": "-0.02em" },
       "line-height": { "value": "20.16px" }
     },
-    "image-caption": {
-      "size": { "value": "14.93px" },
-      "letter-spacing": { "value": "-0.02em" },
-      "line-height": { "value": "20.16px" }
-    },
     "image-credit": {
       "size": { "value": "11.94px" },
       "letter-spacing": { "value": "-0.02em" },

--- a/packages/twig/src/components/image/image.component.yml
+++ b/packages/twig/src/components/image/image.component.yml
@@ -51,4 +51,11 @@ image:
       description: Is this image in a hero? If true, and credit exists, will display credit in a title attribute
       preview: false
       required: false
+    theme:
+      type: select
+      label: Theme
+      description: The theme to be used for the Image component.
+      options:
+        light: light
+        dark: dark
   visibility: storybook

--- a/packages/twig/src/components/image/image.twig
+++ b/packages/twig/src/components/image/image.twig
@@ -3,7 +3,7 @@
 #}
 <figure class="{{prefix}}--image" data-prefix="{{prefix}}">
   <div class="image {{prefix}}--image--wrapper">
-    <picture class="{{prefix}}--image--img" {% if credit and ishero and ishero != 'false' %}title="{{credit}}"{% endif %}>
+    <picture {% if credit and ishero and ishero != 'false' %}title="{{credit}}"{% endif %}>
       {% for img in url|reverse %}
         {% if loop.last == false  %}
           {% if img.breakpoint matches '/^\\d+$/' %}

--- a/packages/twig/src/components/image/image.twig
+++ b/packages/twig/src/components/image/image.twig
@@ -1,7 +1,8 @@
 {#
   IMAGE COMPONENT
 #}
-<figure class="{{prefix}}--image" data-prefix="{{prefix}}">
+{% set theme = theme|default("light") %}
+<figure class="{{prefix}}--image {{prefix}}--image__theme__{{theme}}" data-prefix="{{prefix}}">
   <div class="image {{prefix}}--image--wrapper">
     <picture {% if credit and ishero and ishero != 'false' %}title="{{credit}}"{% endif %}>
       {% for img in url|reverse %}

--- a/packages/twig/src/components/image/image.twig
+++ b/packages/twig/src/components/image/image.twig
@@ -24,6 +24,6 @@
     {% endif %}
   </div>
   {% if caption %}
-    <figcaption class="{{prefix}}--image--caption">{{caption}}</figcaption>
+    <figcaption>{{caption}}</figcaption>
   {% endif %}
 </figure>

--- a/packages/twig/src/components/video/video.twig
+++ b/packages/twig/src/components/video/video.twig
@@ -14,5 +14,5 @@
       vjsType: vjsType
     } %}
   </div>
-  <figcaption class="{{prefix}}--video--caption">{{caption}}</figcaption>
+  <figcaption>{{caption}}</figcaption>
 </figure>


### PR DESCRIPTION
Fixes #1241

This PR introduces several mixins for sharing image styles across the codebase. In addition to the RichText component described in the issue, I also found the caption styles used in the Video component, so I used the mixin there as well.

The Image component lacked support for the dark theme but the image in RichText had support for it, so I also added support for the dark theme to the Image component and updated it to match the designs. The image credit does not display correctly in dark theme and that will be tackled in #1543 