### PR TITLE
feat(styles): added theme support for Video component

### DIFF
--- a/.changeset/lazy-ghosts-compare.md
+++ b/.changeset/lazy-ghosts-compare.md
@@ -1,0 +1,7 @@
+---
+"@ilo-org/react": minor
+"@ilo-org/styles": minor
+"@ilo-org/twig": minor
+---
+
+Video: implemented theme support

--- a/packages/react/src/components/Video/Video.args.ts
+++ b/packages/react/src/components/Video/Video.args.ts
@@ -16,6 +16,7 @@ const videofile: VideoProps = {
   },
   src: "/video-example.mp4",
   youtube: false,
+  theme: "light",
 };
 
 const videofileWithCaptions: VideoProps = {
@@ -51,6 +52,7 @@ const videofileWithCaptions: VideoProps = {
   ],
   src: "/video-example.mp4",
   youtube: false,
+  theme: "light",
 };
 
 const videoyt: VideoProps = {
@@ -69,6 +71,7 @@ const videoyt: VideoProps = {
   },
   src: "https://youtu.be/X72_A4_6zjU",
   youtube: true,
+  theme: "light",
 };
 
 /**

--- a/packages/react/src/components/Video/Video.props.ts
+++ b/packages/react/src/components/Video/Video.props.ts
@@ -1,3 +1,4 @@
+import { ThemeTypes } from "../../types";
 import { VideoPlayerControls, VideoTextTrack } from "./VideoPlayer.props";
 
 export interface Poster {
@@ -35,4 +36,9 @@ export interface VideoProps {
 
   // Optional closed-caption tracks
   tracks?: VideoTextTrack[];
+
+  /**
+   * Specify the theme for the video component, either light or dark
+   */
+  theme?: ThemeTypes;
 }

--- a/packages/react/src/components/Video/Video.tsx
+++ b/packages/react/src/components/Video/Video.tsx
@@ -6,21 +6,22 @@ import VideoPlayer from "./VideoPlayer";
 import { VideoPlayerRef } from "./VideoPlayer.props";
 
 const Video = forwardRef<VideoPlayerRef, VideoProps>(
-  ({ className, caption, ...video }, ref) => {
+  ({ className, caption, theme, ...video }, ref) => {
     const { prefix } = useGlobalSettings();
     const baseClass = `${prefix}--video`;
 
-    const videoClasses = classNames(className, [baseClass]);
-
-    const captionClasses = `${baseClass}--caption`;
+    const videoClasses = classNames(className, {
+      [baseClass]: true,
+      [`${baseClass}__theme__${theme}`]: theme,
+    });
 
     return (
       <figure className={videoClasses}>
-        <div className={`${videoClasses}--wrapper`}>
+        <div className={`${baseClass}--wrapper`}>
           {video && <VideoPlayer {...video} ref={ref} />}
         </div>
         {caption && (
-          <figcaption className={captionClasses}>{caption}</figcaption>
+          <figcaption className={`${baseClass}--caption`}>{caption}</figcaption>
         )}
       </figure>
     );

--- a/packages/react/src/stories/Video/Video.stories.tsx
+++ b/packages/react/src/stories/Video/Video.stories.tsx
@@ -18,7 +18,12 @@ const VideoMeta: Meta<typeof Video> = {
   title: "Components/Media/Video",
   tags: ["autodocs"],
   component: Video,
-  argTypes: {},
+  argTypes: {
+    theme: {
+      control: "select",
+      options: ["light", "dark"],
+    },
+  },
   parameters: {
     docs: {
       page: () => (

--- a/packages/styles/scss/components/_video.scss
+++ b/packages/styles/scss/components/_video.scss
@@ -58,6 +58,10 @@
 
   @include image-caption-styles;
 
+  &__theme__dark {
+    @include image-caption-dark-styles;
+  }
+
   // ? drupal style reset issue
   button {
     padding: 0;

--- a/packages/twig/src/components/video/video.component.yml
+++ b/packages/twig/src/components/video/video.component.yml
@@ -42,6 +42,14 @@ video:
           volume: "Volume"
         src: "/images/video-example.mp4"
         tracks: null
+  settings:
+    theme:
+      type: select
+      label: Theme
+      description: The theme to be used for the Video component.
+      options:
+        light: light
+        dark: dark
   variants:
     default:
       label: Default
@@ -105,4 +113,12 @@ youtube_video:
       description: The source type of video, required for youtube embedded videos
       required: false
       preview: "video/youtube"
+  settings:
+    theme:
+      type: select
+      label: Theme
+      description: The theme to be used for the Video component.
+      options:
+        light: light
+        dark: dark
   visibility: storybook

--- a/packages/twig/src/components/video/video.twig
+++ b/packages/twig/src/components/video/video.twig
@@ -1,8 +1,8 @@
 {#
   VIDEO COMPONENT
 #}
-
-<figure class="{{prefix}}--video" data-prefix="{{prefix}}">
+{% set theme = theme|default("light") %}
+<figure class="{{prefix}}--video {{prefix}}--video__theme__{{theme}}" data-prefix="{{prefix}}">
   <div class="{{prefix}}--video--wrapper">
     {% include "@components/video/videoplayer.twig" with {
       alt: alt,
@@ -14,5 +14,7 @@
       vjsType: vjsType
     } %}
   </div>
-  <figcaption>{{caption}}</figcaption>
+  {% if caption %}
+    <figcaption class="{{prefix}}--video--caption">{{caption}}</figcaption>
+  {% endif %}
 </figure>


### PR DESCRIPTION
Fixes #1859 

This PR adds theme support for the Video component so that captions are rendered correctly when the component within a dark themed project.