### PR TITLE
Twig: main-nav component

### DIFF
--- a/.changeset/cool-toys-nail.md
+++ b/.changeset/cool-toys-nail.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": minor
+---
+
+**main-nav**: New navigation component that will replace the old `Navigation` one

--- a/packages/react/src/components/LanguageToggle/LanguageToggle.tsx
+++ b/packages/react/src/components/LanguageToggle/LanguageToggle.tsx
@@ -14,7 +14,7 @@ export type LanguageToggleProps = {
   /**
    * Specify an optional className to be added to your LanguageToggle component.
    */
-  theme?: ThemeTypes;
+  theme?: ThemeTypes | "dark-blue";
 
   /**
    * Hide the glob icon
@@ -83,10 +83,7 @@ const LanguageToggle = forwardRef<
         className={classNames(
           baseClass,
           className,
-          `${baseClass}__theme__${theme}`,
-          {
-            [`${baseClass}__open`]: isCtxMenuOpen,
-          }
+          `${baseClass}__theme__${theme}`
         )}
         {...rest}
       >

--- a/packages/react/src/components/Nav/MainNav.tsx
+++ b/packages/react/src/components/Nav/MainNav.tsx
@@ -50,6 +50,7 @@ const MainNav = forwardRef<HTMLElement, MainNavProps>(
                 <LanguageToggle
                   className={`${baseClass}__widgets-bar__language`}
                   hideIcon={!isAboveXL}
+                  theme="dark-blue"
                   {...widgets.language}
                 />
               )}

--- a/packages/react/tests/MainNav.test.tsx
+++ b/packages/react/tests/MainNav.test.tsx
@@ -1,0 +1,151 @@
+import { expect, describe, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { MainNav } from "../src/components/Nav";
+import { MainNavArgs } from "../src/stories/MainNav/MainNav.args";
+import userEvent from "@testing-library/user-event";
+
+describe("MainNav", () => {
+  it("should render with the correct branding", () => {
+    render(<MainNav {...MainNavArgs} />);
+    expect(
+      screen.getByText(MainNavArgs.branding.tag!.main)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(MainNavArgs.branding.tag!.sub!)
+    ).toBeInTheDocument();
+
+    const logo = screen.getAllByAltText("Logo").at(0);
+    expect(logo!.getAttribute("src")).toBe("/logo_en_horizontal_white.svg");
+  });
+
+  it("should render with the language widget that toggles the context menu", async () => {
+    const { container } = render(<MainNav {...MainNavArgs} />);
+    const languageWidget = container.querySelector(
+      ".ilo--main-nav__widgets-bar__language"
+    );
+
+    expect(languageWidget).toBeInTheDocument();
+
+    const languageContextMenu = document.querySelector(
+      ".ilo--language-toggle--context-menu"
+    );
+
+    expect(languageContextMenu).toBeInTheDocument();
+    expect(languageContextMenu?.querySelectorAll("li").length).toBe(
+      MainNavArgs.widgets.language!.options!.length
+    );
+
+    const languageToggleButton = container.querySelector(
+      '[aria-controls="ilo--language-toggle--context-menu"]'
+    );
+    expect(languageToggleButton).toBeInTheDocument();
+    expect(languageToggleButton).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(languageToggleButton!);
+    expect(languageToggleButton).toHaveAttribute("aria-expanded", "true");
+
+    expect(languageContextMenu).toHaveClass(
+      "ilo--language-toggle--context-menu__open"
+    );
+
+    await userEvent.click(languageToggleButton!);
+    expect(languageToggleButton).toHaveAttribute("aria-expanded", "false");
+    expect(languageContextMenu).not.toHaveClass(
+      "ilo--language-toggle--context-menu__open"
+    );
+  });
+
+  it("should render the more button and toggle navigation dropdown", async () => {
+    render(<MainNav {...MainNavArgs} />);
+
+    const moreButtons = screen.getAllByText(MainNavArgs.menu.labels.more!);
+    expect(moreButtons.length).toBeGreaterThan(0);
+
+    const desktopMoreButton = moreButtons.filter((item) =>
+      item.classList.contains("ilo--nav-menu__more")
+    );
+    expect(desktopMoreButton.length).toBe(1);
+
+    const moreButton = desktopMoreButton.at(0)!;
+    const navigationDropdown = document.querySelector(
+      ".ilo--nav-dropdown:not(.ilo--main-nav__nav-search-dropdown)"
+    );
+
+    expect(navigationDropdown).toBeInTheDocument();
+    expect(navigationDropdown).not.toHaveClass(".ilo--nav-dropdown--open");
+
+    await userEvent.click(moreButton);
+    expect(navigationDropdown).toHaveClass("ilo--nav-dropdown--open");
+
+    await userEvent.click(moreButton);
+    expect(navigationDropdown).not.toHaveClass("ilo--nav-dropdown--open");
+
+    const menuItems = navigationDropdown!.querySelectorAll(
+      ".ilo--nav-menu-grid__item"
+    );
+    expect(menuItems.length).toBe(MainNavArgs.menu.items.length - 5);
+  });
+
+  it("should close more menu when search button is clicked", async () => {
+    render(<MainNav {...MainNavArgs} />);
+
+    const moreButtons = screen.getAllByText(MainNavArgs.menu.labels.more!);
+    const desktopMoreButton = moreButtons.filter((item) =>
+      item.classList.contains("ilo--nav-menu__more")
+    );
+    expect(desktopMoreButton.length).toBe(1);
+
+    const moreButton = desktopMoreButton.at(0)!;
+    const navigationDropdown = document.querySelector(
+      ".ilo--nav-dropdown:not(.ilo--main-nav__nav-search-dropdown)"
+    );
+
+    expect(navigationDropdown).toBeInTheDocument();
+    expect(navigationDropdown).not.toHaveClass(".ilo--nav-dropdown--open");
+
+    await userEvent.click(moreButton);
+    const searchButton = document.querySelector(".ilo--main-nav__nav-search");
+    expect(searchButton).toBeInTheDocument();
+
+    const searchDropdown = document.querySelector(
+      ".ilo--main-nav__nav-search-dropdown"
+    );
+    expect(searchDropdown).toBeInTheDocument();
+    expect(searchDropdown).not.toHaveClass(".ilo--nav-dropdown--open");
+
+    await userEvent.click(searchButton!);
+    expect(navigationDropdown).not.toHaveClass("ilo--nav-dropdown--open");
+    expect(searchDropdown).toHaveClass("ilo--nav-dropdown--open");
+  });
+
+  it("should render the search correctly", async () => {
+    render(<MainNav {...MainNavArgs} />);
+
+    const searchButton = document.querySelector(".ilo--main-nav__nav-search");
+    expect(searchButton).toBeInTheDocument();
+
+    const searchDropdown = document.querySelector(
+      ".ilo--main-nav__nav-search-dropdown"
+    );
+    expect(searchDropdown).toBeInTheDocument();
+    expect(searchDropdown).not.toHaveClass(".ilo--nav-dropdown--open");
+
+    await userEvent.click(searchButton!);
+    expect(searchDropdown).toHaveClass("ilo--nav-dropdown--open");
+
+    const searchInput = screen
+      .getAllByPlaceholderText(
+        MainNavArgs.widgets.search.field!.input!.placeholder!
+      )
+      .at(0)!;
+    expect(searchInput).toBeInTheDocument();
+    expect((searchInput as HTMLInputElement).value).toBe("");
+
+    await userEvent.type(searchInput, "test");
+    expect((searchInput as HTMLInputElement).value).toBe("test");
+  });
+
+  //TODO add a11y tests mentioned in #1423
+});

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,6 +1,21 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+import { vi } from "vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
 
 afterEach(() => {
   cleanup();

--- a/packages/styles/scss/components/_languagetoggle.scss
+++ b/packages/styles/scss/components/_languagetoggle.scss
@@ -14,6 +14,12 @@
       --ilo--language-toggle-color: var(--ilo-color-blue-dark);
       --ilo--language-toggle-color-hover: var(--ilo-color-white);
     }
+
+    &__dark-blue {
+      --ilo--language-toggle-color: var(--ilo-color-white);
+      --ilo--language-toggle-color-hover: var(--ilo-color-blue);
+      --ilo--language-toggle-bg-hover: var(--ilo-color-white);
+    }
   }
 
   display: inline-block;
@@ -43,7 +49,7 @@
 
     &:hover,
     &:focus,
-    &__open {
+    &[aria-expanded="true"] {
       --ilo--language-toggle-color: var(--ilo--language-toggle-color-hover);
       --ilo--language-toggle-bg: var(--ilo--language-toggle-bg-hover);
     }

--- a/packages/styles/scss/components/navigation/_nav-main.scss
+++ b/packages/styles/scss/components/navigation/_nav-main.scss
@@ -114,6 +114,11 @@
         width: px-to-rem(620px);
       }
 
+      .ilo--form-control,
+      .ilo--fieldset {
+        width: 100%;
+      }
+
       .ilo--form-control {
         padding-top: spacing(20);
         padding-bottom: spacing(22);

--- a/packages/styles/scss/components/navigation/internal/mobile/_nav-mobile.scss
+++ b/packages/styles/scss/components/navigation/internal/mobile/_nav-mobile.scss
@@ -45,7 +45,12 @@
 
     &-search-input {
       // Form control overrides can be deleted when form control hides label conditionally
+      .ilo--fieldset {
+        width: 100%;
+      }
+
       .ilo--form-control {
+        width: 100%;
         display: inline;
       }
       .ilo--form-control--label {

--- a/packages/twig/cypress/e2e/navigation/nav.cy.js
+++ b/packages/twig/cypress/e2e/navigation/nav.cy.js
@@ -230,3 +230,214 @@ describe("SubsiteNav", () => {
     });
   });
 });
+
+describe("MainNav", () => {
+  const mainNavFixtures = Object.assign({}, fixture, {
+    navtype: "main",
+    branding: {
+      tag: {
+        main: "Advancing social justice, promoting decent work",
+        sub: "ILO is a specialized agency of the United Nations",
+      },
+      logo: {
+        main: "images/logo_en_horizontal_white.svg",
+        mobile: "images/logo_en_horizontal_white.svg",
+        drawer: "images/logo_en_horizontal_blue.svg",
+        alt: "ILO Logo",
+        link: {
+          href: "https://live.ilo.org",
+          label: "ILO Live Homepage",
+        },
+      },
+    },
+  });
+
+  const mainNavUrl = `/pattern-preview?id=nav&fields=${encodeURI(
+    JSON.stringify(mainNavFixtures)
+  )}`;
+
+  beforeEach(() => {
+    cy.visit(mainNavUrl);
+    cy.get(".ilo--main-nav").as("mainNav");
+  });
+
+  describe("Initial Render", () => {
+    it("renders the main navigation with branding", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__branding").should("exist");
+        cy.get(".ilo--main-nav__branding-main__logo-img")
+          .should("exist")
+          .and("have.attr", "src", mainNavFixtures.branding.logo.main)
+          .and("have.attr", "alt", mainNavFixtures.branding.logo.alt);
+        cy.get(".ilo--main-nav__branding-tag__main").should(
+          "contain",
+          mainNavFixtures.branding.tag.main
+        );
+        cy.get(".ilo--main-nav__branding-tag__sub").should(
+          "contain",
+          mainNavFixtures.branding.tag.sub
+        );
+      });
+    });
+  });
+
+  describe("Dropdown Interactions", () => {
+    it("opens navigation dropdown when clicking more button", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+      cy.get(".ilo__nav-extra-menu").should("exist");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+    });
+
+    it("opens search dropdown when clicking search button", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+      cy.get(".ilo--main-nav__nav-search-dropdown").should("exist");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+    });
+
+    it("closes navigation dropdown when search dropdown opens", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+      cy.get(".ilo__nav-extra-menu").should("be.visible");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+
+      cy.get(".ilo__nav-extra-menu").should("not.be.visible");
+      cy.get(".ilo--main-nav__nav-search-dropdown").should("be.visible");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+    });
+
+    it("closes search dropdown when navigation dropdown opens", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+      cy.get(".ilo--main-nav__nav-search-dropdown").should("be.visible");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+
+      cy.get(".ilo--main-nav__nav-search-dropdown").should("not.be.visible");
+      cy.get(".ilo__nav-extra-menu").should("be.visible");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+    });
+
+    it("closes both dropdowns when clicking outside", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+
+      cy.get("body").click(0, 0);
+      cy.get(".ilo--nav-dropdown").should("not.be.visible");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+
+      cy.get("body").click(0, 0);
+      cy.get(".ilo--nav-dropdown").should("not.be.visible");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+    });
+
+    it("toggles navigation dropdown on multiple clicks", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--nav-menu__more").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("not.be.visible");
+      cy.get(".ilo--nav-menu__more").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+    });
+
+    it("toggles search dropdown on multiple clicks", () => {
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("be.visible");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "true"
+      );
+
+      cy.get("@mainNav").within(() => {
+        cy.get(".ilo--main-nav__nav-search").click();
+      });
+      cy.get(".ilo--nav-dropdown").should("not.be.visible");
+      cy.get(".ilo--main-nav__nav-search").should(
+        "have.attr",
+        "aria-expanded",
+        "false"
+      );
+    });
+  });
+});

--- a/packages/twig/jsconfig.json
+++ b/packages/twig/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "types": ["cypress"]
+  },
+  "include": ["cypress/**/*.js", "cypress/**/*.ts"]
+}

