### PR TITLE
feat(styles): added asterisk to form component labels when they are required

### DIFF
--- a/.changeset/four-mice-walk.md
+++ b/.changeset/four-mice-walk.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": minor
+"@ilo-org/styles": minor
+"@ilo-org/twig": minor
+---
+
+FormControl: added asteriks to form labels when they are required

--- a/packages/react/src/components/FormControl/FormControl.props.ts
+++ b/packages/react/src/components/FormControl/FormControl.props.ts
@@ -59,6 +59,11 @@ export interface FormControlPublicProps {
    * Theme to use for the FormControl. This will be overridden by the theme of the Form.
    */
   theme?: ThemeTypes;
+
+  /**
+   * Is the input required?
+   */
+  required?: boolean;
 }
 
 export interface FormControlPrivateProps {

--- a/packages/react/src/components/FormControl/FormControl.tsx
+++ b/packages/react/src/components/FormControl/FormControl.tsx
@@ -79,6 +79,7 @@ const FormControl: FC<FormControlProps> = ({
   theme = "light",
   labelSize = "medium",
   labelPlacement = "top",
+  required,
 }) => {
   const { prefix } = useGlobalSettings();
   const { theme: formTheme } = useFormContext();
@@ -135,6 +136,7 @@ const FormControl: FC<FormControlProps> = ({
   const labelBaseClass = `${baseClass}--label`;
   const labelSizeClass = `${labelBaseClass}__size__${labelSize}`;
   const labelClass = classnames(labelBaseClass, labelSizeClass);
+  const labelRequiredClass = `${labelBaseClass}--required`;
 
   // Helper class
   const helperClass = `${baseClass}--helper`;
@@ -149,7 +151,14 @@ const FormControl: FC<FormControlProps> = ({
     <FormControlContext.Provider value={contextValue}>
       <div className={formControlClass} style={style}>
         <span className={labelClass}>
-          <label htmlFor={fieldId}>{label}</label>
+          <label htmlFor={fieldId}>
+            {label}
+            {required && (
+              <span className={labelRequiredClass} aria-hidden="true">
+                *
+              </span>
+            )}
+          </label>
           {tooltip && (
             <Tooltip
               id={tooltipId}

--- a/packages/styles/scss/components/_formcontrol.scss
+++ b/packages/styles/scss/components/_formcontrol.scss
@@ -176,6 +176,10 @@
         margin-right: calc(1 * var(--ilo-spacing-base));
       }
     }
+
+    &--required {
+      color: var(--ilo-color-red-dark);
+    }
   }
 
   &--helper {

--- a/packages/twig/src/components/form/formcontrol.twig
+++ b/packages/twig/src/components/form/formcontrol.twig
@@ -55,6 +55,7 @@
 {% set labelSizeClass = labelBaseClass ~ "__size__" ~ labelSize|default("medium") %}
 {% set labelClass = [labelBaseClass, labelSizeClass] %}
 {% set helperClass = baseClass ~ "--helper" %}
+{% set labelRequiredClass = labelBaseClass ~ "--required" %}
 
 {% set showError = error and errorMessage %}
 {% set showHelper = not showError and helper %}
@@ -66,7 +67,7 @@
 	{% if label %}
 		<span class="{{ labelClass|join(' ') }}">
 			{% block label %}
-				<label for="{{ id }}">{{ label }}</label>
+				<label for="{{ id }}">{{ label }}{% if required %}<span class="{{ labelRequiredClass }}" aria-hidden="true">*</span>{% endif %}</label>
 			{% endblock %}
 			{% if tooltip %}
 				{% include '@components/tooltip/tooltip.twig' with {


### PR DESCRIPTION
Fixes #644 

This PR adds asterisk to form component labels when the form component is marked as required. Both the twig and react versions of the DS were updated with this change.