### PR TITLE
fix(styles): added ellipsis to long track names in the AudioPlayer

### DIFF
--- a/.changeset/five-houses-sniff.md
+++ b/.changeset/five-houses-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+AudioPlayer: added ellipsis to long track names

--- a/.changeset/five-houses-sniff.md
+++ b/.changeset/five-houses-sniff.md
@@ -1,5 +1,7 @@
 ---
 "@ilo-org/styles": patch
+"@ilo-org/react": patch
+"@ilo-org/twig": patch
 ---
 
 AudioPlayer: added ellipsis to long track names

--- a/packages/styles/scss/components/_audioplayer.scss
+++ b/packages/styles/scss/components/_audioplayer.scss
@@ -41,6 +41,9 @@
     font-size: var(--ilo-font-size-sm);
     font-weight: var(--ilo-font-weight-medium);
     line-height: var(--ilo-line-height-lg);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
   &--track-details {
     display: flex;
@@ -194,6 +197,9 @@
       border-bottom: none;
       padding-inline: spacing(3) 0;
       padding-block: 0;
+    }
+    &--track-name {
+      width: 30vw;
     }
     &--center {
       justify-content: center;


### PR DESCRIPTION
Fixes #1844 

This PR adjusts the styling of the AudioPlayer so that long track names don't wrap and instead gets trimmed with ellipsis at the end.