### PR TITLE
Feat/remove styles dep

### DIFF
--- a/.changeset/olive-moons-shine.md
+++ b/.changeset/olive-moons-shine.md
@@ -1,0 +1,43 @@
+---
+"@ilo-org/react": minor
+"@ilo-org/twig": minor
+"@ilo-org/styles": minor
+---
+
+Ship all stylesheets and Sass utilities with `@ilo-org/react` and `@ilo-org/twig`; drop `@ilo-org/styles` as a hard dependency
+
+`@ilo-org/styles` gains a `scss/_helpers.scss` entrypoint that forwards the
+design system's Sass functions and mixins from a single place. It is guaranteed
+to emit no CSS (enforced by a test), so it is safe to `@use` from every
+`.module.scss` without duplicating rules into the compiled bundle.
+
+`@ilo-org/react` and `@ilo-org/twig` already shipped the compiled CSS under
+`styles/`; they now also republish the Sass source under `styles/scss/`,
+mirroring the layout of `@ilo-org/styles`. Everything a consumer needs —
+compiled CSS and Sass — is therefore importable from the component library
+itself, and `@ilo-org/styles` no longer needs to be installed or documented
+alongside it:
+
+```scss
+@use "@ilo-org/react/styles/scss/helpers" as *;
+// or, with the Twig flavor:
+@use "@ilo-org/twig/styles/scss/helpers" as *;
+// or, without a component library:
+@use "@ilo-org/styles/scss/helpers" as *;
+```
+
+Changes visible to consumers:
+
+- `@ilo-org/styles` moves from a dependency of `@ilo-org/react` and
+  `@ilo-org/twig` to a build-time devDependency, so it no longer lands in
+  consumers' dependency trees.
+- `@ilo-org/icons` is now a dependency of `@ilo-org/react`, which the `icon`
+  mixin genuinely needs at compile time (`@ilo-org/twig` already had it).
+- The `"./styles/"` export on `@ilo-org/react` is replaced with `"./styles/*"`
+  plus an explicit `"./styles/scss/helpers"` key. Trailing-slash exports are
+  deprecated (Node DEP0148) and were removed in Node 17 —
+  `@ilo-org/react/styles/index.css` previously failed to resolve in plain Node.
+  Existing imports keep working.
+- `@ilo-org/twig` gains an exports map with the same `"./styles/*"` and
+  `"./styles/scss/helpers"` keys, plus a `"./*"` passthrough so that existing
+  deep imports like `@ilo-org/twig/dist/components/...` keep resolving.

--- a/.changeset/quiet-pandas-repeat.md
+++ b/.changeset/quiet-pandas-repeat.md
@@ -1,0 +1,21 @@
+---
+"@ilo-org/styles": patch
+---
+
+Split the emitting parts out of `_animations.scss`
+
+`_animations.scss` mixed two pure mixins (`globaltransition`, `pulse-animation`)
+with five CSS-emitting `@keyframes` blocks, and `_mixins.scss` pulled the whole
+module in. Every stylesheet that used any mixin therefore inherited all five
+keyframes, and because legacy `@import` chains do not dedupe, the compiled
+bundle accumulated hundreds of duplicate copies.
+
+The two mixins now live in a new `scss/_animation-mixins.scss`, which
+`_mixins.scss` uses instead. `_animations.scss` keeps the keyframes and
+`@forward`s the mixins, so the 16 component stylesheets that `@use "../animations"`
+continue to work unchanged.
+
+No API changes and no removed selectors — all non-keyframe CSS is byte-identical.
+`@keyframes` blocks in the compiled `index.css` drop from 450 to 80, with all
+five names (`emptygradient`, `pulse`, `slideDown`, `slideUp`, `spin`) intact.
+Consumers importing `scss/mixins.scss` no longer receive any keyframes at all.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,13 +46,14 @@
       "import": "./lib/esm/index.js",
       "default": "./lib/cjs/index.js"
     },
