### PR TITLE
fix(config): restored missing files from published eslint-config package

### DIFF
--- a/.changeset/rare-lions-grab.md
+++ b/.changeset/rare-lions-grab.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/eslint-config": minor
+---
+
+Fixed missing files in published package

--- a/config/eslint-config/package.json
+++ b/config/eslint-config/package.json
@@ -8,9 +8,6 @@
     "url": "git+https://github.com/international-labour-organization/designsystem.git",
     "directory": "config/eslint-config"
   },
-  "files": [
-    "*.{js,ts,json}"
-  ],
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #1793 

This PR fixes the package configuration of the `eslint-config` package so that the actual config files are present in the published npm package. I opted to remove the explicit `files` declaration in `package.json` so that the entire package folder is published as is together with the changelog, readme and license.