### PR TITLE
fix(twig): fixed initial icon size

### DIFF
--- a/.changeset/spicy-brooms-buy.md
+++ b/.changeset/spicy-brooms-buy.md
@@ -1,0 +1,5 @@
+---
+"@ilo-org/twig": patch
+---
+
+Icon: fixed element size before svg is loaded

--- a/packages/twig/src/components/icon/icon.twig
+++ b/packages/twig/src/components/icon/icon.twig
@@ -1,1 +1,1 @@
-<svg class="{{prefix}}--icon{% if class %} {{class}}{% endif %}" data-name="{{name}}" data-size="{{size}}" data-color="{{color}}" data-loadcomponent="Icon" aria-hidden="true"></svg>
+<svg class="{{prefix}}--icon{% if class %} {{class}}{% endif %}" data-name="{{name}}" data-size="{{size}}" width="{{size}}" height="{{size}}" data-color="{{color}}" data-loadcomponent="Icon" aria-hidden="true"></svg>


### PR DESCRIPTION
Fixes #1860 

This PR fixes the initial icon size of the Icon component so that it doesn't grow to a huge size until the component initializes and the SVG loads.