### PR TITLE
feat(react): implement closed captions

### DIFF
--- a/.changeset/odd-scissors-work.md
+++ b/.changeset/odd-scissors-work.md
@@ -1,6 +1,6 @@
 ---
-"@ilo-org/react": patch
-"@ilo-org/styles": patch
+"@ilo-org/react": minor
+"@ilo-org/styles": minor
 ---
 
 Video: Video player now supports closed captioning

--- a/.changeset/odd-scissors-work.md
+++ b/.changeset/odd-scissors-work.md
@@ -1,0 +1,6 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/styles": patch
+---
+
+Video: Video player now supports closed captioning

--- a/packages/react/public/video-example.en.vtt
+++ b/packages/react/public/video-example.en.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:03.000
+Welcome to this sample video.
+
+00:00:03.000 --> 00:00:07.000
+This is a dummy English caption track.
+
+00:00:07.000 --> 00:00:11.000
+Use the CC button to switch languages.

--- a/packages/react/public/video-example.es.vtt
+++ b/packages/react/public/video-example.es.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:03.000
+Bienvenido a este video de ejemplo.
+
+00:00:03.000 --> 00:00:07.000
+Esta es una pista de subtitulos de prueba en espanol.
+
+00:00:07.000 --> 00:00:11.000
+Usa el boton CC para cambiar de idioma.