-    "./styles/": "./lib/styles/"
+    "./styles/*": "./lib/styles/*",
+    "./styles/scss/helpers": "./lib/styles/scss/_helpers.scss"
   },
   "sideEffects": false,
   "license": "Apache-2.0",
   "types": "./lib/types/index.d.ts",
   "scripts": {
-    "build:lib": "tsc --noEmit --project tsconfig.build.json && vite build",
+    "build:lib": "tsc --noEmit --project tsconfig.build.json && vite build && node scripts/check-exports.mjs",
     "build:docs": "storybook build",
     "check": "tsc --noEmit --p tsconfig.build.json",
     "dev:lib": "vite build --watch",
@@ -79,8 +80,8 @@
   "dependencies": {
     "@ilo-org/brand-assets": "workspace:*",
     "@ilo-org/fonts": "workspace:*",
+    "@ilo-org/icons": "workspace:*",
     "@ilo-org/icons-react": "workspace:*",
-    "@ilo-org/styles": "workspace:*",
     "@popperjs/core": "^2.11.8",
     "classnames": "^2.3.1",
     "dom-helpers": "^5.2.1",
@@ -95,6 +96,7 @@
     "@chromatic-com/storybook": "3.2.7",
     "@ilo-org/eslint-config": "workspace:*",
     "@ilo-org/prettier-config": "workspace:*",
+    "@ilo-org/styles": "workspace:*",
     "@ilo-org/typescript-config": "workspace:*",
     "@storybook/addon-actions": "^8.6.11",
     "@storybook/addon-docs": "^8.6.11",
@@ -124,6 +126,7 @@
     "html-to-image": "^1.11.11",
     "http-server": "^14.1.0",
     "jsdom": "^25.0.0",
+    "sass": "^1.62.1",
     "storybook": "^8.6.11",
     "storybook-addon-rtl": "^1.0.0",
     "vite": "^5.2.0",

--- a/packages/react/scripts/check-exports.mjs
+++ b/packages/react/scripts/check-exports.mjs
@@ -1,0 +1,28 @@
+/**
+ * Asserts this package's exports map still resolves the subpaths consumers are
+ * told to import.
+ *
+ * The Sass surface itself is guarded upstream, by the @ilo-org/styles tests.
+ * What cannot move there is this: the exports map is a property of
+ * THIS package.json, and it is checked with require.resolve rather than a Sass
+ * compile because Sass resolves through loadPaths, which bypasses package
+ * exports entirely and therefore proves nothing about them.
+ *
+ * It runs as part of build:lib rather than as a vitest test because it asserts
+ * against the freshly built lib/, which a bare `vitest` run would not have.
+ */
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+for (const subpath of [
+  "@ilo-org/react/styles/index.css",
+  // Node's exports resolution has no directory-index step, so this one resolves
+  // only because of the explicit literal key in the exports map — the
+  // "./styles/*" wildcard would map it to a directory and fail.
+  "@ilo-org/react/styles/scss/helpers",
+]) {
+  require.resolve(subpath); // throws ERR_PACKAGE_PATH_NOT_EXPORTED on regression
+}
+
+console.log("✓ exports resolve");

--- a/packages/react/src/stories/docs/intro.mdx
+++ b/packages/react/src/stories/docs/intro.mdx
@@ -12,11 +12,7 @@ This website provides guidance and documentation for the ILO Design System using
 $ npm i @ilo-org/react
 ```
 
-If you plan on using the default styles for the library, then you should also install the `@ilo-org/styles` package.
-
-```bash
-$ npm i @ilo-org/styles
-```
+The default styles ship with the package, so there is nothing else to install.
 
 ## Peer dependencies
 
@@ -44,8 +40,36 @@ import { Button } from "@ilo-org/react/Button";
 
 Styles for the library should be imported at the top of your project.
 
+```typescript
+import "@ilo-org/react/styles/index.css";
+```
+
+Or, if you'd rather link to the stylesheet directly:
+
 ```html
-<link rel="stylesheet" href="node_modules/@ilo-org/styles/index.css" />
+<link
+  rel="stylesheet"
+  href="node_modules/@ilo-org/react/lib/styles/index.css"
+/>
+```
+
+### Sass functions and mixins
+
+If you write Sass, the design system's functions and mixins are available from a
+single entrypoint. It emits no CSS of its own, so it is safe to `@use` from every
+`.module.scss` without duplicating rules into your bundle.
+
+```scss
+@use "@ilo-org/react/styles/scss/helpers" as *;
+
+.thing {
+  padding: spacing(4);
+  max-width: px-to-rem(1296px);
+
+  @include breakpoint("md", true) {
+    display: none;
+  }
+}
 ```
 
 ## Contributing

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -37,6 +37,10 @@ const config: ViteConfig = {
           src: "node_modules/@ilo-org/styles/css/*",
           dest: "styles",
         },
+        {
+          src: "node_modules/@ilo-org/styles/scss/*",
+          dest: "styles/scss",
+        },
       ],
     }),
   ],

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -40,6 +40,7 @@
     "format": "prettier --check . --ignore-path ../../.prettierignore",
     "format:fix": "prettier --write . --ignore-path ../../.prettierignore",
     "lint": "eslint",
+    "test": "vitest",
     "lint:fix": "eslint --fix"
   },
   "license": "Apache-2.0",
@@ -56,6 +57,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
-    "sass": "^1.62.1"
+    "sass": "^1.62.1",
+    "vitest": "^2.0.5"
   }
 }

--- a/packages/styles/scss/_animation-mixins.scss
+++ b/packages/styles/scss/_animation-mixins.scss
@@ -1,0 +1,21 @@
+//*------------------------------------*\
+//    $ANIMATION MIXINS
+//*------------------------------------*/
+
+/// Applies the global transition to any transitionable property
+/// @param {String} $properties - the name of the property on which to transition
+/// @return {CSS} transition for the given properties
+@mixin globaltransition($properties) {
+  transition-property: unquote($properties);
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+/// Animation for loading skeletons
+@mixin pulse-animation() {
+  animation-name: pulse;
+  animation-delay: 0.5s;
+  animation-duration: 2s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}

--- a/packages/styles/scss/_animations.scss
+++ b/packages/styles/scss/_animations.scss
@@ -1,14 +1,6 @@
-// ======================================
-// Global transition
-// ======================================
-/// Applies the global transition to any transitionable property
-/// @param {String} $properties - the name of the property on which to transition
-/// @return {CSS} transition for the given properties
-@mixin globaltransition($properties) {
-  transition-property: unquote($properties);
-  transition-duration: 150ms;
-  transition-timing-function: ease-out;
-}
+// Animation mixins live in their own module so that consumers can use them
+// without pulling in the keyframes below. Re-forwarded here for back-compat.
+@forward "animation-mixins";
 
 // ======================================
 // Animation of empty gradient
@@ -37,14 +29,6 @@
 // ======================================
 // Animation for loading skeletons
 // ======================================
-@mixin pulse-animation() {
-  animation-name: pulse;
-  animation-delay: 0.5s;
-  animation-duration: 2s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-}
-
 @keyframes pulse {
   0% {
     opacity: 1;

--- a/packages/styles/scss/_helpers.scss
+++ b/packages/styles/scss/_helpers.scss
@@ -1,0 +1,19 @@
+//*------------------------------------*\
+//    $HELPERS — public Sass API
+//    Functions and mixins only.
+//    Guaranteed to emit no CSS.
+//    Consumers reach this file as `@use "@ilo-org/styles/scss/helpers"` or,
+//    because @ilo-org/react republishes scss/ under styles/scss/, as
+//    `@use "@ilo-org/react/styles/scss/helpers"`.
+//*------------------------------------*/
+
+@forward "functions";
+
+// `dataurlicon` is deliberately withheld from the public API: its default
+// `$color` parameter references `$color-base-neutrals-black`, which is not
+// defined anywhere in this package. Every internal call site passes an explicit
+// colour, so the mixin is dormant there, but a consumer calling it with one
+// argument would hit an undefined-variable error. It is already marked for
+// deprecation in favour of the `icon` mixin. Consumers wanting it can still
+// reach it via `@use "@ilo-org/styles/scss/mixins.scss"`.
+@forward "mixins" hide dataurlicon;

--- a/packages/styles/scss/_mixins.scss
+++ b/packages/styles/scss/_mixins.scss
@@ -3,7 +3,7 @@
 //*------------------------------------*/
 @use "icons" as *;
 @use "functions" as *;
-@use "animations" as *;
+@use "animation-mixins" as *;
 @use "theme/breakpoints" as *;
 
 // ======================================

--- a/packages/styles/scss/theme/_breakpoints.scss
+++ b/packages/styles/scss/theme/_breakpoints.scss
@@ -1,6 +1,7 @@
-/**
-  * Breakpoints are defined in scss because they can't be referenced as a css variables
-  */
+// Breakpoints are defined in scss because they can't be referenced as css
+// variables. This file is part of the helpers closure, which must not emit css
+// into consumer stylesheets.
+
 $breakpoints-foundation: (
   xs: 320px,
   sm: 414px,

--- a/packages/styles/tests/helpers.test.mjs
+++ b/packages/styles/tests/helpers.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * Guards the public Sass surface this package produces.
+ *
+ * Compiles the scss/_helpers.scss entrypoint the way a consumer would reach it:
+ * `@use "@ilo-org/styles/scss/helpers"` resolves here, and @ilo-org/react
+ * copies scss/ verbatim into its published lib/styles/scss/, so the same file
+ * backs `@use "@ilo-org/react/styles/scss/helpers"`.
+ */
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import * as sass from "sass";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+// Resolving `scss/helpers` as a bare path exercises Sass's partial convention,
+// which is exactly what `@use "@ilo-org/styles/scss/helpers"` relies on.
+const loadPaths = [packageRoot, join(packageRoot, "node_modules")];
+
+const compile = (source) =>
+  sass.compileString(source, {
+    loadPaths,
+    silenceDeprecations: ["global-builtin", "import"],
+  }).css;
+
+describe("helpers", () => {
+  // The whole point of the layer. If it ever emits a rule, every consumer
+  // .module.scss that @uses it silently carries a duplicate copy.
+  it("emits no CSS", () => {
+    expect(compile('@use "scss/helpers" as *;').trim()).toBe("");
+  });
+
+  describe("is usable from a consumer stylesheet", () => {
+    let css;
+
+    beforeAll(() => {
+      css = compile(
+        '@use "scss/helpers" as *;\n' +
+          ".thing { padding: spacing(4); max-width: px-to-rem(1296px);\n" +
+          '  @include breakpoint("md", true) { display: none; } }'
+      );
+    });
+
+    // Assert on the shape of the output rather than exact numbers, so that a
+    // change to a design token does not fail these tests.
+    it("resolves spacing() to the spacing custom property", () => {
+      expect(css).toMatch(/--ilo-spacing-base/);
+    });
+
+    it("resolves px-to-rem() to a rem value", () => {
+      expect(css).toMatch(/max-width:\s*[\d.]+rem/);
+    });
+
+    it("resolves breakpoint() to a media query", () => {
+      expect(css).toMatch(/@media screen and \(max-width:\s*609px\)/);
+    });
+  });
+});

--- a/packages/styles/vitest.config.mjs
+++ b/packages/styles/vitest.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.mjs"],
+  },
+});

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -5,6 +5,11 @@
   "files": [
     "dist/**/*"
   ],
+  "exports": {
+    "./styles/*": "./dist/styles/*",
+    "./styles/scss/helpers": "./dist/styles/scss/_helpers.scss",
+    "./*": "./*"
+  },
   "license": "Apache-2.0",
   "description": "Twig components for the ILO's Design System",
   "publishConfig": {
@@ -45,7 +50,7 @@
     }
   ],
   "scripts": {
-    "build:lib": "rollup -c",
+    "build:lib": "rollup -c && node scripts/check-exports.mjs",
     "build:docs": "storybook build -o ./storybook-static",
     "storybook": "storybook dev -p 6006",
     "start:theme": "docker compose up -d",
@@ -61,6 +66,7 @@
     "@etchteam/storybook-addon-github-link": "^1.0.1",
     "@ilo-org/eslint-config": "workspace:*",
     "@ilo-org/react": "workspace:*",
+    "@ilo-org/styles": "workspace:*",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
@@ -95,7 +101,6 @@
     "@ilo-org/fonts": "workspace:*",
     "@ilo-org/icons": "workspace:*",
     "@ilo-org/maestro": "workspace:*",
-    "@ilo-org/styles": "workspace:*",
     "@popperjs/core": "^2.11.8",
     "cypress": "^14.3.2",
     "embla-carousel": "^8.6.0",

--- a/packages/twig/rollup.config.js
+++ b/packages/twig/rollup.config.js
@@ -78,6 +78,10 @@ const copyConfig = copy({
       src: "node_modules/@ilo-org/styles/css/*",
       dest: "dist/styles",
     },
+    {
+      src: "node_modules/@ilo-org/styles/scss/*",
+      dest: "dist/styles/scss",
+    },
   ],
   hook: "writeBundle",
   verbose: true,

--- a/packages/twig/scripts/check-exports.mjs
+++ b/packages/twig/scripts/check-exports.mjs
@@ -1,0 +1,31 @@
+/**
+ * Asserts this package's exports map still resolves the subpaths consumers are
+ * told to import.
+ *
+ * The Sass surface itself is guarded upstream, by the @ilo-org/styles tests.
+ * What cannot move there is this: the exports map is a property of THIS
+ * package.json, and it is checked with require.resolve rather than a Sass
+ * compile because Sass resolves through loadPaths, which bypasses package
+ * exports entirely and therefore proves nothing about them.
+ *
+ * It runs as part of build:lib rather than as a test because it asserts
+ * against the freshly built dist/.
+ */
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+for (const subpath of [
+  "@ilo-org/twig/styles/index.css",
+  // Node's exports resolution has no directory-index step, so this one resolves
+  // only because of the explicit literal key in the exports map — the
+  // "./styles/*" wildcard would map it to a directory and fail.
+  "@ilo-org/twig/styles/scss/helpers",
+  // The "./*" passthrough: this package had no exports map before, so direct
+  // dist/ paths are public API for existing consumers and must keep resolving.
+  "@ilo-org/twig/dist/styles/index.css",
+]) {
+  require.resolve(subpath); // throws ERR_PACKAGE_PATH_NOT_EXPORTED on regression
+}
+
+console.log("✓ exports resolve");

--- a/packages/twig/stories/docs/custom.mdx
+++ b/packages/twig/stories/docs/custom.mdx
@@ -110,7 +110,7 @@ Define CSS and JavaScript assets in `your_theme_name.libraries.yml`.
 global-styles:
   css:
     theme:
-      node_modules/@ilo-org/twig/dist/global/styles.css: {}
+      node_modules/@ilo-org/twig/dist/styles/index.css: {}
 ```
 
 ### Individual Component Libraries
@@ -244,8 +244,27 @@ export default defineConfig({
 
 ```js
 // src/main.js
-import "@ilo-org/twig/dist/global/styles.css";
+import "@ilo-org/twig/styles/index.css";
 import "@ilo-org/twig/dist/components/accordion/accordion.behavior.js";
+```
+
+### Sass functions and mixins
+
+If you write Sass, the design system's functions and mixins are available from
+a single entrypoint. It emits no CSS of its own, so it is safe to `@use` from
+any stylesheet without duplicating rules into your bundle.
+
+```scss
+@use "@ilo-org/twig/styles/scss/helpers" as *;
+
+.thing {
+  padding: spacing(4);
+  max-width: px-to-rem(1296px);
+
+  @include breakpoint("md", true) {
+    display: none;
+  }
+}
 ```
 
 ## Version Management

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,12 +322,12 @@ importers:
       '@ilo-org/fonts':
         specifier: workspace:*
         version: link:../fonts
+      '@ilo-org/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@ilo-org/icons-react':
         specifier: workspace:*
         version: link:../icons-react
-      '@ilo-org/styles':
-        specifier: workspace:*
-        version: link:../styles
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -371,6 +371,9 @@ importers:
       '@ilo-org/prettier-config':
         specifier: workspace:*
         version: link:../../config/prettier-config
+      '@ilo-org/styles':
+        specifier: workspace:*
+        version: link:../styles
       '@ilo-org/typescript-config':
         specifier: workspace:*
         version: link:../../config/typescript-config
@@ -458,6 +461,9 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
+      sass:
+        specifier: ^1.62.1
+        version: 1.101.0
       storybook:
         specifier: ^8.6.11
         version: 8.6.18(prettier@3.9.5)
@@ -488,7 +494,7 @@ importers:
     devDependencies:
       cssnano:
         specifier: ^7.0.6
-        version: 7.1.9(postcss@8.5.19)
+        version: 7.1.9(postcss@8.5.26)
       del:
         specifier: ^7.0.0
         version: 7.1.0
@@ -500,7 +506,7 @@ importers:
         version: 4.3.0
       gulp-postcss:
         specifier: ^9.0.1
-        version: 9.1.0(postcss@8.5.19)
+        version: 9.1.0(postcss@8.5.26)
       gulp-rename:
         specifier: ^2.0.0
         version: 2.1.0
@@ -513,6 +519,9 @@ importers:
       sass:
         specifier: ^1.62.1
         version: 1.101.0
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.9(@types/node@20.19.43)(@vitest/ui@2.1.9)(jsdom@25.0.1)(sass@1.101.0)(terser@5.49.2)
 
   packages/themes:
     devDependencies:
@@ -534,9 +543,6 @@ importers:
       '@ilo-org/maestro':
         specifier: workspace:*
         version: link:../maestro
-      '@ilo-org/styles':
-        specifier: workspace:*
-        version: link:../styles
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -565,6 +571,9 @@ importers:
       '@ilo-org/react':
         specifier: workspace:*
         version: link:../react
+      '@ilo-org/styles':
+        specifier: workspace:*
+        version: link:../styles
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
         version: 1.1.1(rollup@2.80.0)(vite@5.4.21(@types/node@20.19.43)(sass@1.101.0)(terser@5.49.2))
@@ -3135,6 +3144,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -10740,11 +10750,7 @@ snapshots:
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   '@jest/test-sequencer@27.5.1':
     dependencies:
@@ -13191,9 +13197,9 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
-  css-declaration-sorter@7.4.0(postcss@8.5.19):
+  css-declaration-sorter@7.4.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
   css-loader@7.1.4(webpack@5.108.4(esbuild@0.25.12)(postcss@8.5.26)):
     dependencies:
@@ -13259,49 +13265,49 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@7.0.17(postcss@8.5.19):
+  cssnano-preset-default@7.0.17(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
-      css-declaration-sorter: 7.4.0(postcss@8.5.19)
-      cssnano-utils: 5.0.3(postcss@8.5.19)
-      postcss: 8.5.19
-      postcss-calc: 10.1.1(postcss@8.5.19)
-      postcss-colormin: 7.0.10(postcss@8.5.19)
-      postcss-convert-values: 7.0.12(postcss@8.5.19)
-      postcss-discard-comments: 7.0.8(postcss@8.5.19)
-      postcss-discard-duplicates: 7.0.4(postcss@8.5.19)
-      postcss-discard-empty: 7.0.3(postcss@8.5.19)
-      postcss-discard-overridden: 7.0.3(postcss@8.5.19)
-      postcss-merge-longhand: 7.0.7(postcss@8.5.19)
-      postcss-merge-rules: 7.0.11(postcss@8.5.19)
-      postcss-minify-font-values: 7.0.3(postcss@8.5.19)
-      postcss-minify-gradients: 7.0.5(postcss@8.5.19)
-      postcss-minify-params: 7.0.9(postcss@8.5.19)
-      postcss-minify-selectors: 7.1.2(postcss@8.5.19)
-      postcss-normalize-charset: 7.0.3(postcss@8.5.19)
-      postcss-normalize-display-values: 7.0.3(postcss@8.5.19)
-      postcss-normalize-positions: 7.0.4(postcss@8.5.19)
-      postcss-normalize-repeat-style: 7.0.4(postcss@8.5.19)
-      postcss-normalize-string: 7.0.3(postcss@8.5.19)
-      postcss-normalize-timing-functions: 7.0.3(postcss@8.5.19)
-      postcss-normalize-unicode: 7.0.9(postcss@8.5.19)
-      postcss-normalize-url: 7.0.3(postcss@8.5.19)
-      postcss-normalize-whitespace: 7.0.3(postcss@8.5.19)
-      postcss-ordered-values: 7.0.4(postcss@8.5.19)
-      postcss-reduce-initial: 7.0.9(postcss@8.5.19)
-      postcss-reduce-transforms: 7.0.3(postcss@8.5.19)
-      postcss-svgo: 7.1.3(postcss@8.5.19)
-      postcss-unique-selectors: 7.0.7(postcss@8.5.19)
+      css-declaration-sorter: 7.4.0(postcss@8.5.26)
+      cssnano-utils: 5.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-calc: 10.1.1(postcss@8.5.26)
+      postcss-colormin: 7.0.10(postcss@8.5.26)
+      postcss-convert-values: 7.0.12(postcss@8.5.26)
+      postcss-discard-comments: 7.0.8(postcss@8.5.26)
+      postcss-discard-duplicates: 7.0.4(postcss@8.5.26)
+      postcss-discard-empty: 7.0.3(postcss@8.5.26)
+      postcss-discard-overridden: 7.0.3(postcss@8.5.26)
+      postcss-merge-longhand: 7.0.7(postcss@8.5.26)
+      postcss-merge-rules: 7.0.11(postcss@8.5.26)
+      postcss-minify-font-values: 7.0.3(postcss@8.5.26)
+      postcss-minify-gradients: 7.0.5(postcss@8.5.26)
+      postcss-minify-params: 7.0.9(postcss@8.5.26)
+      postcss-minify-selectors: 7.1.2(postcss@8.5.26)
+      postcss-normalize-charset: 7.0.3(postcss@8.5.26)
+      postcss-normalize-display-values: 7.0.3(postcss@8.5.26)
+      postcss-normalize-positions: 7.0.4(postcss@8.5.26)
+      postcss-normalize-repeat-style: 7.0.4(postcss@8.5.26)
+      postcss-normalize-string: 7.0.3(postcss@8.5.26)
+      postcss-normalize-timing-functions: 7.0.3(postcss@8.5.26)
+      postcss-normalize-unicode: 7.0.9(postcss@8.5.26)
+      postcss-normalize-url: 7.0.3(postcss@8.5.26)
+      postcss-normalize-whitespace: 7.0.3(postcss@8.5.26)
+      postcss-ordered-values: 7.0.4(postcss@8.5.26)
+      postcss-reduce-initial: 7.0.9(postcss@8.5.26)
+      postcss-reduce-transforms: 7.0.3(postcss@8.5.26)
+      postcss-svgo: 7.1.3(postcss@8.5.26)
+      postcss-unique-selectors: 7.0.7(postcss@8.5.26)
 
-  cssnano-utils@5.0.3(postcss@8.5.19):
+  cssnano-utils@5.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  cssnano@7.1.9(postcss@8.5.19):
+  cssnano@7.1.9(postcss@8.5.26):
     dependencies:
-      cssnano-preset-default: 7.0.17(postcss@8.5.19)
+      cssnano-preset-default: 7.0.17(postcss@8.5.26)
       lilconfig: 3.1.3
-      postcss: 8.5.19
+      postcss: 8.5.26
 
   csso@4.2.0:
     dependencies:
@@ -14739,12 +14745,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gulp-postcss@9.1.0(postcss@8.5.19):
+  gulp-postcss@9.1.0(postcss@8.5.26):
     dependencies:
       fancy-log: 2.0.0
       plugin-error: 2.0.1
-      postcss: 8.5.19
-      postcss-load-config: 5.1.0(postcss@8.5.19)
+      postcss: 8.5.26
+      postcss-load-config: 5.1.0(postcss@8.5.26)
       vinyl-sourcemaps-apply: 0.2.1
     transitivePeerDependencies:
       - jiti
@@ -17095,89 +17101,89 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-calc@10.1.1(postcss@8.5.19):
+  postcss-calc@10.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.10(postcss@8.5.19):
+  postcss-colormin@7.0.10(postcss@8.5.26):
     dependencies:
       '@colordx/core': 5.5.0
       browserslist: 4.28.6
       caniuse-api: 3.0.0
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.12(postcss@8.5.19):
+  postcss-convert-values@7.0.12(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.8(postcss@8.5.19):
+  postcss-discard-comments@7.0.8(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
-  postcss-discard-duplicates@7.0.4(postcss@8.5.19):
+  postcss-discard-duplicates@7.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-discard-empty@7.0.3(postcss@8.5.19):
+  postcss-discard-empty@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-discard-overridden@7.0.3(postcss@8.5.19):
+  postcss-discard-overridden@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-load-config@5.1.0(postcss@8.5.19):
+  postcss-load-config@5.1.0(postcss@8.5.26):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-merge-longhand@7.0.7(postcss@8.5.19):
+  postcss-merge-longhand@7.0.7(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.11(postcss@8.5.19)
+      stylehacks: 7.0.11(postcss@8.5.26)
 
-  postcss-merge-rules@7.0.11(postcss@8.5.19):
+  postcss-merge-rules@7.0.11(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.3(postcss@8.5.19)
-      postcss: 8.5.19
+      cssnano-utils: 5.0.3(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
-  postcss-minify-font-values@7.0.3(postcss@8.5.19):
+  postcss-minify-font-values@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.5(postcss@8.5.19):
+  postcss-minify-gradients@7.0.5(postcss@8.5.26):
     dependencies:
       '@colordx/core': 5.5.0
-      cssnano-utils: 5.0.3(postcss@8.5.19)
-      postcss: 8.5.19
+      cssnano-utils: 5.0.3(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.9(postcss@8.5.19):
+  postcss-minify-params@7.0.9(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
-      cssnano-utils: 5.0.3(postcss@8.5.19)
-      postcss: 8.5.19
+      cssnano-utils: 5.0.3(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.1.2(postcss@8.5.19):
+  postcss-minify-selectors@7.1.2(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
       caniuse-api: 3.0.0
       cssesc: 3.0.0
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
@@ -17201,66 +17207,66 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.5.26)
       postcss: 8.5.26
 
-  postcss-normalize-charset@7.0.3(postcss@8.5.19):
+  postcss-normalize-charset@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-normalize-display-values@7.0.3(postcss@8.5.19):
+  postcss-normalize-display-values@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.4(postcss@8.5.19):
+  postcss-normalize-positions@7.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.4(postcss@8.5.19):
+  postcss-normalize-repeat-style@7.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.3(postcss@8.5.19):
+  postcss-normalize-string@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.3(postcss@8.5.19):
+  postcss-normalize-timing-functions@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.9(postcss@8.5.19):
+  postcss-normalize-unicode@7.0.9(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.3(postcss@8.5.19):
+  postcss-normalize-url@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.3(postcss@8.5.19):
+  postcss-normalize-whitespace@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.4(postcss@8.5.19):
+  postcss-ordered-values@7.0.4(postcss@8.5.26):
     dependencies:
-      cssnano-utils: 5.0.3(postcss@8.5.19)
-      postcss: 8.5.19
+      cssnano-utils: 5.0.3(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.9(postcss@8.5.19):
+  postcss-reduce-initial@7.0.9(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
       caniuse-api: 3.0.0
-      postcss: 8.5.19
+      postcss: 8.5.26
 
-  postcss-reduce-transforms@7.0.3(postcss@8.5.19):
+  postcss-reduce-transforms@7.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@7.1.4:
@@ -17273,15 +17279,15 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@7.1.3(postcss@8.5.19):
+  postcss-svgo@7.1.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       svgo: 4.0.2
 
-  postcss-unique-selectors@7.0.7(postcss@8.5.19):
+  postcss-unique-selectors@7.0.7(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
   postcss-value-parser@4.2.0: {}
@@ -18327,10 +18333,10 @@ snapshots:
     dependencies:
       webpack: 5.108.4(esbuild@0.25.12)(postcss@8.5.26)
 
-  stylehacks@7.0.11(postcss@8.5.19):
+  stylehacks@7.0.11(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.6
-      postcss: 8.5.19
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.4
 
   supports-color@5.5.0:


### PR DESCRIPTION
Ship all stylesheets and Sass utilities with `@ilo-org/react` and `@ilo-org/twig`; drop `@ilo-org/styles` as a hard dependency
