### PR TITLE
fix(react): AudioPlayer pause icon not rendering on play

### DIFF
--- a/.changeset/twenty-cows-battle.md
+++ b/.changeset/twenty-cows-battle.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/react": patch
+---
+
+**AudioPlayer:** Fix pause button not showing on play

--- a/packages/react/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/packages/react/src/components/AudioPlayer/AudioPlayer.tsx
@@ -257,7 +257,12 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
           >
             <Icon
               className={`${baseClass}--play-icon`}
-              name={state.playing ? "Pause" : "TriangleRight"}
+              name="TriangleRight"
+              size={32}
+            />
+            <Icon
+              className={`${baseClass}--pause-icon`}
+              name="Pause"
               size={32}
             />
           </button>
@@ -284,7 +289,8 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
             aria-label={state.volume === 0 ? "Unmute" : "Mute"}
             onClick={handleVolumeClick}
           >
-            <Icon name={state.volume === 0 ? "SoundOff" : "SoundOn"} />
+            <Icon className={`${baseClass}--sound-on-icon`} name="SoundOn" />
+            <Icon className={`${baseClass}--sound-off-icon`} name="SoundOff" />
           </button>
           <input
             type="range"

--- a/packages/react/tests/AudioPlayer.test.tsx
+++ b/packages/react/tests/AudioPlayer.test.tsx
@@ -102,6 +102,26 @@ describe("AudioPlayer", () => {
     expect(audio._mock.pause).toHaveBeenCalled();
   });
 
+  it("should render both play and pause icons so CSS can toggle them via aria-label", async () => {
+    render(<AudioPlayer {...sampleProps} />);
+    const playButton = screen.getByRole("button", { name: "Play" });
+
+    // Both icons must be in the DOM at all times — the SCSS swaps visibility
+    // based on the button's aria-label.
+    expect(playButton).toContainElement(
+      screen.getByTestId("triangleright-icon")
+    );
+    expect(playButton).toContainElement(screen.getByTestId("pause-icon"));
+
+    await userEvent.click(playButton);
+
+    const pausedButton = screen.getByRole("button", { name: "Pause" });
+    expect(pausedButton).toContainElement(
+      screen.getByTestId("triangleright-icon")
+    );
+    expect(pausedButton).toContainElement(screen.getByTestId("pause-icon"));
+  });
+
   it("should skip forward and backward correctly", async () => {
     render(<AudioPlayer {...sampleProps} />);
     const audio = document.getElementsByTagName("audio")[0];


### PR DESCRIPTION
Render both play and pause icons in the play button (and both sound icons in the volume button) so the SCSS aria-label rules can toggle visibility, matching the Twig implementation.