### PR TITLE
fix(styles): update focus handling in buttons

### DIFF
--- a/.changeset/red-pillows-enjoy.md
+++ b/.changeset/red-pillows-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Buttons: Update focus handling to remove persistent focus state

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -125,13 +125,6 @@
       color: var(--ilo-button-labels-hover-color);
     }
 
-    &:focus {
-      background-color: var(--ilo-color-background-focus);
-      border: var(--ilo-border-md) var(--ilo-color-borders-focus) solid;
-      color: var(--ilo-button-labels-focus-color);
-      outline: none;
-    }
-
     &:active {
       background-color: var(--ilo-color-background-active);
       border: var(--ilo-border-md) var(--ilo-color-borders-active) solid;
@@ -141,20 +134,23 @@
   }
 
   &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
     background-color: var(--ilo-color-background-focus);
     border: var(--ilo-border-md) var(--ilo-color-borders-focus) solid;
     box-shadow:
       4px 4px 0 1px var(--ilo-color-borders-focus) inset,
       -4px -4px 0 1px var(--ilo-color-borders-focus) inset;
     color: var(--ilo-button-labels-focus-color);
-    outline: none;
     @include globaltransition("color, background-color, border-color");
+  }
 
-    &.#{$prefix}--small {
-      box-shadow:
-        3px 3px 0 1px var(--ilo-color-borders-focus) inset,
-        -3px -3px 0 1px var(--ilo-color-borders-focus) inset;
-    }
+  &__small:focus-visible {
+    box-shadow:
+      3px 3px 0 1px var(--ilo-color-borders-focus) inset,
+      -3px -3px 0 1px var(--ilo-color-borders-focus) inset;
   }
 
   &:hover {

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -145,12 +145,12 @@
       -4px -4px 0 1px var(--ilo-color-borders-focus) inset;
     color: var(--ilo-button-labels-focus-color);
     @include globaltransition("color, background-color, border-color");
-  }
 
-  &__small:focus-visible {
-    box-shadow:
-      3px 3px 0 1px var(--ilo-color-borders-focus) inset,
-      -3px -3px 0 1px var(--ilo-color-borders-focus) inset;
+    &.#{$prefix}--small {
+      box-shadow:
+        3px 3px 0 1px var(--ilo-color-borders-focus) inset,
+        -3px -3px 0 1px var(--ilo-color-borders-focus) inset;
+    }
   }
 
   &:hover {


### PR DESCRIPTION
Fixes #1800

@bashlk as you suspected focus did persist because of the `:focus` selector. Refactored to use `:focus-visible` instead.

[button_focus.webm](https://github.com/user-attachments/assets/78891666-afc9-449f-8836-abc2efbee7b9)
