### PR TITLE
fix(styles): fixed button content color while focused

### DIFF
--- a/.changeset/healthy-buses-smash.md
+++ b/.changeset/healthy-buses-smash.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/styles": patch
+---
+
+Button: fixed button content color while focused

--- a/packages/styles/scss/components/_button.scss
+++ b/packages/styles/scss/components/_button.scss
@@ -143,7 +143,6 @@
     box-shadow:
       4px 4px 0 1px var(--ilo-color-borders-focus) inset,
       -4px -4px 0 1px var(--ilo-color-borders-focus) inset;
-    color: var(--ilo-button-labels-focus-color);
     @include globaltransition("color, background-color, border-color");
 
     &.#{$prefix}--small {


### PR DESCRIPTION
Fixes #1847 

This PR fixes the color of the text and icon within the button while it is focused. The issue arose because the button component used an undefined CSS variable which fell back to the initial / default value. I opted to remove the declaration entirely since it isn't necessary to achieve the required visual state.