### PR TITLE
Fix SearchField prop types

### DIFF
--- a/.changeset/dull-trainers-whisper.md
+++ b/.changeset/dull-trainers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**Input:** Make `value` prop optional

--- a/.changeset/olive-beers-mix.md
+++ b/.changeset/olive-beers-mix.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**SearchField:** use `input.value` to initialize search value

--- a/packages/react/src/components/Input/Input.props.ts
+++ b/packages/react/src/components/Input/Input.props.ts
@@ -61,5 +61,8 @@ export interface InputProps {
    */
   type: TextInputTypes;
 
-  value: string;
+  /**
+   * The input's value.
+   */
+  value?: string;
 }

--- a/packages/react/src/components/SearchField/SearchField.tsx
+++ b/packages/react/src/components/SearchField/SearchField.tsx
@@ -9,8 +9,8 @@ const SearchField: FC<
   SearchFieldProps & React.RefAttributes<HTMLInputElement>
 > = forwardRef<HTMLInputElement, SearchFieldProps>(
   ({ action, callback, className, input, onInputChange }, ref) => {
-    const [searchValue, setSearchValue] = useState("");
     const { prefix } = useGlobalSettings();
+    const [searchValue, setSearchValue] = useState<string>(input?.value || "");
     const baseClass = `${prefix}--searchfield`;
     const buttonClass = `${baseClass}--button`;
     const formClass = `${baseClass}--form`;
@@ -37,7 +37,7 @@ const SearchField: FC<
 
     // Update search value on input and trigger dynamic search callback
     const onKeyPress: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-      const newValue = e.target.value;
+      const newValue = e.target?.value as string;
       setSearchValue(newValue);
       if (onInputChange) {
         onInputChange(newValue);

--- a/packages/react/src/stories/SearchField/SearchField.stories.tsx
+++ b/packages/react/src/stories/SearchField/SearchField.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import {
   Title,
   Description,
@@ -9,7 +9,6 @@ import {
 } from "@storybook/blocks";
 import { SearchField } from "../../components/SearchField";
 import { Input } from "../../components/Input";
-import { SearchFieldProps } from "../../components/SearchField/SearchField.props";
 import SearchFieldArgs from "../../components/SearchField/SearchField.args";
 
 const SearchFieldMeta: Meta<typeof SearchField> = {
@@ -23,15 +22,14 @@ const SearchFieldMeta: Meta<typeof SearchField> = {
   parameters: {
     componentSubtitle: "Component",
     docs: {
+      description: {
+        component:
+          "The SearchField component displays a single search input and a button. It fires a callback function passed to it as the callback prop onChange of the field, and another callback function onClick of the button.",
+      },
       page: () => (
         <>
           <Title />
-          <Description>
-            The SearchField component displays a single search input and a
-            button. It fires a callback function passed to it as the callback
-            prop onChange of the field, and another callback function onClick of
-            the button.
-          </Description>
+          <Description />
           <Primary />
           <Stories title="Examples"></Stories>
           <ArgTypes />
@@ -39,84 +37,59 @@ const SearchFieldMeta: Meta<typeof SearchField> = {
       ),
     },
   },
+  render: (args) => (
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <SearchField {...args} />
+    </div>
+  ),
 };
 
 export default SearchFieldMeta;
 
-/**
- * SearchField Template
- *
- * create a Storybook template for this component
- *
- *@param (Object) args - props to be passed to the component
- */
-const SearchFieldTemplate: StoryFn<SearchFieldProps> = (args) => (
-  <div style={{ width: "100%", maxWidth: "600px" }}>
-    <SearchField {...args} />
-  </div>
-);
+type Story = StoryObj<typeof SearchField>;
 
-export const SearchFieldDefault: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldDefault.args = SearchFieldArgs.searchfield;
-SearchFieldDefault.storyName = "Default";
-
-export const SearchFieldError: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldError.args = SearchFieldArgs.searchfielderror;
-SearchFieldError.storyName = "Error";
-
-export const SearchFieldDisabled: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldDisabled.args = SearchFieldArgs.searchfielddisabled;
-SearchFieldDisabled.storyName = "Disabled";
-
-export const SearchFieldLabel: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldLabel.args = SearchFieldArgs.searchfieldlabel;
-SearchFieldLabel.storyName = "Labelled";
-
-export const SearchFieldHelper: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldHelper.args = SearchFieldArgs.searchfieldhelper;
-SearchFieldHelper.storyName = "Helper";
-
-/**
- * Dynamic Search Template
- *
- * Demonstrates the onInputChange callback for real-time search functionality
- */
-const DynamicSearchTemplate: StoryFn<SearchFieldProps> = (args) => {
-  const [searchResults, setSearchResults] = useState<string>("");
-
-  const handleInputChange = (value: string) => {
-    // Simulate dynamic search - in real usage, this would trigger an API call or filter data
-    setSearchResults(value ? `Searching for: "${value}"` : "");
-  };
-
-  return (
-    <div style={{ width: "100%", maxWidth: "600px" }}>
-      <SearchField {...args} onInputChange={handleInputChange} />
-      {searchResults && (
-        <p style={{ marginTop: "1rem", color: "#666" }}>{searchResults}</p>
-      )}
-    </div>
-  );
+export const SearchFieldDefault: Story = {
+  name: "Default",
+  args: SearchFieldArgs.searchfield,
 };
 
-export const SearchFieldDynamic: StoryFn<SearchFieldProps> =
-  DynamicSearchTemplate.bind({});
+export const SearchFieldError: Story = {
+  name: "Error",
+  args: SearchFieldArgs.searchfielderror,
+};
 
-// enumerate the props for the dynamic search field
-SearchFieldDynamic.args = SearchFieldArgs.searchfielddynamic;
-SearchFieldDynamic.storyName = "Dynamic Search";
+export const SearchFieldDisabled: Story = {
+  name: "Disabled",
+  args: SearchFieldArgs.searchfielddisabled,
+};
+
+export const SearchFieldLabel: Story = {
+  name: "Labelled",
+  args: SearchFieldArgs.searchfieldlabel,
+};
+
+export const SearchFieldHelper: Story = {
+  name: "Helper",
+  args: SearchFieldArgs.searchfieldhelper,
+};
+
+export const SearchFieldDynamic: Story = {
+  name: "Dynamic Search",
+  args: SearchFieldArgs.searchfielddynamic,
+  render: (args) => {
+    const [searchResults, setSearchResults] = useState<string>("");
+
+    const handleInputChange = (value: string) => {
+      setSearchResults(value ? `Searching for: "${value}"` : "");
+    };
+
+    return (
+      <div style={{ width: "100%", maxWidth: "600px" }}>
+        <SearchField {...args} onInputChange={handleInputChange} />
+        {searchResults && (
+          <p style={{ marginTop: "1rem", color: "#666" }}>{searchResults}</p>
+        )}
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Hey @bashlk, for you to review please. You're right that `<SearchField />` wasn't doing anything with `input.value` so I've now used it to initialize the `searchValue` state. 

However, I also made the `value` prop on `InputProps` optional. 

I'm not sure what you meant by the `callback` prop, that gets called on submit and it works. Use `onInputChange` if you want the callback to fire `onKeyPress`

Fixes #1795 