--- a/packages/twig/src/components/nav/desktop/navmenu.twig
+++ b/packages/twig/src/components/nav/desktop/navmenu.twig
@@ -2,8 +2,7 @@
 
 {% set prefix = prefix|default('ilo') %}
 {% set base_class = prefix ~ '--nav-menu' %}
-
-<div class="{{ base_class }} {{ className }}">
+<div class="{{ base_class }} {{ className }} {% if light|boolval %}{{ base_class }}--light{% endif %}">
   <ul class="{{ base_class }}__list">
     {% for item in menu %}
       <li class="{{ base_class }}__item {{ item.className }}">

--- a/packages/twig/src/components/nav/desktop/navmenu.twig
+++ b/packages/twig/src/components/nav/desktop/navmenu.twig
@@ -17,7 +17,7 @@
       class="{{ base_class }}__more"
       aria-expanded="false"
       aria-haspopup="menu"
-      aria-controls="{{ prefix }}--nav-dropdown"
+      aria-controls="{{ prefix }}__nav-extra-menu"
       id="{{ prefix }}--nav-dropdown__button">
       {{ more.label }}
       <span class="{{ base_class }}__more-icon"></span>

--- a/packages/twig/src/components/nav/desktop/navsearch.twig
+++ b/packages/twig/src/components/nav/desktop/navsearch.twig
@@ -1,0 +1,25 @@
+{# navsearch.twig #}
+{% set prefix = prefix|default("ilo") %}
+{% set base_class = prefix ~ "--nav-dropdown" %}
+
+<template id="{{ prefix }}--nav-search__template">
+	<div class="{{ base_class }} {{ className|default("") }}" id="{{ base_class }}" tabindex="0">
+		<div class="{{ base_class }}__container">
+			{% include '@components/form/form.twig' with {
+      attributes: {
+        action: search.url,
+        "aria-label": search.label,
+        "data-search": "true",
+      },
+      fieldsets: [{
+        fields: [{
+          type: "search",
+          placeholder: search.label,
+          id: prefix ~ '__widgets-search-input-field',
+        }]
+      }]
+    }
+    %}
+		</div>
+	</div>
+</template>

--- a/packages/twig/src/components/nav/desktop/navsearch.twig
+++ b/packages/twig/src/components/nav/desktop/navsearch.twig
@@ -6,18 +6,18 @@
 	<div class="{{ base_class }} {{ className|default("") }}" id="{{ base_class }}" tabindex="0">
 		<div class="{{ base_class }}__container">
 			{% include '@components/form/form.twig' with {
-      attributes: {
-        action: search.url,
-        "aria-label": search.label,
-        "data-search": "true",
-      },
-      fieldsets: [{
-        fields: [{
-          type: "search",
-          placeholder: search.label,
-          id: prefix ~ '__widgets-search-input-field',
+        attributes: {
+          action: search.url,
+          "aria-label": search.label,
+          "data-search": "true",
+        },
+        fieldsets: [{
+          fields: [{
+            type: "search",
+            placeholder: search.label,
+            id: prefix ~ '__widgets-search-input-field',
+          }]
         }]
-      }]
     }
     %}
 		</div>

--- a/packages/twig/src/components/nav/desktop/navsearch.twig
+++ b/packages/twig/src/components/nav/desktop/navsearch.twig
@@ -18,8 +18,7 @@
             id: prefix ~ '__widgets-search-input-field',
           }]
         }]
