### PR TITLE
Fix Hero card-offset background parity & seam hairline

### DIFF
--- a/.changeset/hero-card-offset-parity.md
+++ b/.changeset/hero-card-offset-parity.md
@@ -1,0 +1,16 @@
+---
+"@ilo-org/react": patch
+---
+
+**Hero:** Fixed the card-offset space (between the left edge of the screen
+and the HeroCard) so it correctly matches the hero card's background and
+theme, bringing the React component in line with the Twig implementation.
+
+- The root element now receives a `hero__card-background__*` class derived
+  from `heroCard.background`, so the offset honours `semi-transparent` and
+  `transparent` cards. Previously this class was never emitted in React,
+  leaving the offset solid regardless of the card's background.
+- The Hero `theme` now falls back to `heroCard.theme` when not explicitly
+  set (matching Twig's `theme|default(herocard.theme)`), so a `light` card
+  no longer renders next to a `dark` offset. An explicit `theme` on `Hero`
+  still takes precedence.

--- a/.changeset/hero-offset-seam-hairline.md
+++ b/.changeset/hero-offset-seam-hairline.md
@@ -1,0 +1,11 @@
+---
+"@ilo-org/react": patch
+"@ilo-org/twig": patch
+"@ilo-org/styles": patch
+---
+
+**Hero:** Removed the seam-bridging `box-shadow` on semi-transparent
+card-offsets. With a translucent fill the shadow composited over the card's
+own semi-transparent layer, producing a darker hairline at the offset/card
+boundary on high-resolution screens. This is a visual change to the Hero in
+any package that renders it.

--- a/.changeset/yellow-dancers-impress.md
+++ b/.changeset/yellow-dancers-impress.md
@@ -1,5 +1,7 @@
 ---
 "@ilo-org/styles": patch
+"@ilo-org/twig": patch
+"@ilo-org/react": patch
 ---
 
 Dropdown: Prevented focus styling being applied on hover for disabled dropdowns

--- a/packages/react/src/components/Hero/Hero.tsx
+++ b/packages/react/src/components/Hero/Hero.tsx
@@ -60,7 +60,9 @@ export type HeroProps = {
   posterSize?: "small" | "medium" | "large" | "xlarge";
 
   /**
-   * Theme for the card
+   * Theme for the hero. Overrides the hero card's own theme when set;
+   * otherwise defaults to `heroCard.theme`. Drives the colour of the
+   * card-offset space so it matches the card.
    */
   theme?: ThemeTypes;
 };
@@ -73,7 +75,7 @@ const Hero = forwardRef<HTMLDivElement, HeroProps>(
       align = "baseline",
       cardSize = "small",
       posterSize = "large",
-      theme = "dark",
+      theme: themeProp,
       image,
       breadcrumb,
       heroCard,
@@ -85,6 +87,14 @@ const Hero = forwardRef<HTMLDivElement, HeroProps>(
     const { prefix } = useGlobalSettings();
 
     const baseClass = `hero`;
+
+    // Mirror the Twig component: the hero's theme and background default to
+    // the hero card's own theme/background unless explicitly overridden at
+    // the Hero level. The SCSS relies on these root classes (e.g.
+    // `__card-theme__light` and `[class*="semi-transparent"]`) to colour the
+    // `--card-offset` space so it matches the card.
+    const theme = themeProp ?? heroCard.theme ?? "dark";
+    const background = heroCard.background ?? "solid";
 
     const orderedImages = useMemo(() => {
       if (!image) return [];
@@ -102,6 +112,7 @@ const Hero = forwardRef<HTMLDivElement, HeroProps>(
           `${baseClass}__card-size__${cardSize}`,
           `${baseClass}__poster-size__${posterSize}`,
           `${baseClass}__card-theme__${theme}`,
+          `${baseClass}__card-background__${background}`,
           { [`${baseClass}__gap__${gap}`]: gap },
           className
         )}

--- a/packages/react/src/stories/Hero/Hero.stories.tsx
+++ b/packages/react/src/stories/Hero/Hero.stories.tsx
@@ -1,10 +1,47 @@
 import { StoryObj, Meta } from "@storybook/react";
 import { Hero, HeroProps } from "../../components/Hero";
+import { HeroCardProps } from "../../components/HeroCard";
+import { ThemeTypes } from "../../types";
 
-const meta: Meta<typeof Hero> = {
+// `heroCard` is a single object prop, so Storybook renders it as one JSON
+// control with no per-field selects. These convenience args surface the
+// card's theme/background as top-level radio controls; the `render` below
+// merges them back into `heroCard`.
+type HeroStoryArgs = HeroProps & {
+  /** Convenience Storybook control that overrides `heroCard.theme`. */
+  cardTheme?: ThemeTypes;
+  /** Convenience Storybook control that overrides `heroCard.background`. */
+  cardBackground?: HeroCardProps["background"];
+};
+
+const meta: Meta<HeroStoryArgs> = {
   title: "Components/Content/Hero",
   component: Hero,
   tags: ["autodocs"],
+  argTypes: {
+    cardTheme: {
+      name: "heroCard.theme",
+      options: ["light", "dark"],
+      control: { type: "radio" },
+      table: { category: "Hero Card" },
+    },
+    cardBackground: {
+      name: "heroCard.background",
+      options: ["solid", "transparent", "semi-transparent"],
+      control: { type: "radio" },
+      table: { category: "Hero Card" },
+    },
+  },
+  render: ({ cardTheme, cardBackground, ...args }) => (
+    <Hero
+      {...args}
+      heroCard={{
+        ...args.heroCard,
+        ...(cardTheme && { theme: cardTheme }),
+        ...(cardBackground && { background: cardBackground }),
+      }}
+    />
+  ),
   parameters: {
     docs: {
       description: {
@@ -15,7 +52,7 @@ const meta: Meta<typeof Hero> = {
   },
 };
 
-const Default: StoryObj<HeroProps> = {
+const Default: StoryObj<HeroStoryArgs> = {
   args: {
     image: {
       alt: "Lorem ipsum",
@@ -74,7 +111,7 @@ const Default: StoryObj<HeroProps> = {
   },
 };
 
-const Homepage: StoryObj<HeroProps> = {
+const Homepage: StoryObj<HeroStoryArgs> = {
   args: {
     ...Default.args,
     align: "center",
@@ -94,7 +131,7 @@ const Homepage: StoryObj<HeroProps> = {
   },
 };
 
-const Article: StoryObj<HeroProps> = {
+const Article: StoryObj<HeroStoryArgs> = {
   args: {
     ...Default.args,
     align: "bottom",
@@ -134,5 +171,24 @@ const Article: StoryObj<HeroProps> = {
   },
 };
 
+const LightSemiTransparent: StoryObj<HeroStoryArgs> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Light theme with a semi-transparent card and `justify: start`. The card-offset space between the left edge of the screen and the HeroCard picks up the same semi-transparent fill as the card. NOTE: the offset only appears at the `lg` breakpoint on viewports wider than ~1364px — view this in a full-width canvas.",
+      },
+    },
+  },
+  args: {
+    ...Default.args,
+    justify: "start",
+    align: "baseline",
+    gap: "transparent",
+    cardTheme: "light",
+    cardBackground: "semi-transparent",
+  },
+};
+
 export default meta;
-export { Default, Homepage, Article };
+export { Default, Homepage, Article, LightSemiTransparent };

--- a/packages/styles/scss/components/_hero.scss
+++ b/packages/styles/scss/components/_hero.scss
@@ -242,7 +242,10 @@
         &[class*="semi-transparent"] {
           #{$c}--card-offset {
             background: rgba(35, 0, 80, 0.6);
-            box-shadow: 0.3px 0 0 0 rgba(35, 0, 80, 0.6);
+            // No seam-bridging box-shadow here: with a translucent fill the
+            // shadow composites over the card's own semi-transparent layer,
+            // producing a darker hairline at the offset/card boundary.
+            box-shadow: none;
           }
         }
       }
@@ -256,7 +259,9 @@
         &[class*="semi-transparent"] {
           #{$c}--card-offset {
             background: rgba(255, 255, 255, 0.6);
-            box-shadow: 0.3px 0 0 0 rgba(255, 255, 255, 0.6);
+            // See dark variant above: no box-shadow for translucent fills,
+            // otherwise the shadow doubles up into a darker seam line.
+            box-shadow: none;
           }
         }
       }


### PR DESCRIPTION
Fixes the offset space between the left edge of the screen and the HeroCard, which didn't match the card when the card used a light theme or a semi-transparent/transparent background. Brings the React component in line with the existing Twig behavior.

