### PR TITLE
fix(styles): video play button resize

### DIFF
--- a/.changeset/lovely-stingrays-listen.md
+++ b/.changeset/lovely-stingrays-listen.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+**Video:** Fix bug where restarting the player caused play button to resize

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -86,8 +86,9 @@
     padding-bottom: 56.25%;
   }
 
-  // Initial state
-  &--element:not(.vjs-has-started) {
+  // Initial and ended state
+  &--element:not(.vjs-has-started),
+  &--element.vjs-ended {
     .vjs-poster {
       background-size: cover;
       object-fit: cover;
@@ -121,6 +122,10 @@
 
         .vjs-play-control {
           @include videobutton("triangle_right");
+
+          &.vjs-paused {
+            @include videobutton("triangle_right");
+          }
         }
 
         .vjs-duration {
@@ -142,6 +147,10 @@
           gap: px-to-rem(4px);
           .vjs-play-control {
             @include videobutton("triangle_right", "big");
+
+            &.vjs-paused {
+              @include videobutton("triangle_right", "big");
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes a bug that caused the play button in the video component to resize when the video was restarted programmatically.