-    }
-    %}
+      } %}
 		</div>
 	</div>
 </template>

--- a/packages/twig/src/components/nav/mobile/mobiledrawer_main.twig
+++ b/packages/twig/src/components/nav/mobile/mobiledrawer_main.twig
@@ -9,14 +9,33 @@
 {% endblock %}
 
 {% block mobile_drawer_widgets %}
-  {% if widgets.search %}
-    <a class="{{ mobile_class }}__widgets-search" href="{{ widgets.search.url }}" aria-label="{{ widgets.search.label }}">
-      <span class="{{ mobile_class }}__widgets-search__label">
-        {{ widgets.search.label }}
-      </span>
-      <span class="{{ mobile_class }}__widgets-search__icon" />
-    </a>
-  {% endif %}
+	{# Search Widget #}
+	{% if inputSearch|boolval %}
+		<div class="{{ mobile_class }}__widgets-search-input">
+			{% include '@components/form/form.twig' with {
+      attributes: {
+        action: widgets.search.url,
+        "aria-label": widgets.search.label,
+        "data-search": "true",
+      },
+      fieldsets: [{
+        fields: [{
+          type: "search",
+          placeholder: widgets.search.label,
+          id: prefix|default("ilo") ~ '__widgets-search-input-field',
+        }]
+      }]
+    }
+    %}
+		</div>
+	{% elseif widgets.search %}
+		<a class="{{ mobile_class }}__widgets-search" href="{{ widgets.search.url }}" aria-label="{{ widgets.search.label }}">
+			<span class="{{ mobile_class }}__widgets-search__label">
+				{{ widgets.search.label }}
+			</span>
+			<span class="{{ mobile_class }}__widgets-search__icon"/>
+		</a>
+	{% endif %}
 
   {% if widgets.link %}
     <a class="{{ mobile_class }}__widgets-link" href="{{ widgets.link.href }}">{{ widgets.link.label }}</a>

--- a/packages/twig/src/components/nav/nav.component.yml
+++ b/packages/twig/src/components/nav/nav.component.yml
@@ -141,5 +141,27 @@ nav:
             link:
               href: "https://live.ilo.org"
               label: "ILO Live Homepage"
+        widgets:
+          language:
+            label: "Language"
+            language: "English"
+            links:
+              - label: "English"
+                url: "https://www.ilo.org/en"
+              - label: "Français"
+                url: "https://www.ilo.org/fr"
+              - label: "Español"
+                url: "https://www.ilo.org/es"
+              - label: "العربية"
+                url: "https://www.ilo.org/ar"
+              - label: "中文"
+                url: "https://www.ilo.org/ru"
+              - label: "Português"
+                url: "https://www.ilo.org/pt"
+              - label: "Italiano"
+                url: "https://www.ilo.org/it"
+          search:
+            label: "Search"
+            url: "https://www.ilo.org/search"
 
   visibility: storybook

--- a/packages/twig/src/components/nav/nav.component.yml
+++ b/packages/twig/src/components/nav/nav.component.yml
@@ -18,9 +18,6 @@ nav:
           link:
             href: "https://live.ilo.org"
             label: "ILO Live Homepage"
-        tag:
-          main: "Advancing social justice, promoting decent work"
-          sub: "ILO is a specialized agency of the United Nations"
     widgets:
       type: object
       label: Widgets
@@ -104,5 +101,45 @@ nav:
       options:
         compact: compact
         complex: complex
-      preview: "complex"
+        main: main
+      preview: "compact"
+
+  variants:
+    default:
+      label: Default
+    compact:
+      label: Compact
+    complex:
+      label: Complex
+      fields:
+        navtype: complex
+        branding:
+          tag:
+            main: "Advancing social justice, promoting decent work"
+            sub: "ILO is a specialized agency of the United Nations"
+          logo:
+            main: "images/ilo-live-logo-en-dark.png"
+            mobile: "images/ilo-live-logo-en-light.png"
+            drawer: "images/ilo-live-logo-en-dark.png"
+            alt: "ILO Logo"
+            link:
+              href: "https://live.ilo.org"
+              label: "ILO Live Homepage"
+    main:
+      label: Main
+      fields:
+        navtype: main
+        branding:
+          tag:
+            main: "Advancing social justice, promoting decent work"
+            sub: "ILO is a specialized agency of the United Nations"
+          logo:
+            main: "images/logo_en_horizontal_white.svg"
+            mobile: "images/logo_en_horizontal_white.svg"
+            drawer: "images/logo_en_horizontal_blue.svg"
+            alt: "ILO Logo"
+            link:
+              href: "https://live.ilo.org"
+              label: "ILO Live Homepage"
+
   visibility: storybook

--- a/packages/twig/src/components/nav/nav.js
+++ b/packages/twig/src/components/nav/nav.js
@@ -48,13 +48,13 @@ export default class Nav extends StatefulComponent {
     });
 
     // Set up a ResizeObserver to track nav element width changes