--- a/packages/react/src/components/Video/Video.args.ts
+++ b/packages/react/src/components/Video/Video.args.ts
@@ -31,8 +31,8 @@ const videofileWithCaptions: VideoProps = {
     play: "Play",
     pause: "Pause",
     volume: "Volume",
-    chooseSubtitles: "Choose subtitles",
-    none: "None",
+    chooseSubtitlesText: "Choose subtitles",
+    noCaptionsText: "None",
   },
   tracks: [
     {

--- a/packages/react/src/components/Video/Video.args.ts
+++ b/packages/react/src/components/Video/Video.args.ts
@@ -14,21 +14,41 @@ const videofile: VideoProps = {
     pause: "Pause",
     volume: "Volume",
   },
-  // tracks: [
-  //   {
-  //     src: "/video-example.en.vtt",
-  //     srclang: "en",
-  //     label: "English",
-  //     kind: "captions",
-  //     default: true,
-  //   },
-  //   {
-  //     src: "/video-example.es.vtt",
-  //     srclang: "es",
-  //     label: "Spanish",
-  //     kind: "captions",
-  //   },
-  // ],
+  src: "/video-example.mp4",
+  youtube: false,
+};
+
+const videofileWithCaptions: VideoProps = {
+  className: "image",
+  caption:
+    "The ILO brings together governments, employers and workers to set labour standards and promote decent work.",
+  poster: {
+    src: "/media-file-poster.jpg",
+    alt: "The ILO logo on a blue background",
+  },
+  controls: {
+    fullscreen: "Fullscreen",
+    play: "Play",
+    pause: "Pause",
+    volume: "Volume",
+    chooseSubtitles: "Choose subtitles",
+    none: "None",
+  },
+  tracks: [
+    {
+      src: "/video-example.en.vtt",
+      srclang: "en",
+      label: "English",
+      kind: "captions",
+      default: true,
+    },
+    {
+      src: "/video-example.es.vtt",
+      srclang: "es",
+      label: "Spanish",
+      kind: "captions",
+    },
+  ],
   src: "/video-example.mp4",
   youtube: false,
 };
@@ -56,6 +76,7 @@ const videoyt: VideoProps = {
  */
 const videoArgs = {
   videofile,
+  videofileWithCaptions,
   videoyt,
 };
 

--- a/packages/react/src/components/Video/Video.args.ts
+++ b/packages/react/src/components/Video/Video.args.ts
@@ -14,6 +14,21 @@ const videofile: VideoProps = {
     pause: "Pause",
     volume: "Volume",
   },
+  // tracks: [
+  //   {
+  //     src: "/video-example.en.vtt",
+  //     srclang: "en",
+  //     label: "English",
+  //     kind: "captions",
+  //     default: true,
+  //   },
+  //   {
+  //     src: "/video-example.es.vtt",
+  //     srclang: "es",
+  //     label: "Spanish",
+  //     kind: "captions",
+  //   },
+  // ],
   src: "/video-example.mp4",
   youtube: false,
 };

--- a/packages/react/src/components/Video/Video.props.ts
+++ b/packages/react/src/components/Video/Video.props.ts
@@ -1,4 +1,4 @@
-import { VideoPlayerControls } from "./VideoPlayer.props";
+import { VideoPlayerControls, VideoTextTrack } from "./VideoPlayer.props";
 
 export interface Poster {
   src: string;
@@ -32,4 +32,7 @@ export interface VideoProps {
    * Specify the image src for the image
    */
   poster?: Poster;
+
+  // Optional closed-caption tracks
+  tracks?: VideoTextTrack[];
 }

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -10,13 +10,9 @@ const Video = forwardRef<VideoPlayerRef, VideoProps>(
     const { prefix } = useGlobalSettings();
     const baseClass = `${prefix}--video`;
 
-    const videoClasses = classNames(className, {
-      [baseClass]: true,
-    });
+    const videoClasses = classNames(className, [baseClass]);
 
-    const captionClasses = classNames("", {
-      [`${baseClass}--caption`]: true,
-    });
+    const captionClasses = `${baseClass}--caption`;
 
     return (
       <figure className={videoClasses}>

--- a/packages/react/src/components/Video/VideoPlayer.props.ts
+++ b/packages/react/src/components/Video/VideoPlayer.props.ts
@@ -4,6 +4,34 @@ import videojs from "video.js";
 export interface VideoPlayerRef {
   player: videojs.Player | undefined;
 }
+
+export interface VideoTextTrack {
+  /**
+   * Source URL for a WebVTT track file.
+   */
+  src: string;
+
+  /**
+   * Track language code (for example "en" or "fr").
+   */
+  srclang: string;
+
+  /**
+   * Human readable language label shown in the CC menu.
+   */
+  label: string;
+
+  /**
+   * Track type rendered by Video.js.
+   */
+  kind?: "captions" | "subtitles";
+
+  /**
+   * Whether this track is selected by default.
+   */
+  default?: boolean;
+}
+
 export interface VideoPlayerControls {
   /**
    * Specify the label for the fullscreen button
@@ -48,4 +76,7 @@ export interface VideoPlayerProps {
    * if YouTube, set to true
    */
   youtube?: boolean;
+
+  // Optional closed-captions tracks
+  tracks?: VideoTextTrack[];
 }

--- a/packages/react/src/components/Video/VideoPlayer.props.ts
+++ b/packages/react/src/components/Video/VideoPlayer.props.ts
@@ -37,12 +37,12 @@ export interface VideoPlayerControls {
   /**
    * Specify the heading shown in the subtitles menu
    */
-  chooseSubtitles?: string;
+  chooseSubtitlesText?: string;
 
   /**
    * Specify the label for the option that turns subtitles off
    */
-  none?: string;
+  noCaptionsText?: string;
 }
 
 export const defaultVideoControls: Required<VideoPlayerControls> = {
@@ -50,8 +50,8 @@ export const defaultVideoControls: Required<VideoPlayerControls> = {
   play: "Play",
   pause: "Pause",
   volume: "Volume",
-  chooseSubtitles: "Choose subtitles",
-  none: "None",
+  chooseSubtitlesText: "Choose subtitles",
+  noCaptionsText: "None",
 };
 
 export interface VideoPlayerProps {

--- a/packages/react/src/components/Video/VideoPlayer.props.ts
+++ b/packages/react/src/components/Video/VideoPlayer.props.ts
@@ -6,29 +6,10 @@ export interface VideoPlayerRef {
 }
 
 export interface VideoTextTrack {
-  /**
-   * Source URL for a WebVTT track file.
-   */
   src: string;
-
-  /**
-   * Track language code (for example "en" or "fr").
-   */
   srclang: string;
-
-  /**
-   * Human readable language label shown in the CC menu.
-   */
   label: string;
-
-  /**
-   * Track type rendered by Video.js.
-   */
   kind?: "captions" | "subtitles";
-
-  /**
-   * Whether this track is selected by default.
-   */
   default?: boolean;
 }
 
@@ -76,7 +57,5 @@ export interface VideoPlayerProps {
    * if YouTube, set to true
    */
   youtube?: boolean;
-
-  // Optional closed-captions tracks
   tracks?: VideoTextTrack[];
 }

--- a/packages/react/src/components/Video/VideoPlayer.props.ts
+++ b/packages/react/src/components/Video/VideoPlayer.props.ts
@@ -20,7 +20,7 @@ export interface VideoPlayerControls {
   fullscreen: string;
 
   /**
-   * Specify the label for the  play button
+   * Specify the label for the play button
    */
   play: string;
 
@@ -33,7 +33,26 @@ export interface VideoPlayerControls {
    * Specify the label for the volume button
    */
   volume: string;
+
+  /**
+   * Specify the heading shown in the subtitles menu
+   */
+  chooseSubtitles?: string;
+
+  /**
+   * Specify the label for the option that turns subtitles off
+   */
+  none?: string;
 }
+
+export const defaultVideoControls: Required<VideoPlayerControls> = {
+  fullscreen: "Fullscreen",
+  play: "Play",
+  pause: "Pause",
+  volume: "Volume",
+  chooseSubtitles: "Choose subtitles",
+  none: "None",
+};
 
 export interface VideoPlayerProps {
   src: string;

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -131,22 +131,14 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
         closeMenu();
       };
 
-      const handleEscapeKey = (event: KeyboardEvent) => {
-        if (event.key === "Escape") {
-          closeMenu();
-        }
-      };
-
       const handleTrackChange = () => closeMenu();
 
       menuButton.addEventListener("pointerup", handleToggle);
-      document.addEventListener("keydown", handleEscapeKey);
       document.addEventListener("pointerup", handleOutsideTouch);
       player.current.on("texttrackchange", handleTrackChange);
 
       return () => {
         menuButton.removeEventListener("pointerup", handleToggle);
-        document.removeEventListener("keydown", handleEscapeKey);
         document.removeEventListener("pointerup", handleOutsideTouch);
         player.current?.off("texttrackchange", handleTrackChange);
       };

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -1,12 +1,42 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import "videojs-youtube";
-import { VideoPlayerProps, VideoPlayerRef } from "./VideoPlayer.props";
+import {
+  VideoPlayerProps,
+  VideoPlayerRef,
+  VideoTextTrack,
+} from "./VideoPlayer.props";
 import videojs, { ILOVideo } from "video.js";
 
 const video = videojs as unknown as ILOVideo;
 
+const toRemoteTextTrack = (
+  track: VideoTextTrack
+): videojs.TextTrackOptions => ({
+  kind: track.kind ?? "captions",
+  src: track.src,
+  srclang: track.srclang,
+  label: track.label,
+  default: Boolean(track.default),
+});
+
+const syncRemoteTextTracks = (
+  player: videojs.Player,
+  tracks?: VideoTextTrack[]
+) => {
+  const remoteTracks = player.remoteTextTracks();
+  for (let i = remoteTracks.length - 1; i >= 0; i--) {
+    player.removeRemoteTextTrack(
+      remoteTracks[i] as unknown as HTMLTrackElement
+    );
+  }
+
+  tracks?.forEach((track) => {
+    player.addRemoteTextTrack(toRemoteTextTrack(track), false);
+  });
+};
+
 const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
-  ({ src, poster, youtube }, ref) => {
+  ({ src, poster, youtube, tracks }, ref) => {
     const placeholderRef = useRef<HTMLDivElement>(null);
     const player = useRef<videojs.Player | undefined>(undefined);
 
@@ -42,7 +72,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             chaptersButton: false,
             audioTrackButton: false,
             pictureInPictureToggle: false,
-            subsCapsButton: false,
+            subsCapsButton: true,
             seekToLive: false,
             liveDisplay: false,
           },
@@ -57,14 +87,16 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             techOrder: ["youtube"],
           },
           liveTracker: false,
+          tracks: tracks?.map(toRemoteTextTrack),
         });
       } else {
         player.current.poster(poster?.src || "");
         player.current.src([
           { type: youtube ? "video/youtube" : undefined, src: src },
         ]);
+        syncRemoteTextTracks(player.current, tracks);
       }
-    }, [poster?.src, src, youtube]);
+    }, [poster?.src, src, tracks, youtube]);
 
     useEffect(() => {
       return () => {

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -106,7 +106,6 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
       }
 
       const openClassName = "ilo-cc-open";
-      const closeButtonClassName = "ilo-cc-menu-close-button";
       const hiddenClassName = "vjs-hidden";
       const setMenuVisibility = (isOpen: boolean) => {
         subsCapsButton.classList.toggle(openClassName, isOpen);
@@ -138,36 +137,15 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
         }
       };
 
-      const existingCloseButton = menuPanel.querySelector<HTMLElement>(
-        `.${closeButtonClassName}`
-      );
-      const closeButton = (existingCloseButton ??
-        document.createElement("button")) as HTMLButtonElement;
-      if (!existingCloseButton) {
-        closeButton.className = closeButtonClassName;
-        closeButton.type = "button";
-        menuPanel.appendChild(closeButton);
-      }
-
-      const handleCloseButtonInteraction = (event: Event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        closeMenu();
-      };
       const handleTrackChange = () => closeMenu();
 
       menuButton.addEventListener("pointerup", handleToggle);
-      closeButton.addEventListener("pointerup", handleCloseButtonInteraction);
       document.addEventListener("keydown", handleEscapeKey);
       document.addEventListener("pointerup", handleOutsideTouch);
       player.current.on("texttrackchange", handleTrackChange);
 
       return () => {
         menuButton.removeEventListener("pointerup", handleToggle);
-        closeButton.removeEventListener(
-          "pointerup",
-          handleCloseButtonInteraction
-        );
         document.removeEventListener("keydown", handleEscapeKey);
         document.removeEventListener("pointerup", handleOutsideTouch);
         player.current?.off("texttrackchange", handleTrackChange);

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -4,6 +4,7 @@ import {
   VideoPlayerProps,
   VideoPlayerRef,
   VideoTextTrack,
+  defaultVideoControls,
 } from "./VideoPlayer.props";
 import videojs, { ILOVideo } from "video.js";
 
@@ -26,9 +27,10 @@ const appendTextTracks = (
 };
 
 const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
-  ({ src, poster, youtube, tracks }, ref) => {
+  ({ src, poster, youtube, tracks, controls }, ref) => {
     const placeholderRef = useRef<HTMLDivElement>(null);
     const player = useRef<videojs.Player | undefined>(undefined);
+    const mergedControls = { ...defaultVideoControls, ...controls };
 
     useImperativeHandle(
       ref,
@@ -105,7 +107,17 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     }, []);
 
     return (
-      <div className="ilo--videoplayer">
+      <div
+        className="ilo--videoplayer"
+        style={
+          {
+            "--ilo-video-choose-subtitles": JSON.stringify(
+              mergedControls.chooseSubtitles
+            ),
+            "--ilo-video-none": JSON.stringify(mergedControls.none),
+          } as React.CSSProperties
+        }
+      >
         <div ref={placeholderRef} />
       </div>
     );

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -167,9 +167,9 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
         style={
           {
             "--ilo-video-choose-subtitles": JSON.stringify(
-              mergedControls.chooseSubtitles
+              mergedControls.chooseSubtitlesText
             ),
-            "--ilo-video-none": JSON.stringify(mergedControls.none),
+            "--ilo-video-none": JSON.stringify(mergedControls.noCaptionsText),
           } as React.CSSProperties
         }
       >

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -9,29 +9,19 @@ import videojs, { ILOVideo } from "video.js";
 
 const video = videojs as unknown as ILOVideo;
 
-const toRemoteTextTrack = (
-  track: VideoTextTrack
-): videojs.TextTrackOptions => ({
-  kind: track.kind ?? "captions",
-  src: track.src,
-  srclang: track.srclang,
-  label: track.label,
-  default: Boolean(track.default),
-});
-
-const syncRemoteTextTracks = (
-  player: videojs.Player,
-  tracks?: VideoTextTrack[]
+const appendTextTracks = (
+  videoElement: HTMLVideoElement,
+  tracks: VideoTextTrack[]
 ) => {
-  const remoteTracks = player.remoteTextTracks();
-  for (let i = remoteTracks.length - 1; i >= 0; i--) {
-    player.removeRemoteTextTrack(
-      remoteTracks[i] as unknown as HTMLTrackElement
-    );
-  }
-
-  tracks?.forEach((track) => {
-    player.addRemoteTextTrack(toRemoteTextTrack(track), false);
+  tracks.forEach((track) => {
+    const { kind, src, srclang, label, default: isDefault } = track;
+    const trackElement = document.createElement("track");
+    trackElement.kind = kind ?? "captions";
+    trackElement.src = src;
+    trackElement.srclang = srclang;
+    trackElement.label = label;
+    trackElement.default = !!isDefault;
+    videoElement.appendChild(trackElement);
   });
 };
 
@@ -58,6 +48,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
       if (!player.current) {
         const videoElement = document.createElement("video");
         videoElement.className = "ilo--video--element";
+        if (tracks?.length) appendTextTracks(videoElement, tracks);
         placeholderRef.current.appendChild(videoElement);
 
         player.current = video(videoElement, {
@@ -87,19 +78,22 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             techOrder: ["youtube"],
           },
           liveTracker: false,
-          tracks: tracks?.map(toRemoteTextTrack),
         });
       } else {
         player.current.poster(poster?.src || "");
         player.current.src([
           { type: youtube ? "video/youtube" : undefined, src: src },
         ]);
-        syncRemoteTextTracks(player.current, tracks);
       }
-    }, [poster?.src, src, tracks, youtube]);
+    }, [poster?.src, src, youtube]);
 
     useEffect(() => {
       return () => {
+        const trackElements = placeholderRef.current?.querySelectorAll("track");
+        if (trackElements?.length) {
+          trackElements.forEach((trackElement) => trackElement.remove());
+        }
+
         if (player.current) {
           player.current.dispose();
           player.current = undefined;

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -90,6 +90,91 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     }, [poster?.src, src, youtube]);
 
     useEffect(() => {
+      const container = placeholderRef.current;
+      if (!container || !player.current) {
+        return;
+      }
+
+      const subsCapsButton = container.querySelector(".vjs-subs-caps-button");
+      const menuButton = subsCapsButton?.querySelector(
+        ".vjs-menu-button, button"
+      );
+      const menuPanel = subsCapsButton?.querySelector(".vjs-menu");
+
+      if (!subsCapsButton || !menuButton || !menuPanel) {
+        return;
+      }
+
+      const openClassName = "ilo-cc-open";
+      const closeButtonClassName = "ilo-cc-menu-close-button";
+      const hiddenClassName = "vjs-hidden";
+      const setMenuVisibility = (isOpen: boolean) => {
+        subsCapsButton.classList.toggle(openClassName, isOpen);
+        menuPanel.classList.toggle(hiddenClassName, !isOpen);
+      };
+
+      const closeMenu = () => {
+        setMenuVisibility(false);
+      };
+
+      const handleToggle = (event: Event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const shouldOpen = menuPanel.classList.contains(hiddenClassName);
+        setMenuVisibility(shouldOpen);
+      };
+
+      const handleOutsideTouch = (event: Event) => {
+        const eventTarget = event.target as Node | null;
+        if (!eventTarget || subsCapsButton.contains(eventTarget)) {
+          return;
+        }
+        closeMenu();
+      };
+
+      const handleEscapeKey = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          closeMenu();
+        }
+      };
+
+      const existingCloseButton = menuPanel.querySelector<HTMLElement>(
+        `.${closeButtonClassName}`
+      );
+      const closeButton = (existingCloseButton ??
+        document.createElement("button")) as HTMLButtonElement;
+      if (!existingCloseButton) {
+        closeButton.className = closeButtonClassName;
+        closeButton.type = "button";
+        menuPanel.appendChild(closeButton);
+      }
+
+      const handleCloseButtonInteraction = (event: Event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        closeMenu();
+      };
+      const handleTrackChange = () => closeMenu();
+
+      menuButton.addEventListener("pointerup", handleToggle);
+      closeButton.addEventListener("pointerup", handleCloseButtonInteraction);
+      document.addEventListener("keydown", handleEscapeKey);
+      document.addEventListener("pointerup", handleOutsideTouch);
+      player.current.on("texttrackchange", handleTrackChange);
+
+      return () => {
+        menuButton.removeEventListener("pointerup", handleToggle);
+        closeButton.removeEventListener(
+          "pointerup",
+          handleCloseButtonInteraction
+        );
+        document.removeEventListener("keydown", handleEscapeKey);
+        document.removeEventListener("pointerup", handleOutsideTouch);
+        player.current?.off("texttrackchange", handleTrackChange);
+      };
+    }, []);
+
+    useEffect(() => {
       return () => {
         const trackElements = placeholderRef.current?.querySelectorAll("track");
         if (trackElements?.length) {

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -65,7 +65,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             chaptersButton: false,
             audioTrackButton: false,
             pictureInPictureToggle: false,
-            subsCapsButton: true,
+            subsCapsButton: !!tracks?.length,
             seekToLive: false,
             liveDisplay: false,
           },

--- a/packages/react/src/components/Video/VideoPlayer.tsx
+++ b/packages/react/src/components/Video/VideoPlayer.tsx
@@ -90,61 +90,6 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     }, [poster?.src, src, youtube]);
 
     useEffect(() => {
-      const container = placeholderRef.current;
-      if (!container || !player.current) {
-        return;
-      }
-
-      const subsCapsButton = container.querySelector(".vjs-subs-caps-button");
-      const menuButton = subsCapsButton?.querySelector(
-        ".vjs-menu-button, button"
-      );
-      const menuPanel = subsCapsButton?.querySelector(".vjs-menu");
-
-      if (!subsCapsButton || !menuButton || !menuPanel) {
-        return;
-      }
-
-      const openClassName = "ilo-cc-open";
-      const hiddenClassName = "vjs-hidden";
-      const setMenuVisibility = (isOpen: boolean) => {
-        subsCapsButton.classList.toggle(openClassName, isOpen);
-        menuPanel.classList.toggle(hiddenClassName, !isOpen);
-      };
-
-      const closeMenu = () => {
-        setMenuVisibility(false);
-      };
-
-      const handleToggle = (event: Event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        const shouldOpen = menuPanel.classList.contains(hiddenClassName);
-        setMenuVisibility(shouldOpen);
-      };
-
-      const handleOutsideTouch = (event: Event) => {
-        const eventTarget = event.target as Node | null;
-        if (!eventTarget || subsCapsButton.contains(eventTarget)) {
-          return;
-        }
-        closeMenu();
-      };
-
-      const handleTrackChange = () => closeMenu();
-
-      menuButton.addEventListener("pointerup", handleToggle);
-      document.addEventListener("pointerup", handleOutsideTouch);
-      player.current.on("texttrackchange", handleTrackChange);
-
-      return () => {
-        menuButton.removeEventListener("pointerup", handleToggle);
-        document.removeEventListener("pointerup", handleOutsideTouch);
-        player.current?.off("texttrackchange", handleTrackChange);
-      };
-    }, []);
-
-    useEffect(() => {
       return () => {
         const trackElements = placeholderRef.current?.querySelectorAll("track");
         if (trackElements?.length) {
@@ -166,7 +111,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
         className="ilo--videoplayer"
         style={
           {
-            "--ilo-video-choose-subtitles": JSON.stringify(
+            "--ilo-video-choose-subtitle-text": JSON.stringify(
               mergedControls.chooseSubtitlesText
             ),
             "--ilo-video-none": JSON.stringify(mergedControls.noCaptionsText),

--- a/packages/react/src/stories/Video/Video.stories.tsx
+++ b/packages/react/src/stories/Video/Video.stories.tsx
@@ -57,6 +57,14 @@ const VideoTemplate: StoryFn<VideoProps> = (args) => <Video {...args} />;
 export const VideoFileMedia: StoryFn<VideoProps> = VideoTemplate.bind({});
 
 /**
+ * Video File with Captions Instance
+ *
+ */
+export const VideoFileWithCaptions: StoryFn<VideoProps> = VideoTemplate.bind(
+  {}
+);
+
+/**
  * Video YouTube Instance
  *
  */
@@ -65,6 +73,10 @@ export const VideoYTMedia: StoryFn<VideoProps> = VideoTemplate.bind({});
 // enumerate the props for the video file option
 VideoFileMedia.args = videoArgs.videofile;
 VideoFileMedia.storyName = "Media file";
+
+// enumerate the props for the video file with captions option
+VideoFileWithCaptions.args = videoArgs.videofileWithCaptions;
+VideoFileWithCaptions.storyName = "Media with Captions";
 
 // enumerate the props for the video youtube option
 VideoYTMedia.args = videoArgs.videoyt;

--- a/packages/react/tests/Video.test.tsx
+++ b/packages/react/tests/Video.test.tsx
@@ -1,0 +1,137 @@
+import { createRef } from "react";
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { Video } from "../src/components/Video";
+import { VideoPlayerRef } from "../src/components/Video/VideoPlayer.props";
+
+const { mockPlayer, videojsMock } = vi.hoisted(() => {
+  const mockPlayer = {
+    dispose: vi.fn(),
+    poster: vi.fn(),
+    src: vi.fn(),
+  };
+  const videojsMock = vi.fn<
+    (
+      element: HTMLVideoElement,
+      options: Record<string, unknown>
+    ) => typeof mockPlayer
+  >(() => mockPlayer);
+  return { mockPlayer, videojsMock };
+});
+
+vi.mock("../src/hooks/useGlobalSettings", () => ({
+  default: () => ({ prefix: "ilo" }),
+}));
+
+vi.mock("video.js", () => ({
+  default: videojsMock,
+}));
+
+vi.mock("videojs-youtube", () => ({}));
+
+const fixture = {
+  src: "/video-example.mp4",
+  poster: {
+    src: "/media-file-poster.jpg",
+    alt: "Poster alt text",
+  },
+  caption:
+    "The ILO brings together governments, employers and workers to set labour standards.",
+  tracks: [
+    {
+      src: "/video-example.en.vtt",
+      srclang: "en",
+      label: "English",
+      kind: "captions" as const,
+      default: true,
+    },
+    {
+      src: "/video-example.es.vtt",
+      srclang: "es",
+      label: "Spanish",
+      kind: "captions" as const,
+    },
+  ],
+};
+
+describe("Video", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the figure with base and wrapper classes", () => {
+    const { container } = render(<Video src={fixture.src} />);
+    const figure = container.querySelector("figure");
+
+    expect(figure).toHaveClass("ilo--video");
+    expect(container.querySelector(".ilo--video--wrapper")).toBeInTheDocument();
+    expect(container.querySelector(".ilo--videoplayer")).toBeInTheDocument();
+  });
+
+  it("should render the caption when provided", () => {
+    render(<Video src={fixture.src} caption={fixture.caption} />);
+
+    const caption = screen.getByText(fixture.caption);
+    expect(caption).toBeInTheDocument();
+    expect(caption.tagName).toBe("FIGCAPTION");
+    expect(caption).toHaveClass("ilo--video--caption");
+  });
+
+  it("should initialize video.js with src and poster", async () => {
+    render(<Video src={fixture.src} poster={fixture.poster} />);
+
+    await waitFor(() => expect(videojsMock).toHaveBeenCalled());
+
+    const [videoElement, options] = videojsMock.mock.calls[0];
+    expect(videoElement).toHaveClass("ilo--video--element");
+    expect(options).toMatchObject({
+      poster: fixture.poster.src,
+      sources: [{ type: undefined, src: fixture.src }],
+    });
+  });
+
+  it("should use the youtube source type when youtube is true", async () => {
+    const youtubeSrc = "https://youtu.be/X72_A4_6zjU";
+    render(<Video src={youtubeSrc} youtube />);
+
+    await waitFor(() => expect(videojsMock).toHaveBeenCalled());
+
+    const [, options] = videojsMock.mock.calls[0];
+    expect(options).toMatchObject({
+      sources: [{ type: "video/youtube", src: youtubeSrc }],
+    });
+  });
+
+  it("should append text tracks to the video element", async () => {
+    render(<Video src={fixture.src} tracks={fixture.tracks} />);
+
+    await waitFor(() => expect(videojsMock).toHaveBeenCalled());
+
+    const [videoElement] = videojsMock.mock.calls[0];
+    const trackElements = videoElement.querySelectorAll("track");
+
+    expect(trackElements).toHaveLength(fixture.tracks.length);
+    expect(trackElements[0]).toHaveAttribute("src", fixture.tracks[0].src);
+    expect(trackElements[0]).toHaveAttribute("srclang", "en");
+    expect(trackElements[0]).toHaveAttribute("label", "English");
+    expect(trackElements[0]).toHaveAttribute("kind", "captions");
+    expect(trackElements[0]).toHaveAttribute("default");
+  });
+
+  it("should expose the video.js player via ref", async () => {
+    const ref = createRef<VideoPlayerRef>();
+    render(<Video src={fixture.src} ref={ref} />);
+
+    await waitFor(() => expect(ref.current?.player).toBe(mockPlayer));
+  });
+
+  it("should dispose the player on unmount", async () => {
+    const { unmount } = render(<Video src={fixture.src} />);
+
+    await waitFor(() => expect(videojsMock).toHaveBeenCalled());
+    unmount();
+
+    expect(mockPlayer.dispose).toHaveBeenCalled();
+  });
+});

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -221,28 +221,20 @@
       position: relative;
       z-index: 30;
 
-      > .vjs-menu-button,
-      > button {
+      > .vjs-menu-button {
         @include videobutton("closed_captions");
-        touch-action: manipulation;
       }
 
-      > .vjs-menu-button .vjs-icon-placeholder,
-      > button .vjs-icon-placeholder {
-        display: none;
-      }
-
-      &.vjs-lock-showing > .vjs-menu-button,
-      &.vjs-lock-showing > button,
-      &.ilo-cc-open > .vjs-menu-button,
-      &.ilo-cc-open > button {
-        border-bottom: px-to-rem(2px) solid var(--ilo-color-blue);
+      &.vjs-hover > .vjs-menu-button,
+      &:hover > .vjs-menu-button,
+      &:focus-within > .vjs-menu-button {
+        background-color: var(--ilo-color-blue-light);
+        @include dataurlicon("closed_captions", rgba(30, 45, 190, 1));
       }
 
       .vjs-menu {
-        background: #d8e4ef;
+        background: var(--ilo-color-brand-200);
         border: 0;
-        box-shadow: 0 px-to-rem(2px) px-to-rem(8px) rgba(0, 0, 0, 0.16);
         bottom: calc(100% + #{px-to-rem(8px)});
         display: none;
         left: 50%;
@@ -253,9 +245,19 @@
         z-index: 40;
         padding-top: px-to-rem(28px);
 
+        // gap added to ensure vjs-hover persists when hovering to menu from captions button
+        &::after {
+          content: "";
+          height: px-to-rem(8px);
+          left: 0;
+          position: absolute;
+          right: 0;
+          top: 100%;
+        }
+
         &:before {
           @include typography("body-xsmall");
-          content: var(--ilo-video-choose-subtitles, "Choose subtitles");
+          content: var(--ilo-video-choose-subtitle-text, "Choose subtitles");
           color: var(--ilo-color-gray-charcoal);
           font-weight: var(--ilo-font-weight-bold);
           left: px-to-rem(12px);
@@ -264,31 +266,10 @@
         }
       }
 
-      .ilo-cc-menu-close-button {
-        background-color: transparent;
-        border: 0;
-        cursor: pointer;
-        height: px-to-rem(14px);
-        position: absolute;
-        right: px-to-rem(12px);
-        top: px-to-rem(8px);
-        width: px-to-rem(14px);
-        z-index: 1;
-        touch-action: manipulation;
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: contain;
-        @include dataurlicon("close", rgba(45, 45, 45, 1));
-      }
-
-      &.vjs-lock-showing .vjs-menu:not(.vjs-hidden),
-      &.ilo-cc-open .vjs-menu:not(.vjs-hidden),
+      .vjs-menu.vjs-lock-showing:not(.vjs-hidden),
+      &.vjs-hover .vjs-menu:not(.vjs-hidden),
       &:focus-within .vjs-menu:not(.vjs-hidden) {
         display: block;
-      }
-
-      .vjs-menu.vjs-hidden {
-        display: none;
       }
 
       .vjs-menu-content {
@@ -310,14 +291,13 @@
         text-shadow: none;
         white-space: nowrap;
 
-        &:hover,
-        &:focus {
-          background: rgba(255, 255, 255, 0.35);
+        &:hover {
+          background: var(--ilo-color-neutrals-200);
         }
 
         &:before {
           background: transparent;
-          border: 2px solid #b8c7d6;
+          border: 2px solid var(--ilo-color-neutrals-500);
           border-radius: 50%;
           content: "";
           display: inline-block;
@@ -330,9 +310,9 @@
           color: var(--ilo-color-gray-charcoal);
 
           &:before {
-            border-color: #2d0065;
-            box-shadow: inset 0 0 0 px-to-rem(2px) #d8e4ef;
-            background: #2d0065;
+            border-color: var(--ilo-color-neutrals-black);
+            box-shadow: inset 0 0 0 px-to-rem(2px) var(--ilo-color-neutrals-200);
+            background: var(--ilo-color-neutrals-black);
           }
         }
       }
@@ -349,10 +329,6 @@
       }
 
       .vjs-menu .vjs-icon-placeholder {
-        display: none;
-      }
-
-      .vjs-texttrack-settings {
         display: none;
       }
     }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -167,6 +167,10 @@
       .vjs-volume-panel {
         display: none;
       }
+
+      .vjs-subs-caps-button {
+        display: none;
+      }
     }
   }
 
@@ -208,6 +212,146 @@
     .vjs-fullscreen-control {
       order: 5;
       @include videobutton("fullscreen");
+    }
+
+    // Closed captions control
+    .vjs-subs-caps-button {
+      order: 3;
+      margin-right: px-to-rem(2px);
+      position: relative;
+      width: px-to-rem(40px);
+      height: px-to-rem(40px);
+      z-index: 30;
+
+      > .vjs-menu-button,
+      > button {
+        align-items: center;
+        background: var(--ilo-color-gray-charcoal);
+        border: 0;
+        color: var(--ilo-color-gray-light);
+        cursor: pointer;
+        display: flex;
+        height: 100%;
+        justify-content: center;
+        width: 100%;
+
+        &:hover,
+        &:focus {
+          background: var(--ilo-color-blue-light);
+          color: var(--ilo-color-blue);
+        }
+      }
+
+      > .vjs-menu-button .vjs-icon-placeholder,
+      > button .vjs-icon-placeholder {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      > .vjs-menu-button .vjs-icon-placeholder:before,
+      > button .vjs-icon-placeholder:before {
+        @include typography("body-xsmall");
+        content: "CC";
+        color: currentColor;
+        font-weight: var(--ilo-font-weight-bold);
+        letter-spacing: 0.02em;
+      }
+
+      .vjs-menu {
+        background: #d8e4ef;
+        border: 0;
+        box-shadow: 0 px-to-rem(2px) px-to-rem(8px) rgba(0, 0, 0, 0.16);
+        bottom: calc(100% + #{px-to-rem(8px)});
+        display: none;
+        left: 50%;
+        min-width: px-to-rem(190px);
+        position: absolute;
+        right: auto;
+        transform: translateX(-50%);
+        z-index: 40;
+        padding-top: px-to-rem(28px);
+
+        &:before {
+          @include typography("body-xsmall");
+          content: "Choose subtitles";
+          color: var(--ilo-color-gray-charcoal);
+          font-weight: var(--ilo-font-weight-bold);
+          left: px-to-rem(12px);
+          position: absolute;
+          top: px-to-rem(8px);
+        }
+
+        &:after {
+          @include typography("body-xsmall");
+          content: "x";
+          color: var(--ilo-color-gray-charcoal);
+          position: absolute;
+          right: px-to-rem(10px);
+          top: px-to-rem(8px);
+        }
+      }
+
+      &.vjs-lock-showing .vjs-menu,
+      &:focus-within .vjs-menu {
+        display: block;
+      }
+
+      .vjs-menu-content {
+        margin: 0;
+        max-height: px-to-rem(120px);
+        overflow-y: auto;
+        padding: 0 0 px-to-rem(4px);
+      }
+
+      .vjs-menu-item {
+        @include typography("body-xsmall");
+        align-items: center;
+        color: var(--ilo-color-gray-charcoal);
+        display: flex;
+        gap: px-to-rem(8px);
+        line-height: px-to-rem(20px);
+        padding: px-to-rem(2px) px-to-rem(12px);
+        position: relative;
+        text-shadow: none;
+        white-space: nowrap;
+
+        &:hover,
+        &:focus {
+          background: rgba(255, 255, 255, 0.35);
+        }
+
+        &:before {
+          background: transparent;
+          border: 2px solid #b8c7d6;
+          border-radius: 50%;
+          content: "";
+          display: inline-block;
+          height: px-to-rem(10px);
+          width: px-to-rem(10px);
+          flex-shrink: 0;
+        }
+
+        &.vjs-selected {
+          color: var(--ilo-color-gray-charcoal);
+
+          &:before {
+            border-color: #2d0065;
+            box-shadow: inset 0 0 0 px-to-rem(2px) #d8e4ef;
+            background: #2d0065;
+          }
+        }
+      }
+
+      .vjs-menu .vjs-icon-placeholder {
+        display: none;
+      }
+
+      .vjs-texttrack-settings {
+        display: none;
+      }
     }
 
     // Duration Bar
@@ -287,7 +431,7 @@
 
     // Volume Control
     .vjs-volume-panel {
-      order: 3;
+      order: 4;
       border-bottom: 1px solid;
       bottom: 0;
       flex-direction: column;

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -268,6 +268,7 @@
 
       .vjs-menu.vjs-lock-showing:not(.vjs-hidden),
       &.vjs-hover .vjs-menu:not(.vjs-hidden),
+      &:hover .vjs-menu:not(.vjs-hidden),
       &:focus-within .vjs-menu:not(.vjs-hidden) {
         display: block;
       }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -345,6 +345,17 @@
         }
       }
 
+      .vjs-menu-item[tabindex="-1"]:first-child .vjs-menu-item-text {
+        font-size: 0;
+
+        &:after {
+          @include typography("body-xsmall");
+          content: "None";
+          font-size: px-to-rem(12px);
+          line-height: px-to-rem(20px);
+        }
+      }
+
       .vjs-menu .vjs-icon-placeholder {
         display: none;
       }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -252,7 +252,7 @@
 
         &:before {
           @include typography("body-xsmall");
-          content: "Choose subtitles";
+          content: var(--ilo-video-choose-subtitles, "Choose subtitles");
           color: var(--ilo-color-gray-charcoal);
           font-weight: var(--ilo-font-weight-bold);
           left: px-to-rem(12px);
@@ -330,7 +330,7 @@
 
         &:after {
           @include typography("body-xsmall");
-          content: "None";
+          content: var(--ilo-video-none, "None");
           font-size: px-to-rem(12px);
           line-height: px-to-rem(20px);
         }

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -254,10 +254,26 @@
       > .vjs-menu-button .vjs-icon-placeholder:before,
       > button .vjs-icon-placeholder:before {
         @include typography("body-xsmall");
-        content: "CC";
+        content: "cc";
+        align-items: center;
+        border: px-to-rem(2px) solid currentColor;
+        border-radius: px-to-rem(1px);
+        box-sizing: border-box;
         color: currentColor;
+        display: inline-flex;
         font-weight: var(--ilo-font-weight-bold);
-        letter-spacing: 0.02em;
+        height: px-to-rem(22px);
+        justify-content: center;
+        letter-spacing: 0;
+        line-height: 1;
+        padding: 0 px-to-rem(3px);
+        text-transform: lowercase;
+        width: px-to-rem(24px);
+      }
+
+      &.vjs-lock-showing > .vjs-menu-button,
+      &.vjs-lock-showing > button {
+        border-bottom: px-to-rem(2px) solid var(--ilo-color-blue);
       }
 
       .vjs-menu {
@@ -285,12 +301,27 @@
         }
 
         &:after {
-          @include typography("body-xsmall");
-          content: "x";
+          content: "";
           color: var(--ilo-color-gray-charcoal);
+          height: px-to-rem(14px);
           position: absolute;
-          right: px-to-rem(10px);
+          right: px-to-rem(12px);
           top: px-to-rem(8px);
+          width: px-to-rem(14px);
+          background: linear-gradient(
+              45deg,
+              transparent calc(50% - 1px),
+              currentColor calc(50% - 1px),
+              currentColor calc(50% + 1px),
+              transparent calc(50% + 1px)
+            ),
+            linear-gradient(
+              -45deg,
+              transparent calc(50% - 1px),
+              currentColor calc(50% - 1px),
+              currentColor calc(50% + 1px),
+              transparent calc(50% + 1px)
+            );
         }
       }
 

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -224,6 +224,7 @@
       > .vjs-menu-button,
       > button {
         @include videobutton("closed_captions");
+        touch-action: manipulation;
       }
 
       > .vjs-menu-button .vjs-icon-placeholder,
@@ -232,7 +233,9 @@
       }
 
       &.vjs-lock-showing > .vjs-menu-button,
-      &.vjs-lock-showing > button {
+      &.vjs-lock-showing > button,
+      &.ilo-cc-open > .vjs-menu-button,
+      &.ilo-cc-open > button {
         border-bottom: px-to-rem(2px) solid var(--ilo-color-blue);
       }
 
@@ -259,24 +262,33 @@
           position: absolute;
           top: px-to-rem(8px);
         }
-
-        &:after {
-          content: "";
-          height: px-to-rem(14px);
-          position: absolute;
-          right: px-to-rem(12px);
-          top: px-to-rem(8px);
-          width: px-to-rem(14px);
-          background-position: center;
-          background-repeat: no-repeat;
-          background-size: contain;
-          @include dataurlicon("close", rgba(45, 45, 45, 1));
-        }
       }
 
-      &.vjs-lock-showing .vjs-menu,
-      &:focus-within .vjs-menu {
+      .ilo-cc-menu-close-button {
+        background-color: transparent;
+        border: 0;
+        cursor: pointer;
+        height: px-to-rem(14px);
+        position: absolute;
+        right: px-to-rem(12px);
+        top: px-to-rem(8px);
+        width: px-to-rem(14px);
+        z-index: 1;
+        touch-action: manipulation;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        @include dataurlicon("close", rgba(45, 45, 45, 1));
+      }
+
+      &.vjs-lock-showing .vjs-menu:not(.vjs-hidden),
+      &.ilo-cc-open .vjs-menu:not(.vjs-hidden),
+      &:focus-within .vjs-menu:not(.vjs-hidden) {
         display: block;
+      }
+
+      .vjs-menu.vjs-hidden {
+        display: none;
       }
 
       .vjs-menu-content {

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -219,56 +219,16 @@
       order: 3;
       margin-right: px-to-rem(2px);
       position: relative;
-      width: px-to-rem(40px);
-      height: px-to-rem(40px);
       z-index: 30;
 
       > .vjs-menu-button,
       > button {
-        align-items: center;
-        background: var(--ilo-color-gray-charcoal);
-        border: 0;
-        color: var(--ilo-color-gray-light);
-        cursor: pointer;
-        display: flex;
-        height: 100%;
-        justify-content: center;
-        width: 100%;
-
-        &:hover,
-        &:focus {
-          background: var(--ilo-color-blue-light);
-          color: var(--ilo-color-blue);
-        }
+        @include videobutton("closed_captions");
       }
 
       > .vjs-menu-button .vjs-icon-placeholder,
       > button .vjs-icon-placeholder {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-      }
-
-      > .vjs-menu-button .vjs-icon-placeholder:before,
-      > button .vjs-icon-placeholder:before {
-        @include typography("body-xsmall");
-        content: "cc";
-        align-items: center;
-        border: px-to-rem(2px) solid currentColor;
-        border-radius: px-to-rem(1px);
-        box-sizing: border-box;
-        color: currentColor;
-        display: inline-flex;
-        font-weight: var(--ilo-font-weight-bold);
-        height: px-to-rem(22px);
-        justify-content: center;
-        letter-spacing: 0;
-        line-height: 1;
-        padding: 0 px-to-rem(3px);
-        text-transform: lowercase;
-        width: px-to-rem(24px);
+        display: none;
       }
 
       &.vjs-lock-showing > .vjs-menu-button,
@@ -302,26 +262,15 @@
 
         &:after {
           content: "";
-          color: var(--ilo-color-gray-charcoal);
           height: px-to-rem(14px);
           position: absolute;
           right: px-to-rem(12px);
           top: px-to-rem(8px);
           width: px-to-rem(14px);
-          background: linear-gradient(
-              45deg,
-              transparent calc(50% - 1px),
-              currentColor calc(50% - 1px),
-              currentColor calc(50% + 1px),
-              transparent calc(50% + 1px)
-            ),
-            linear-gradient(
-              -45deg,
-              transparent calc(50% - 1px),
-              currentColor calc(50% - 1px),
-              currentColor calc(50% + 1px),
-              transparent calc(50% + 1px)
-            );
+          background-position: center;
+          background-repeat: no-repeat;
+          background-size: contain;
+          @include dataurlicon("close", rgba(45, 45, 45, 1));
         }
       }
 


### PR DESCRIPTION
This PR introduced closed captions to the React video player component via a customized `CC` button utilizing underlying the `video.js` `subCapsButton`. Recording for desktop and mobile (andorid) devices attached.

- Added unit tests for the video component
- Created a new story for media with captions.

Chrome 148: 
https://github.com/user-attachments/assets/aa1ea57a-63b9-43d1-9f12-ed2f5b5d5315


Android 16 (tested on Samsung S23 Ultra):
https://github.com/user-attachments/assets/82c1e484-19bf-4afb-97aa-9d451165fd41



