### PR TITLE
fix(styles): added default text color to text input

### DIFF
--- a/.changeset/dirty-moons-occur.md
+++ b/.changeset/dirty-moons-occur.md
@@ -1,0 +1,8 @@
+---
+"@ilo-org/styles": patch
+---
+
+DatePicker: set default text color
+FileUpload: set default text color
+NumberPicker: set default text color
+SearchField: set default text color

--- a/packages/styles/scss/components/_input.scss
+++ b/packages/styles/scss/components/_input.scss
@@ -7,6 +7,7 @@
 // component.
 .ilo--input {
   appearance: none;
+  color: var(--ilo-color-light-text-default);
   background-color: var(--ilo-color-white);
   border: var(--ilo-border-md) solid var(--ilo-color-gray-base);
   box-sizing: border-box;


### PR DESCRIPTION
Fixes #1862 

This PR sets a default text color to the text input so that it is not inherited by default and cause unreadable text in dark theme environments.