-    this.resizeObserver = new ResizeObserver(() => {
+    this.menuResizeObserver = new ResizeObserver(() => {
       if (this.state.dropDownIsOpen) {
         this.handleResize(this.dropdown);
       }
     });
 
-    this.resizeObserver = new ResizeObserver(() => {
+    this.searchResizeObserver = new ResizeObserver(() => {
       if (this.state.searchIsOpen) {
         this.handleResize(this.inputSearch);
       }
@@ -216,12 +216,14 @@ export default class Nav extends StatefulComponent {
         button: this.dropdownButton,
         stateKey: "dropDownIsOpen",
         otherStateKey: "searchIsOpen",
+        resizeObserver: this.menuResizeObserver,
       },
       search: {
         element: this.inputSearch,
         button: this.inputSearchButton,
         stateKey: "searchIsOpen",
         otherStateKey: "dropDownIsOpen",
+        resizeObserver: this.searchResizeObserver,
       },
     };
 
@@ -246,7 +248,7 @@ export default class Nav extends StatefulComponent {
     this.handleResize(config.element);
 
     // Start observing the nav element for width changes
-    this.resizeObserver.observe(this.element);
+    config.resizeObserver.observe(this.element);
 
     // Add an event listener to the window to close the dropdown when the user clicks outside of it
     window.addEventListener("click", this.handleOutsideClick);
@@ -279,7 +281,7 @@ export default class Nav extends StatefulComponent {
 
     // Only disconnect observer and remove listener if no dropdown is open
     if (!this.state.dropDownIsOpen && !this.state.searchIsOpen) {
-      this.resizeObserver.disconnect();
+      config.resizeObserver.disconnect();
       window.removeEventListener("click", this.handleOutsideClick);
     }
   };

--- a/packages/twig/src/components/nav/nav.js
+++ b/packages/twig/src/components/nav/nav.js
@@ -217,6 +217,7 @@ export default class Nav extends StatefulComponent {
         stateKey: "dropDownIsOpen",
         otherStateKey: "searchIsOpen",
         resizeObserver: this.menuResizeObserver,
+        focusTrapHandler: this.handleMenuFocusTrap,
       },
       search: {
         element: this.inputSearch,
@@ -224,6 +225,7 @@ export default class Nav extends StatefulComponent {
         stateKey: "searchIsOpen",
         otherStateKey: "dropDownIsOpen",
         resizeObserver: this.searchResizeObserver,
+        focusTrapHandler: this.handleSearchFocusTrap,
       },
     };
 
@@ -259,7 +261,7 @@ export default class Nav extends StatefulComponent {
     // Add aria-expanded="true" to the button
     config.button.setAttribute("aria-expanded", "true");
 
-    this.handleTabNavigation(config.element);
+    this.handleTabNavigation(config);
   };
 
   /**
@@ -326,7 +328,7 @@ export default class Nav extends StatefulComponent {
    *
    * @param {KeyboardEvent} event - The keyboard event object
    */
-  handleFocusTrap = (event) => {
+  handleMenuFocusTrap = (event) => {
     createFocusTrap(event, this.dropdown.querySelectorAll("a"), () => {
       this.state.dropDownIsOpen = false;
       this.dropdownButton.focus();
@@ -334,13 +336,24 @@ export default class Nav extends StatefulComponent {
   };
 
   /**
+   * Handles focus trapping within the search input.
+   * @param {KeyboardEvent} event - The keyboard event object
+   */
+  handleSearchFocusTrap = (event) => {
+    createFocusTrap(event, this.inputSearch.querySelectorAll("input"), () => {
+      this.state.searchIsOpen = false;
+      this.inputSearchButton.focus();
+    });
+  };
+
+  /**
    * Sets up keyboard navigation for the dropdown.
    * Focuses the dropdown and adds keyboard event listeners.
    */
-  handleTabNavigation = () => {
+  handleTabNavigation = (config) => {
     setTimeout(() => {
-      this.dropdown.focus();
-      this.dropdown.addEventListener("keydown", this.handleFocusTrap);
+      config.element.focus();
+      config.element.addEventListener("keydown", config.focusTrapHandler);
     }, 100);
   };
 }

--- a/packages/twig/src/components/nav/nav.js
+++ b/packages/twig/src/components/nav/nav.js
@@ -26,6 +26,7 @@ export default class Nav extends StatefulComponent {
     // Initial state
     const initialState = {
       dropDownIsOpen: false,
+      searchIsOpen: false,
       isDesktop: true,
     };
 
@@ -38,6 +39,9 @@ export default class Nav extends StatefulComponent {
     // References to elements that get rendered dynamically on the client
     this.dropdown = null;
 
+    // References to element that is rendered dynamically in `nav_main.twig`
+    this.inputSearch = null;
+
     // Set up a breakpoint observer to track viewport size changes
     this.breakpointObserver = createBreakpointObserver((breakpoint) => {
       this.state.isDesktop = ["xl", "xxl"].includes(breakpoint);
@@ -46,7 +50,13 @@ export default class Nav extends StatefulComponent {
     // Set up a ResizeObserver to track nav element width changes
     this.resizeObserver = new ResizeObserver(() => {
       if (this.state.dropDownIsOpen) {
-        this.handleResizeDropdown();
+        this.handleResize(this.dropdown);
+      }
+    });
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.state.searchIsOpen) {
+        this.handleResize(this.inputSearch);
       }
     });
 
@@ -88,15 +98,18 @@ export default class Nav extends StatefulComponent {
    * @returns {Nav} Returns the instance for method chaining
    */
   renderClientContent = () => {
-    const dropdownTemplate = this.element.querySelector(
-      `#${this.prefix}--nav-dropdown__template`
-    );
-    // Clone the template content
-    if (dropdownTemplate) {
-      const dropdownContent = dropdownTemplate.content.cloneNode(true);
+    const items = [
+      `#${this.prefix}--nav-dropdown__template`,
+      `#${this.prefix}--nav-search__template`,
+    ];
 
-      // Append template content to the body
-      document.body.appendChild(dropdownContent);
+    for (const templateSelector of items) {
+      const template = document.querySelector(templateSelector);
+
+      if (template) {
+        const content = template.content.cloneNode(true);
+        document.body.appendChild(content);
+      }
     }
 
     return this;
@@ -113,9 +126,17 @@ export default class Nav extends StatefulComponent {
       `.${this.prefix}--nav-menu__more`
     );
 
+    this.inputSearchButton = this.element.querySelector(
+      `.${this.prefix}--main-nav__nav-search`
+    );
+
     // Get a reference to the rendered dropdown (not the template)
     this.dropdown = document.body.querySelector(
-      `.${this.prefix}--nav-dropdown`
+      `.${this.prefix}__nav-extra-menu.${this.prefix}--nav-dropdown`
+    );
+
+    this.inputSearch = document.body.querySelector(
+      `.${this.prefix}--main-nav__nav-extra-search.${this.prefix}--nav-dropdown`
     );
 
     return this;
@@ -128,7 +149,15 @@ export default class Nav extends StatefulComponent {
    */
   enableHandlers = () => {
     if (this.dropdownButton) {
-      this.dropdownButton.addEventListener("click", this.handleDropdownClick);
+      this.dropdownButton.addEventListener("click", () => {
+        this.state.dropDownIsOpen = !this.state.dropDownIsOpen;
+      });
+    }
+
+    if (this.inputSearchButton) {
+      this.inputSearchButton.addEventListener("click", () => {
+        this.state.searchIsOpen = !this.state.searchIsOpen;
+      });
     }
     return this;
   };
@@ -142,9 +171,17 @@ export default class Nav extends StatefulComponent {
   registerStateHandlers = () => {
     this.registerStateHandler("dropDownIsOpen", (value) => {
       if (value) {
-        this.handleOpenDropdown();
+        this.handleOpen("dropdown");
       } else {
-        this.handleCloseDropdown();
+        this.handleClose("dropdown");
+      }
+    });
+
+    this.registerStateHandler("searchIsOpen", (value) => {
+      if (value) {
+        this.handleOpen("search");
+      } else {
+        this.handleClose("search");
       }
     });
 
@@ -162,16 +199,51 @@ export default class Nav extends StatefulComponent {
   handleBreakpointChange = (isDesktop) => {
     if (!isDesktop) {
       this.state.dropDownIsOpen = false;
+      this.state.searchIsOpen = false;
     }
   };
 
   /**
-   * Handles the opening of the dropdown menu.
-   * Sets up necessary event listeners and applies appropriate classes.
+   * Gets the configuration for a dropdown type.
+   *
+   * @param {string} type - The dropdown type ('dropdown' or 'search')
+   * @returns {Object} Configuration object for the dropdown
    */
-  handleOpenDropdown = () => {
+  getDropdownConfig = (type) => {
+    const configs = {
+      dropdown: {
+        element: this.dropdown,
+        button: this.dropdownButton,
+        stateKey: "dropDownIsOpen",
+        otherStateKey: "searchIsOpen",
+      },
+      search: {
+        element: this.inputSearch,
+        button: this.inputSearchButton,
+        stateKey: "searchIsOpen",
+        otherStateKey: "dropDownIsOpen",
+      },
+    };
+
+    return configs[type];
+  };
+
+  /**
+   * General method to handle opening any dropdown.
+   * Sets up necessary event listeners and applies appropriate classes.
+   *
+   * @param {string} type - The dropdown type ('dropdown' or 'search')
+   */
+  handleOpen = (type) => {
+    const config = this.getDropdownConfig(type);
+
+    if (!config.element || !config.button) return;
+
+    // Close the other dropdown
+    this.state[config.otherStateKey] = false;
+
     // Resize the dropdown
-    this.handleResizeDropdown();
+    this.handleResize(config.element);
 
     // Start observing the nav element for width changes
     this.resizeObserver.observe(this.element);
@@ -180,55 +252,46 @@ export default class Nav extends StatefulComponent {
     window.addEventListener("click", this.handleOutsideClick);
 
     // Add open class to the dropdown
-    this.dropdown?.classList.add(`${this.prefix}--nav-dropdown--open`);
+    config.element.classList.add(`${this.prefix}--nav-dropdown--open`);
 
-    // Add aria-expanded="true" to the dropdown button
-    this.dropdownButton.setAttribute("aria-expanded", "true");
+    // Add aria-expanded="true" to the button
+    config.button.setAttribute("aria-expanded", "true");
 
-    // Add open class to the dropdown button
-    this.dropdownButton?.classList.add(`${this.prefix}--nav-menu__more--open`);
-
-    this.handleTabNavigation();
+    this.handleTabNavigation(config.element);
   };
 
   /**
-   * Handles the closing of the dropdown menu.
+   * General method to handle closing any dropdown.
    * Removes event listeners and appropriate classes.
+   *
+   * @param {string} type - The dropdown type ('dropdown' or 'search')
    */
-  handleCloseDropdown = () => {
+  handleClose = (type) => {
+    const config = this.getDropdownConfig(type);
+
+    if (!config.element || !config.button) return;
+
     // Remove open class from the dropdown
-    this.dropdown?.classList.remove(`${this.prefix}--nav-dropdown--open`);
+    config.element.classList.remove(`${this.prefix}--nav-dropdown--open`);
 
-    // Remove open class from the dropdown button
-    this.dropdownButton?.classList.remove(
-      `${this.prefix}--nav-menu__more--open`
-    );
+    // Remove aria-expanded="true" from the button
+    config.button.setAttribute("aria-expanded", "false");
 
-    // Remove aria-expanded="true" from the dropdown button
-    this.dropdownButton.setAttribute("aria-expanded", "false");
-
-    // Stop observing the nav element
-    this.resizeObserver.disconnect();
-
-    // Remove event listener from the window
-    window.removeEventListener("click", this.handleOutsideClick);
+    // Only disconnect observer and remove listener if no dropdown is open
+    if (!this.state.dropDownIsOpen && !this.state.searchIsOpen) {
+      this.resizeObserver.disconnect();
+      window.removeEventListener("click", this.handleOutsideClick);
+    }
   };
 
   /**
-   * Adjusts the dropdown's position and size based on the parent element.
-   * Ensures the dropdown aligns properly with its parent navigation element.
+   * Resizes the given element to match the dimensions of the nav element.
+   * @param {HTMLElement} element - The element to resize
    */
-  handleResizeDropdown = () => {
-    this.dropdown.style.width = `${this.element.offsetWidth}px`;
-    this.dropdown.style.left = `${this.element.getBoundingClientRect().left}px`;
-    this.dropdown.style.top = `${this.element.getBoundingClientRect().bottom}px`;
-  };
-
-  /**
-   * Toggles the dropdown's open/closed state when the dropdown button is clicked.
-   */
-  handleDropdownClick = () => {
-    this.state.dropDownIsOpen = !this.state.dropDownIsOpen;
+  handleResize = (element) => {
+    element.style.width = `${this.element.offsetWidth}px`;
+    element.style.left = `${this.element.getBoundingClientRect().left}px`;
+    element.style.top = `${this.element.getBoundingClientRect().bottom}px`;
   };
 
   /**
@@ -244,6 +307,14 @@ export default class Nav extends StatefulComponent {
       !this.dropdown?.contains(event.target)
     ) {
       this.state.dropDownIsOpen = false;
+    }
+
+    if (
+      this.state.searchIsOpen &&
+      !this.element?.contains(event.target) &&
+      !this.inputSearch?.contains(event.target)
+    ) {
+      this.state.searchIsOpen = false;
     }
   };
 

--- a/packages/twig/src/components/nav/nav.twig
+++ b/packages/twig/src/components/nav/nav.twig
@@ -1,5 +1,7 @@
 {% if navtype == 'compact' %}
   {% include '@components/nav/nav_compact.twig' %}
-{% else %}
+{% elseif navtype == 'complex' %}
   {% include '@components/nav/nav_complex.twig' %}
+{% else %}
+  {% include '@components/nav/nav_main.twig' %}
 {% endif %}

--- a/packages/twig/src/components/nav/nav_compact.twig
+++ b/packages/twig/src/components/nav/nav_compact.twig
@@ -72,7 +72,8 @@
   {% if moreItems %}
     {% include "@components/nav/desktop/navdropdown.twig" with {
       menu: moreItems,
-      prefix: prefix
+      prefix: prefix,
+      className: prefix ~ '__nav-extra-menu'
     } only %}
   {% endif %}
 

--- a/packages/twig/src/components/nav/nav_complex.twig
+++ b/packages/twig/src/components/nav/nav_complex.twig
@@ -88,7 +88,8 @@
       {% if moreItems|length %}
         {% include "@components/nav/desktop/navdropdown.twig" with {
           menu: moreItems,
-          prefix: prefix
+          prefix: prefix,
+					className: prefix ~ '__nav-extra-menu'
         } only %}
       {% endif %}
 
@@ -136,4 +137,3 @@
     </nav>
   </div>
 </header>
-

--- a/packages/twig/src/components/nav/nav_main.twig
+++ b/packages/twig/src/components/nav/nav_main.twig
@@ -1,0 +1,139 @@
+{# navcomplex.twig #}
+
+{% set prefix = prefix|default('ilo') %}
+{% set base_class = prefix ~ '--main-nav' %}
+{% set mobile_drawer_class = prefix ~ '--nav-mobile-drawer' %}
+
+<header class="{{ base_class }}" data-loadcomponent="Nav" data-prefix="{{prefix}}">
+	<div class="{{ base_class }}-bg--dark">
+		<div class="{{ base_class }}__widgets {{ base_class }}__container">
+			<span class="{{ base_class }}__widgets-bar-corner"></span>
+			<span class="{{ base_class }}__widgets-bar">
+				{% if widgets.link %}
+					<a href="{{ widgets.link.href }}" class="{{ base_class }}__widgets-bar__link">
+						{{ widgets.link.label }}
+					</a>
+				{% endif %}
+				{% if widgets.language %}
+					{% include "@components/languagetoggle/languagetoggle.twig" with {
+            className: base_class ~ '__widgets-bar__language',
+            hideIcon: false,
+            language: widgets.language.language,
+            links: widgets.language.links,
+          } %}
+				{% endif %}
+			</span>
+		</div>
+	</div>
+
+	<div class="{{ base_class }}-bg--dark">
+		<div class="{{ base_class }}__branding {{ base_class }}__container">
+			<div class="{{ base_class }}__branding-main">
+				<div class="{{ base_class }}__branding-main__logo" role="button" tabindex="0" aria-label="Branding">
+					{% include "@components/logo/logo.twig" with {
+            src: branding.logo.main,
+            alt: branding.logo.alt,
+            link: branding.logo.link,
+            className: base_class ~ '__branding-main__logo',
+            imgClassName: base_class ~ '__branding-main__logo-img',
+            prefix: prefix
+          } %}
+				</div>
+			</div>
+			<div class="{{ base_class }}__branding-tag">
+				<h4 class="{{ base_class }}__branding-tag__main">{{ branding.tag.main }}</h4>
+				{% if branding.tag.sub %}
+					<span class="{{ base_class }}__branding-tag__sub">{{ branding.tag.sub }}</span>
+				{% endif %}
+			</div>
+		</div>
+	</div>
+
+	<div class="{{ base_class }}-bg--darker">
+		<nav class="{{ base_class }}__nav {{ base_class }}__container">
+			<div class="{{ base_class }}__nav-mobile">
+				<div class="{{ base_class }}__nav-mobile__logo" role="button" tabindex="0" aria-label="Branding">
+					{% include "@components/logo/logo.twig" with {
+            src: branding.logo.mobile,
+            alt: branding.logo.alt,
+            link: branding.logo.link,
+            className: base_class ~ '__nav-mobile__logo',
+            imgClassName: base_class ~ '__nav-mobile__logo-img',
+            prefix: prefix
+          } %}
+				</div>
+			</div>
+
+			{% if facadeItems %}
+				{% include "@components/nav/desktop/navmenu.twig" with {
+          className: base_class ~ '__nav-menu',
+          menu: facadeItems,
+          more: moreItems|length ? {
+            label: labels.more,
+          } : null,
+          prefix: prefix,
+					light: true
+        } only %}
+			{% endif %}
+
+			{% if moreItems|length %}
+				{% include "@components/nav/desktop/navdropdown.twig" with {
+          menu: moreItems,
+          prefix: prefix,
+					className: prefix ~ '__nav-extra-menu'
+        } only %}
+			{% endif %}
+
+			<button class="{{ base_class }}__nav-search" aria-label="Open search"
+			  aria-extanded="false"
+				aria-haspopup="menu"
+				aria-controls="{{ prefix }}__extra-"
+			>
+				<span class="{{ base_class }}__nav-search__icon"></span>
+			</button>
+
+			{% include "@components/nav/desktop/navsearch.twig" with {
+          prefix: prefix,
+          search: widgets.search,
+						className: base_class ~ '__nav-extra-search ' ~ prefix ~ '--main-nav__nav-search-dropdown'
+        } only %}
+
+			<button class="{{ base_class }}__nav-burger" aria-label="Toggle navigation" aria-expanded="false" aria-haspopup="menu" aria-controls="{{ prefix }}--nav-mobile-drawer__main">
+				<span class="{{ base_class }}__nav-burger__icon"></span>
+			</button>
+
+			{% include "@components/nav/mobile/mobiledrawer_main.twig" with {
+        menu: facadeItems,
+        prefix: prefix,
+        branding: branding,
+        widgets: widgets,
+        labels: labels,
+        showMoreButton: moreItems|length,
+        inputSearch: true,
+        id: "main",
+      } only %}
+
+			{% if widgets.language.links|length %}
+				{% include "@components/nav/mobile/mobiledrawer_nested.twig" with {
+        menu: widgets.language.links,
+        prefix: prefix,
+        title: labels.language,
+        menu_home: labels.home,
+          isActiveLabel: widgets.language.language,
+          id: "languages",
+        } only %}
+			{% endif %}
+
+			{% if moreItems|length %}
+				{% include "@components/nav/mobile/mobiledrawer_nested.twig" with {
+          menu: moreItems,
+          prefix: prefix,
+          title: labels.more,
+          menu_home: labels.home,
+          id: "more",
+        } only %}
+			{% endif %}
+
+		</nav>
+	</div>
+</header>

--- a/packages/twig/src/components/nav/nav_main.twig
+++ b/packages/twig/src/components/nav/nav_main.twig
@@ -9,11 +9,6 @@
 		<div class="{{ base_class }}__widgets {{ base_class }}__container">
 			<span class="{{ base_class }}__widgets-bar-corner"></span>
 			<span class="{{ base_class }}__widgets-bar">
-				{% if widgets.link %}
-					<a href="{{ widgets.link.href }}" class="{{ base_class }}__widgets-bar__link">
-						{{ widgets.link.label }}
-					</a>
-				{% endif %}
 				{% if widgets.language %}
 					{% include "@components/languagetoggle/languagetoggle.twig" with {
             className: base_class ~ '__widgets-bar__language',

--- a/packages/twig/src/components/nav/nav_main.twig
+++ b/packages/twig/src/components/nav/nav_main.twig
@@ -15,6 +15,7 @@
             hideIcon: false,
             language: widgets.language.language,
             links: widgets.language.links,
+						theme: "dark-blue"
           } %}
 				{% endif %}
 			</span>

--- a/packages/twig/stories/nav.stories.js
+++ b/packages/twig/stories/nav.stories.js
@@ -1,6 +1,7 @@
 import Navigation from "../src/components/nav/nav.twig";
 import NavigationPatterns from "../src/components/nav/nav.component.yml";
 import { Maestro } from "@ilo-org/maestro";
+console.log(NavigationPatterns);
 
 const story = Maestro.create(Navigation, NavigationPatterns);
 
@@ -10,7 +11,8 @@ const Meta = {
   ...story.meta,
 };
 
-const [Default] = story.stories;
+console.log(story.stories);
+const [Default, Compact, Complex, Main] = story.stories;
 
 export default Meta;
-export { Default };
+export { Default, Compact, Complex, Main };

--- a/packages/twig/stories/nav.stories.js
+++ b/packages/twig/stories/nav.stories.js
@@ -1,7 +1,6 @@
 import Navigation from "../src/components/nav/nav.twig";
 import NavigationPatterns from "../src/components/nav/nav.component.yml";
 import { Maestro } from "@ilo-org/maestro";
-console.log(NavigationPatterns);
 
 const story = Maestro.create(Navigation, NavigationPatterns);
 
@@ -11,7 +10,6 @@ const Meta = {
   ...story.meta,
 };
 
-console.log(story.stories);
 const [Default, Compact, Complex, Main] = story.stories;
 
 export default Meta;


### PR DESCRIPTION
# Description 

⚠️  Merge after #1647 

This PR introduces a new  main-nav component for the `twig` design system

https://github.com/user-attachments/assets/8615189b-a48e-4d8e-929d-3d14070dc098

https://github.com/user-attachments/assets/87106eff-be60-4d6f-bbe6-93cc1269a6a5

## Search

New search is implemented inside of `navsearch.twig` and JS bundle is reworked to allow use of both drop-downs, double open collision  is also handled. Search functionality is handled with the same `form` component so migration should not cause many problems, search fields also have dedicated selector to target them with ease 

## Styling

All styles are shared, only 4 lines of css is dedicated to twig to handle the form sizing 