### PR TITLE
React: rationalize SearchField props

### DIFF
--- a/.changeset/thirty-rings-trade.md
+++ b/.changeset/thirty-rings-trade.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**SearchField:** Rationalize props while conserving backwards compatibility for `input` prop, which will be deprecated in the next major release.

--- a/packages/react/src/components/SearchField/SearchField.args.ts
+++ b/packages/react/src/components/SearchField/SearchField.args.ts
@@ -5,7 +5,6 @@ const searchfield: SearchFieldProps = {
   disabled: false,
   name: "search",
   placeholder: "Search Field",
-  value: "",
 };
 
 const searchfielderror: SearchFieldProps = {
@@ -15,7 +14,6 @@ const searchfielderror: SearchFieldProps = {
   errorMessage: "Error message",
   name: "search",
   placeholder: "Search Field",
-  value: "",
 };
 
 const searchfielddisabled: SearchFieldProps = {
@@ -23,7 +21,6 @@ const searchfielddisabled: SearchFieldProps = {
   disabled: true,
   name: "search",
   placeholder: "Search Field",
-  value: "",
 };
 
 const searchfieldlabel: SearchFieldProps = {
@@ -31,7 +28,6 @@ const searchfieldlabel: SearchFieldProps = {
   label: "Search Field",
   name: "search",
   placeholder: "Search Field",
-  value: "",
 };
 
 const searchfieldhelper: SearchFieldProps = {
@@ -39,7 +35,6 @@ const searchfieldhelper: SearchFieldProps = {
   helper: "Search Field Helper text",
   name: "search",
   placeholder: "Search Field",
-  value: "",
 };
 
 const searchfielddynamic: SearchFieldProps = {
@@ -49,7 +44,6 @@ const searchfielddynamic: SearchFieldProps = {
   },
   name: "search",
   placeholder: "Type to search dynamically...",
-  value: "",
 };
 
 /**

--- a/packages/react/src/components/SearchField/SearchField.args.ts
+++ b/packages/react/src/components/SearchField/SearchField.args.ts
@@ -2,61 +2,44 @@ import { SearchFieldProps } from "./SearchField.props";
 
 const searchfield: SearchFieldProps = {
   callback: () => {},
-  input: {
-    callback: () => {},
-    disabled: false,
-    name: "search",
-    placeholder: "Search Field",
-    type: "search",
-    value: "",
-  },
+  disabled: false,
+  name: "search",
+  placeholder: "Search Field",
+  value: "",
 };
 
 const searchfielderror: SearchFieldProps = {
   callback: () => {},
-  input: {
-    callback: () => {},
-    disabled: false,
-    error: "Error message",
-    name: "search",
-    placeholder: "Search Field",
-    type: "search",
-    value: "",
-  },
+  disabled: false,
+  error: true,
+  errorMessage: "Error message",
+  name: "search",
+  placeholder: "Search Field",
+  value: "",
 };
 
 const searchfielddisabled: SearchFieldProps = {
   callback: () => {},
-  input: {
-    callback: () => {},
-    disabled: true,
-    name: "search",
-    placeholder: "Search Field",
-    type: "search",
-    value: "",
-  },
+  disabled: true,
+  name: "search",
+  placeholder: "Search Field",
+  value: "",
 };
 
 const searchfieldlabel: SearchFieldProps = {
   callback: () => {},
-  input: {
-    label: "Search Field",
-    name: "search",
-    placeholder: "Search Field",
-    type: "search",
-    value: "",
-  },
+  label: "Search Field",
+  name: "search",
+  placeholder: "Search Field",
+  value: "",
 };
 
 const searchfieldhelper: SearchFieldProps = {
   callback: () => {},
-  input: {
-    helper: "Search Field Helper text",
-    name: "search",
-    placeholder: "Search Field",
-    type: "search",
-    value: "",
-  },
+  helper: "Search Field Helper text",
+  name: "search",
+  placeholder: "Search Field",
+  value: "",
 };
 
 const searchfielddynamic: SearchFieldProps = {
@@ -64,12 +47,9 @@ const searchfielddynamic: SearchFieldProps = {
   onInputChange: (value: string) => {
     console.log("Dynamic search triggered:", value);
   },
-  input: {
-    name: "search",
-    placeholder: "Type to search dynamically...",
-    type: "search",
-    value: "",
-  },
+  name: "search",
+  placeholder: "Type to search dynamically...",
+  value: "",
 };
 
 /**

--- a/packages/react/src/components/SearchField/SearchField.props.ts
+++ b/packages/react/src/components/SearchField/SearchField.props.ts
@@ -16,7 +16,6 @@ export interface SearchFieldInputProps {
   label?: string;
   name?: string;
   placeholder?: string;
-  value: string;
 }
 
 export interface SearchFieldProps
@@ -35,11 +34,6 @@ export interface SearchFieldProps
    * The search field submit button's click function.
    */
   callback?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => unknown;
-
-  /**
-   * Initial value of the search input
-   */
-  value?: string;
 
   /**
    * Placeholder text for the search input

--- a/packages/react/src/components/SearchField/SearchField.props.ts
+++ b/packages/react/src/components/SearchField/SearchField.props.ts
@@ -1,22 +1,35 @@
-import { InputProps } from "../Input/Input.props";
+import { FormControlPublicProps } from "../FormControl/FormControl.props";
 
-export interface ButtonProps {
+/**
+ * @deprecated Pass these properties at the top level of `SearchFieldProps`
+ * instead. This shape will be removed in a future major release.
+ */
+export interface SearchFieldInputProps {
+  disabled?: boolean;
   /**
-   * The button's label.
+   * @deprecated Use the top-level `error` (boolean) together with
+   * `errorMessage` (string) instead.
    */
-  label: Required<string>;
+  error?: string | false;
+  helper?: string | false;
+  id?: string;
+  label?: string;
+  name?: string;
+  placeholder?: string;
+  value: string;
 }
 
-export interface SearchFieldProps {
+export interface SearchFieldProps
+  extends Omit<FormControlPublicProps, "label"> {
+  /**
+   * The FormControl's label. Optional on SearchField.
+   */
+  label?: string;
+
   /**
    * Specify the action attribute for the search form
    */
   action?: string;
-
-  /**
-   * Specify the properties of the submit button
-   */
-  button?: Required<ButtonProps>;
 
   /**
    * The search field submit button's click function.
@@ -24,14 +37,32 @@ export interface SearchFieldProps {
   callback?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => unknown;
 
   /**
-   * Specify an optional className to be added to your Button.
+   * Initial value of the search input
    */
-  className?: string;
+  value?: string;
 
   /**
-   * Specify the properties of the search field input
+   * Placeholder text for the search input
    */
-  input?: InputProps;
+  placeholder?: string;
+
+  /**
+   * Name attribute for the search input
+   */
+  name?: string;
+
+  /**
+   * Id attribute for the search input. Defaults to an auto-generated id.
+   */
+  id?: string;
+
+  /**
+   * @deprecated Pass `value`, `placeholder`, `label`, `name`, `id`, `helper`,
+   * `disabled`, `error`, and `errorMessage` at the top level of
+   * `SearchFieldProps` instead. This prop will be removed in a future
+   * major release.
+   */
+  input?: SearchFieldInputProps;
 
   /**
    * Callback function triggered on input change for dynamic search.

--- a/packages/react/src/components/SearchField/SearchField.tsx
+++ b/packages/react/src/components/SearchField/SearchField.tsx
@@ -29,7 +29,6 @@ const SearchField: FC<
       labelSize,
       tooltip,
       theme,
-      value,
       placeholder,
       name,
       id,
@@ -38,7 +37,6 @@ const SearchField: FC<
   ) => {
     // Top-level props win; fall back to the deprecated `input` prop so
     // existing consumers keep working unchanged.
-    const resolvedValue = value ?? input?.value ?? "";
     const resolvedPlaceholder = placeholder ?? input?.placeholder;
     const resolvedName = name ?? input?.name;
     const resolvedLabel = label ?? input?.label ?? "";
@@ -51,7 +49,7 @@ const SearchField: FC<
     // preserve the prior behavior of `input.disabled` (input/button only).
     const inputDisabled = disabled ?? input?.disabled;
 
-    const [searchValue, setSearchValue] = useState<string>(resolvedValue);
+    const [searchValue, setSearchValue] = useState<string>("");
     const { prefix } = useGlobalSettings();
     const baseClass = `${prefix}--searchfield`;
     const buttonClass = `${baseClass}--button`;

--- a/packages/react/src/components/SearchField/SearchField.tsx
+++ b/packages/react/src/components/SearchField/SearchField.tsx
@@ -5,11 +5,53 @@ import { SearchFieldProps } from "./SearchField.props";
 import { Icon } from "../Icon";
 import { FormControl } from "../FormControl";
 
+// @TODO Remove the deprecated `input` prop (and SearchFieldInputProps) in
+// the next major release. Until then, the merge logic below preserves
+// backward compatibility for consumers still passing `input={{ ... }}`.
+
 const SearchField: FC<
   SearchFieldProps & React.RefAttributes<HTMLInputElement>
 > = forwardRef<HTMLInputElement, SearchFieldProps>(
-  ({ action, callback, className, input, onInputChange }, ref) => {
-    const [searchValue, setSearchValue] = useState("");
+  (
+    {
+      action,
+      callback,
+      className,
+      input,
+      onInputChange,
+      label,
+      helper,
+      error,
+      errorMessage,
+      disabled,
+      style,
+      labelPlacement,
+      labelSize,
+      tooltip,
+      theme,
+      value,
+      placeholder,
+      name,
+      id,
+    },
+    ref
+  ) => {
+    // Top-level props win; fall back to the deprecated `input` prop so
+    // existing consumers keep working unchanged.
+    const resolvedValue = value ?? input?.value ?? "";
+    const resolvedPlaceholder = placeholder ?? input?.placeholder;
+    const resolvedName = name ?? input?.name;
+    const resolvedLabel = label ?? input?.label ?? "";
+    const resolvedHelper = helper ?? (input?.helper || undefined);
+    const legacyErrorMessage =
+      typeof input?.error === "string" ? input.error : undefined;
+    const resolvedError = error ?? !!input?.error;
+    const resolvedErrorMessage = errorMessage ?? legacyErrorMessage;
+    // Only forward `disabled` to FormControl when set at the top level, to
+    // preserve the prior behavior of `input.disabled` (input/button only).
+    const inputDisabled = disabled ?? input?.disabled;
+
+    const [searchValue, setSearchValue] = useState<string>(resolvedValue);
     const { prefix } = useGlobalSettings();
     const baseClass = `${prefix}--searchfield`;
     const buttonClass = `${baseClass}--button`;
@@ -18,7 +60,7 @@ const SearchField: FC<
       searchValue.trim() !== "" && "show"
     }`;
     const rId = useId();
-    const fieldId = input?.id || rId;
+    const fieldId = id ?? input?.id ?? rId;
 
     const fieldSetClass = `${prefix}--fieldset`;
 
@@ -37,39 +79,39 @@ const SearchField: FC<
 
     // Update search value on input and trigger dynamic search callback
     const onKeyPress: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-      const newValue = e.target.value;
+      const newValue = e.target?.value as string;
       setSearchValue(newValue);
       if (onInputChange) {
         onInputChange(newValue);
       }
     };
 
-    const inputHasType = !!input?.type;
-
-    if (!inputHasType) {
-      throw new Error("SearchField: Input must have type prop");
-    }
-
-    return inputHasType ? (
+    return (
       <form action={action} className={formClass} style={{ display: "flex" }}>
         <FormControl
           fieldId={fieldId}
-          error={!!input?.error}
-          helper={input?.helper || ""}
-          label={input?.label || ""}
-          style={{ width: "100%" }}
+          error={resolvedError}
+          errorMessage={resolvedErrorMessage}
+          helper={resolvedHelper}
+          label={resolvedLabel}
+          disabled={disabled}
+          labelPlacement={labelPlacement}
+          labelSize={labelSize}
+          tooltip={tooltip}
+          theme={theme}
+          style={{ width: "100%", ...style }}
         >
           <div className={classNames(className, baseClass)}>
             <div className={fieldSetClass}>
               <input
-                className={`${prefix}--text-input`}
+                className={`${prefix}--input`}
                 id={fieldId}
-                name={input.name}
+                name={resolvedName}
                 onChange={onKeyPress}
-                placeholder={input?.placeholder}
+                placeholder={resolvedPlaceholder}
                 value={searchValue}
                 ref={ref}
-                disabled={input?.disabled}
+                disabled={inputDisabled}
                 type="search"
               />
               <span
@@ -82,14 +124,14 @@ const SearchField: FC<
             </div>
             <button
               className={buttonClass}
-              disabled={input?.disabled}
+              disabled={inputDisabled}
               type="submit"
               onClick={handleClick}
             />
           </div>
         </FormControl>
       </form>
-    ) : null;
+    );
   }
 );
 

--- a/packages/react/src/stories/SearchField/SearchField.stories.tsx
+++ b/packages/react/src/stories/SearchField/SearchField.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import {
   Title,
   Description,
@@ -8,8 +8,6 @@ import {
   Stories,
 } from "@storybook/blocks";
 import { SearchField } from "../../components/SearchField";
-import { Input } from "../../components/Input";
-import { SearchFieldProps } from "../../components/SearchField/SearchField.props";
 import SearchFieldArgs from "../../components/SearchField/SearchField.args";
 
 const SearchFieldMeta: Meta<typeof SearchField> = {
@@ -17,21 +15,17 @@ const SearchFieldMeta: Meta<typeof SearchField> = {
   component: SearchField,
   tags: ["autodocs"],
   argTypes: {},
-  subcomponents: {
-    Input,
-  },
   parameters: {
     componentSubtitle: "Component",
     docs: {
+      description: {
+        component:
+          "The SearchField component displays a single search input and a button. It fires a callback function passed to it as the callback prop onChange of the field, and another callback function onClick of the button.",
+      },
       page: () => (
         <>
           <Title />
-          <Description>
-            The SearchField component displays a single search input and a
-            button. It fires a callback function passed to it as the callback
-            prop onChange of the field, and another callback function onClick of
-            the button.
-          </Description>
+          <Description />
           <Primary />
           <Stories title="Examples"></Stories>
           <ArgTypes />
@@ -43,80 +37,70 @@ const SearchFieldMeta: Meta<typeof SearchField> = {
 
 export default SearchFieldMeta;
 
-/**
- * SearchField Template
- *
- * create a Storybook template for this component
- *
- *@param (Object) args - props to be passed to the component
- */
-const SearchFieldTemplate: StoryFn<SearchFieldProps> = (args) => (
-  <div style={{ width: "100%", maxWidth: "600px" }}>
-    <SearchField {...args} />
-  </div>
-);
+type Story = StoryObj<typeof SearchField>;
 
-export const SearchFieldDefault: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldDefault.args = SearchFieldArgs.searchfield;
-SearchFieldDefault.storyName = "Default";
-
-export const SearchFieldError: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldError.args = SearchFieldArgs.searchfielderror;
-SearchFieldError.storyName = "Error";
-
-export const SearchFieldDisabled: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldDisabled.args = SearchFieldArgs.searchfielddisabled;
-SearchFieldDisabled.storyName = "Disabled";
-
-export const SearchFieldLabel: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldLabel.args = SearchFieldArgs.searchfieldlabel;
-SearchFieldLabel.storyName = "Labelled";
-
-export const SearchFieldHelper: StoryFn<SearchFieldProps> =
-  SearchFieldTemplate.bind({});
-
-// enumerate the props for the default search field
-SearchFieldHelper.args = SearchFieldArgs.searchfieldhelper;
-SearchFieldHelper.storyName = "Helper";
-
-/**
- * Dynamic Search Template
- *
- * Demonstrates the onInputChange callback for real-time search functionality
- */
-const DynamicSearchTemplate: StoryFn<SearchFieldProps> = (args) => {
-  const [searchResults, setSearchResults] = useState<string>("");
-
-  const handleInputChange = (value: string) => {
-    // Simulate dynamic search - in real usage, this would trigger an API call or filter data
-    setSearchResults(value ? `Searching for: "${value}"` : "");
-  };
-
-  return (
+export const Default: Story = {
+  args: SearchFieldArgs.searchfield,
+  render: (args) => (
     <div style={{ width: "100%", maxWidth: "600px" }}>
-      <SearchField {...args} onInputChange={handleInputChange} />
-      {searchResults && (
-        <p style={{ marginTop: "1rem", color: "#666" }}>{searchResults}</p>
-      )}
+      <SearchField {...args} />
     </div>
-  );
+  ),
 };
 
-export const SearchFieldDynamic: StoryFn<SearchFieldProps> =
-  DynamicSearchTemplate.bind({});
+export const Error: Story = {
+  args: SearchFieldArgs.searchfielderror,
+  render: (args) => (
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <SearchField {...args} />
+    </div>
+  ),
+};
 
-// enumerate the props for the dynamic search field
-SearchFieldDynamic.args = SearchFieldArgs.searchfielddynamic;
-SearchFieldDynamic.storyName = "Dynamic Search";
+export const Disabled: Story = {
+  args: SearchFieldArgs.searchfielddisabled,
+  render: (args) => (
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <SearchField {...args} />
+    </div>
+  ),
+};
+
+export const Labelled: Story = {
+  args: SearchFieldArgs.searchfieldlabel,
+  render: (args) => (
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <SearchField {...args} />
+    </div>
+  ),
+};
+
+export const Helper: Story = {
+  args: SearchFieldArgs.searchfieldhelper,
+  render: (args) => (
+    <div style={{ width: "100%", maxWidth: "600px" }}>
+      <SearchField {...args} />
+    </div>
+  ),
+};
+
+export const DynamicSearch: Story = {
+  name: "Dynamic Search",
+  args: SearchFieldArgs.searchfielddynamic,
+  render: (args) => {
+    const [searchResults, setSearchResults] = useState<string>("");
+
+    const handleInputChange = (value: string) => {
+      setSearchResults(value ? `Searching for: "${value}"` : "");
+    };
+
+    return (
+      <div style={{ width: "100%", maxWidth: "600px" }}>
+        <SearchField {...args} onInputChange={handleInputChange} />
+        {searchResults && (
+          <p style={{ marginTop: "1rem", color: "#666" }}>{searchResults}</p>
+        )}
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
This rationalizes the props and propTypes for `<SearchField />` while conserving backwards compatibility for consumers who are still using the old props. 

Fixes #1795 