### PR TITLE
fix(styles): improve dropdown focus styles

### DIFF
--- a/.changeset/pretty-rules-invite.md
+++ b/.changeset/pretty-rules-invite.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": minor
+---
+
+Dropdowns: Update styles to separate enabled and disabled components

--- a/.changeset/pretty-rules-invite.md
+++ b/.changeset/pretty-rules-invite.md
@@ -1,5 +1,0 @@
----
-"@ilo-org/styles": minor
----
-
-Dropdowns: Update styles to separate enabled and disabled components

--- a/.changeset/yellow-dancers-impress.md
+++ b/.changeset/yellow-dancers-impress.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Dropdown: Prevented focus styling being applied on hover for disabled dropdowns

--- a/packages/styles/scss/components/_dropdown.scss
+++ b/packages/styles/scss/components/_dropdown.scss
@@ -35,7 +35,7 @@
       @include globaltransition("background-color");
     }
 
-    &:has(select:hover):before {
+    &:has(select:enabled:hover):before {
       background-color: var(--ilo-dropdown-background-color-active);
     }
 
@@ -58,6 +58,7 @@
   color: var(--ilo-dropdown-color);
   width: 100%;
   margin: spacing(0);
+
   padding: 0 spacing(14) 0 spacing(4);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -68,13 +69,15 @@
   @include typography("body-medium");
   @include globaltransition("background-color, border-color, color");
 
-  &:hover,
-  &:focus,
-  &:active {
+  &:enabled:is(:hover, :focus, :active) {
     border-inline-start-color: var(--ilo-color-blue);
     box-shadow: inset px-to-rem(1px) 0 0 0 var(--ilo-color-blue);
     background-color: var(--ilo-dropdown-background-color-active);
     --ilo-dropdown-color: var(--ilo-color-gray-charcoal);
+  }
+
+  &:disabled {
+    pointer-events: none;
   }
 
   [dir="rtl"] &:hover,

--- a/packages/styles/scss/components/_dropdown.scss
+++ b/packages/styles/scss/components/_dropdown.scss
@@ -49,6 +49,15 @@
       top: var(--ilo-dropdown-button-icon-offset);
       @include icon("chevron_down", var(--ilo-dropdown-button-icon-color));
     }
+
+    &:has(select:disabled) {
+      --ilo-dropdown-button-icon-color: var(--ilo-dropdown-color);
+
+      &:before,
+      &:after {
+        opacity: 0.45;
+      }
+    }
   }
 
   appearance: none;
@@ -78,6 +87,7 @@
 
   &:disabled {
     pointer-events: none;
+    opacity: 0.45;
   }
 
   [dir="rtl"] &:hover,

--- a/packages/styles/scss/components/_dropdown.scss
+++ b/packages/styles/scss/components/_dropdown.scss
@@ -53,9 +53,22 @@
     &:has(select:disabled) {
       --ilo-dropdown-button-icon-color: var(--ilo-dropdown-color);
 
-      &:before,
       &:after {
         opacity: 0.45;
+      }
+
+      // manually adjusted the left border color to be slightly darker
+      &:before {
+        border-color: color-mix(
+          in srgb,
+          var(--ilo-dropdown-border-color) 45%,
+          transparent
+        );
+        border-inline-start-color: color-mix(
+          in srgb,
+          var(--ilo-dropdown-border-color) 60%,
+          transparent
+        );
       }
     }
   }


### PR DESCRIPTION
Fixes #1806

Dev tested on Firefox v151.x and Chrome v148.x

[dark-mode.webm](https://github.com/user-attachments/assets/51b41801-f781-495c-a5b8-c0accb24d9eb)