### PR TITLE
 Detail Card RTL Arrow

### DIFF
--- a/.changeset/moody-pugs-talk.md
+++ b/.changeset/moody-pugs-talk.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/icons": patch
+---
+
+New `triangle_left` icon added

--- a/.changeset/moody-pugs-talk.md
+++ b/.changeset/moody-pugs-talk.md
@@ -1,5 +1,5 @@
 ---
-"@ilo-org/icons": patch
+"@ilo-org/icons": minor
 ---
 
 New `triangle_left` icon added

--- a/.changeset/real-lemons-trade.md
+++ b/.changeset/real-lemons-trade.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/twig": patch
+---
+
+**Icon:** Class passing support
+**Detail Card:** RTL arrow icon

--- a/.changeset/sweet-eels-beam.md
+++ b/.changeset/sweet-eels-beam.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+**Detail Card:** RTL styles support for the arrow icon

--- a/.changeset/weak-spies-try.md
+++ b/.changeset/weak-spies-try.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**Detail Card:** RTL arrow support

--- a/packages/icons/categories.yml
+++ b/packages/icons/categories.yml
@@ -58,6 +58,7 @@ categories:
           - social_tiktok
           - time
           - triangle_right
+          - triangle_left
           - upload
           - social_x
           - social_youtube

--- a/packages/icons/icons.yml
+++ b/packages/icons/icons.yml
@@ -418,6 +418,13 @@
   sizes:
     - glyph
 
+- name: triangle_left
+  friendly_name: triangle_left
+  aliases:
+    - ILO Icons
+  sizes:
+    - glyph
+
 - name: upload
   friendly_name: upload
   aliases:

--- a/packages/icons/src/svg/triangle_left.svg
+++ b/packages/icons/src/svg/triangle_left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 5V19L10.5 15.5L5 12L16 5Z" fill="currentColor"/>
+</svg>

--- a/packages/react/src/components/Cards/DetailCard.tsx
+++ b/packages/react/src/components/Cards/DetailCard.tsx
@@ -156,7 +156,16 @@ const DetailCard = forwardRef<HTMLDivElement, DetailCardProps>(
             )}
             {details && (
               <p className={`${baseClass}--date-extra`}>
-                <Icon name="TriangleRight" size={20} />
+                <Icon
+                  name="TriangleRight"
+                  size={20}
+                  className={`${baseClass}--icon-right`}
+                />
+                <Icon
+                  name="TriangleLeft"
+                  size={20}
+                  className={`${baseClass}--icon-left`}
+                />
                 {details}
               </p>
             )}

--- a/packages/styles/scss/components/_detailcard.scss
+++ b/packages/styles/scss/components/_detailcard.scss
@@ -64,10 +64,27 @@
         text-indent: px-to-rem(-24px);
 
         .ilo--icon {
-          display: inline-block;
           position: relative;
           vertical-align: sub;
           top: px-to-rem(1px);
+        }
+      }
+
+      #{$self}--icon-left {
+        display: none;
+      }
+
+      #{$self}--icon-right {
+        display: inline-block;
+      }
+
+      [dir="rtl"] & {
+        #{$self}--icon-left {
+          display: inline-block;
+        }
+
+        #{$self}--icon-right {
+          display: none;
         }
       }
 

--- a/packages/twig/src/components/card_detail/card_detail.twig
+++ b/packages/twig/src/components/card_detail/card_detail.twig
@@ -35,7 +35,14 @@
 					{% include "@components/icon/icon.twig" with {
 						name: "triangle_right",
 						size: 20,
-						color: iconColor
+						color: iconColor,
+						class: prefix ~ "--card--icon-right"
+					} %}
+					{% include "@components/icon/icon.twig" with {
+						name: "triangle_left",
+						size: 20,
+						color: iconColor,
+						class: prefix ~ "--card--icon-left"
 					} %}
 					{{dateExtra}}
 				</p>

--- a/packages/twig/src/components/icon/icon.twig
+++ b/packages/twig/src/components/icon/icon.twig
@@ -1,1 +1,1 @@
-<svg class="{{prefix}}--icon" data-name="{{name}}" data-size="{{size}}" data-color="{{color}}" data-loadcomponent="Icon" aria-hidden="true"></svg>
+<svg class="{{prefix}}--icon{% if class %} {{class}}{% endif %}" data-name="{{name}}" data-size="{{size}}" data-color="{{color}}" data-loadcomponent="Icon" aria-hidden="true"></svg>


### PR DESCRIPTION
# Description 

This PR fixes the `arrow` icon issue for the `Detail Card` component for both `react` and `twig` implementations

> React

https://github.com/user-attachments/assets/f396bf3c-7dac-42e7-bfc3-8398faeb7c09

> Twig

https://github.com/user-attachments/assets/b10fa0ad-d5eb-4f95-adca-da62f8680943

# Implementation

- The implementation is declaratively renders both `right` and `left` icons directly from the component(for both) and then styles are manipulated based on the direction.

- `triangle_left` is added to the icon pack 
